### PR TITLE
docs(release): v0.0.10-alpha documentation sync

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "kmgraph",
-  "version": "0.0.9-alpha",
+  "version": "0.0.10-alpha",
   "description": "Structured knowledge capture, lesson-learned documentation, and cross-session memory for Claude Code projects. Includes KG entries, ADRs, meta-issue tracking, chat extraction, and MEMORY.md bidirectional sync.",
   "author": {
     "name": "technomensch",

--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 Structured knowledge capture, lesson-learned documentation, and cross-session memory for Claude Code projects.
 
-**Version:** 0.0.9-alpha
-**Status:** Security Fixes & Documentation Refinements
+**Version:** 0.0.10-alpha
+**Status:** Skills, Subagents, Backfill & Token Optimization
 
 Documentation avaliable at - https://technomensch.github.io/knowledge-graph/
 
@@ -38,13 +38,13 @@ A Claude Code plugin that provides:
 
 Paste [INSTALL.md](INSTALL.md) into any AI assistant for automated setup on any platform — Claude Code, Cursor, Windsurf, Continue.dev, JetBrains, VS Code, Aider, or local LLMs.
 
-**Claude Code users:** Run `claude plugin install knowledge` or load with `claude --plugin-dir /path/to/knowledge-graph`, then run `/kmgraph:init`.
+**Claude Code users:** Run `claude plugin install kmgraph` or load with `claude --plugin-dir /path/to/knowledge-graph`, then run `/kmgraph:init`.
 
 See [Getting Started Guide](docs/GETTING-STARTED.md) for prerequisites and troubleshooting.
 
 ---
 
-## Commands (22 Total)
+## Commands (23 Total)
 
 **Quick Reference**: See [CHEAT-SHEET.md](docs/CHEAT-SHEET.md) for one-page quick reference guide
 **Detailed Guide**: See [COMMAND-GUIDE.md](docs/COMMAND-GUIDE.md) for comprehensive command documentation with learning paths
@@ -83,6 +83,19 @@ Power users use these for complex workflows:
 - `/kmgraph:archive-memory` — Archive stale MEMORY.md entries to prevent bloat
 - `/kmgraph:restore-memory` — Restore archived MEMORY.md entries
 - `/kmgraph:sync-all` — Automated full sync pipeline (4 steps → 1 command)
+- `/kmgraph:handoff` — Create comprehensive handoff documentation for transitions, context limits, or onboarding
+
+---
+
+## v0.0.10 Feature Highlights
+
+**Released 2026-02-27**
+
+- **5 Auto-Triggered Skills** — Context providers activate automatically: lesson-capture (bug solved), kg-recall (past decisions), session-wrap (context limits), adr-guide (architecture decisions), gov-execute-plan (plan execution)
+- **2 Subagents** — Heavy-lift task handlers operating in approval-gated mode: knowledge-extractor (read-only parsing), session-documenter (git archaeology)
+- **Optional KG Backfill** — Initialize knowledge graph with automatic extraction from README, CHANGELOG, existing lessons, decisions, and chat history
+- **Handoff Command** — Generate comprehensive project transition packages (START-HERE, DOCUMENTATION-MAP, SESSION-COMPILATION, OPEN-ISSUES, ARCHITECTURE-SNAPSHOT)
+- **Token Optimization Phase 2** — 46.9% context reduction via skills lazy-loading, subagent delegation for heavy reads, and consolidated automation hooks
 
 ---
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,61 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.10-alpha] - 2026-02-27
+
+### Added
+- **Skills System (v0.0.10.1)**
+  - 5 auto-triggered context providers: `lesson-capture` (bug solved), `kg-recall` (past decisions), `session-wrap` (context limits), `adr-guide` (architecture decisions), `gov-execute-plan` (plan execution)
+  - Skill auto-surfaces suggestions when trigger conditions detected in conversation
+  - Reduces context overhead by ~46.9% via lazy-loading
+
+- **Subagents for Heavy-Lift Tasks (v0.0.10.1)**
+  - `knowledge-extractor` — Read-only parsing of large files; presents findings for user approval before writing
+  - `session-documenter` — Git archaeology for session summaries with conventional commit format
+  - Both operate in approval-gated mode; never auto-writes without user confirmation
+
+- **Optional KG Backfill During Init (v0.0.10.2)**
+  - New Step 1.10 in `/kmgraph:init`: "Would you like to backfill the knowledge graph from existing project context? [y/N]"
+  - If yes: invokes `knowledge-extractor` to scan README, CHANGELOG, lessons-learned/, decisions/, and chat-history/
+  - Extracts candidates and presents for user review before creating entries
+  - Enables new users to inherit institutional knowledge immediately
+
+- **Handoff Command (v0.0.10.3)**
+  - New `/kmgraph:handoff` — Generate comprehensive project transition documentation
+  - Creates 5 documents: START-HERE (current state), DOCUMENTATION-MAP (file inventory), SESSION-COMPILATION (recent work), OPEN-ISSUES (blockers), ARCHITECTURE-SNAPSHOT (codebase structure)
+  - Purpose: Enable seamless knowledge transfer before context limits or developer transitions
+
+- **Delegation Options for Heavy Reads (v0.0.10.3)**
+  - Updated `/kmgraph:extract-chat`, `/kmgraph:session-summary`, `/kmgraph:update-graph` with guidance
+  - When processing 10+ sessions or 50+ KB, suggests delegating to appropriate subagent
+  - Reduces peak context usage for large operations
+
+- **Documentation Configuration (v0.0.10.3)**
+  - Moved CHANGELOG.md to top-level mkdocs navigation (was nested under Contributing)
+  - Added LinkedIn icon to header (between GitHub and search) via custom theme override
+  - Updated COMMAND-GUIDE.md with handoff section and new delegation patterns
+  - Updated GETTING-STARTED.md with skills and subagents explanation and trigger table
+
+### Changed
+- **Commands Reference**
+  - Added `/kmgraph:handoff` (new command)
+  - Command count updated: 22 → 23 total commands
+  - Install instructions now reference `kmgraph` namespace consistently
+
+### Documentation
+- Added "Skills and Subagents" section to GETTING-STARTED.md with trigger tables
+- Added "Project Transitions & Onboarding" section to COMMAND-GUIDE.md
+- Enhanced CHEAT-SHEET.md with delegation syntax examples
+- Updated CLAUDE.md with Skills, Subagents, and Commit Format sections
+
+**Commits across v0.0.10.0 through v0.0.10.3:**
+- v0.0.10.0: Cleanup and workflow consolidation
+- v0.0.10.1: Skills (5), Subagents (2), and KG backfill scaffolding
+- v0.0.10.2: Integrated init backfill option (knowledge-extractor powered)
+- v0.0.10.3: Handoff command, delegation blocks, documentation updates, theme customization
+
+---
+
 ## [0.0.9-alpha] - 2026-02-27
 
 ### Added

--- a/docs/CHEAT-SHEET.md
+++ b/docs/CHEAT-SHEET.md
@@ -21,6 +21,7 @@ One-page cheat sheet for the Knowledge Management Graph. For detailed documentat
 - **Work with multiple knowledge graphs** → `/kmgraph:list` then `/kmgraph:switch`
 - **Link lessons to GitHub issues** → `/kmgraph:link-issue`
 - **Update plugin documentation** → `/kmgraph:update-doc --user-facing`
+- **Create comprehensive project handoff** → `/kmgraph:handoff`
 
 ---
 
@@ -66,6 +67,58 @@ Power users leverage these for complex workflows:
 | `/kmgraph:archive-memory` | Archive stale MEMORY.md entries to prevent bloat |
 | `/kmgraph:restore-memory` | Restore archived MEMORY.md entries |
 | `/kmgraph:sync-all` | Automated full sync pipeline (4 steps → 1 command) |
+| `/kmgraph:handoff` | Create comprehensive handoff documentation for transitions or onboarding |
+
+---
+
+## Auto-Triggered Skills
+
+Skills activate automatically based on conversation context. No invocation needed.
+
+| Skill | Trigger Condition | Suggests |
+|-------|------------------|----------|
+| `lesson-capture` | Bug solved, breakthrough made, "figured it out" | `/kmgraph:capture-lesson` with pre-filled context |
+| `kg-recall` | History question, "have we solved this?", past decision | `/kmgraph:recall` with extracted search terms |
+| `session-wrap` | Context approaching limit, major milestone, session end | `/kmgraph:session-summary` before compaction |
+| `adr-guide` | Architecture decision discussed, "I'm thinking of using..." | `/kmgraph:create-adr` with decision guidance |
+| `gov-execute-plan` | "execute plan", implementation start, `docs/plans/*.md` mentioned | Zero-deviation 8-step execution protocol |
+
+---
+
+## Delegation for Heavy-Lift Tasks
+
+When processing large batches or complex files, delegate to subagents to reduce context usage.
+
+### Extraction & Parsing (knowledge-extractor)
+Use for: multi-file analysis, chat history parsing (10+ sessions), large lesson batches (50+ KB)
+```bash
+# Before delegation (default)
+/kmgraph:extract-chat --after=2026-02-01  # Loads all sessions into context
+
+# Suggested delegation
+/kmgraph:extract-chat --project=knowledge-graph
+# (Assistant suggests: "Consider delegating to knowledge-extractor for multi-project filtering")
+```
+
+### Documentation & Git (session-documenter)
+Use for: full session parsing across multiple branches, automated session summaries
+```bash
+# Before delegation (default)
+/kmgraph:session-summary  # Parses entire chat history in-context
+
+# Suggested delegation
+# (Assistant suggests: "For multi-session history, delegate to session-documenter")
+```
+
+### Knowledge Graph Updates (knowledge-extractor)
+Use for: bulk lesson extraction (10+ lessons at once), pattern analysis
+```bash
+# Before delegation (default)
+/kmgraph:update-graph  # Processes all new lessons in-context
+
+# Suggested delegation
+# (Assistant suggests: "For 50+ KB of lessons, delegate to knowledge-extractor")
+```
 
 ---
 

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@knowledge-graph-plugin/mcp-server",
-  "version": "0.0.9-alpha",
+  "version": "0.0.10-alpha",
   "description": "MCP server for Knowledge Management Graph — cross-platform data layer for knowledge capture, search, and management",
   "main": "dist/index.js",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "knowledge-graph-plugin",
-  "version": "0.0.9-alpha",
+  "version": "0.0.10-alpha",
   "description": "Structured knowledge capture and cross-session memory for Claude Code projects.",
   "files": [
     ".claude-plugin/",


### PR DESCRIPTION
## Summary

Final documentation sync for v0.0.10 release series. Updates README, CHANGELOG, CHEAT-SHEET with new features (skills, subagents, backfill, handoff, token optimization), new command, and synchronizes all version numbers across config files.

## Changes

- **README.md**: Updated version to 0.0.10-alpha, command count to 23, added v0.0.10 feature highlights
- **CHANGELOG.md**: Added comprehensive v0.0.10-alpha entry documenting all 4 releases (v0.0.10.0-10.3)
- **CHEAT-SHEET.md**: Added auto-triggered skills section with trigger conditions and delegation syntax examples for heavy-lift tasks
- **Version Consistency**: Updated package.json, plugin.json, mcp-server/package.json to 0.0.10-alpha

## Features Documented

- 5 auto-triggered skills: lesson-capture, kg-recall, session-wrap, adr-guide, gov-execute-plan
- 2 subagents: knowledge-extractor (read-only), session-documenter (git archaeology)
- Optional KG backfill during init
- New /kmgraph:handoff command for project transitions
- Token optimization via lazy-loading and delegation

## Test Plan

- [x] All documentation files updated
- [x] Version consistency verified: 0.0.10-alpha across all files
- [x] Handoff command documented in COMMAND-GUIDE.md and CHEAT-SHEET.md
- [x] Skills and subagents tables added to GETTING-STARTED.md and CHEAT-SHEET.md
- [x] CHANGELOG includes all v0.0.10 releases with detailed feature lists

🤖 Generated with [Claude Code](https://claude.com/claude-code)