### PR TITLE
docs(roadmap): replace stale v0.0.8.6 Next Steps with Superseded by

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,4 +1,4 @@
-# Knowledge Plugin — Roadmap
+# Knowledge Management Graph — Roadmap
 
 ## v0.0.10.4-alpha (Released: 2026-03-01)
 
@@ -93,9 +93,10 @@
 - Build verification: mkdocs build successful
 - Mermaid diagram rendering verified in both modes
 
-### Next Steps
-- 🔄 Merge to main and verify on GitHub Pages
-- 📦 Plan v0.0.9 (enhanced features)
+### Superseded by
+- ✅ v0.0.9-alpha (2026-02-27): Infrastructure alignment, namespace migration
+- ✅ v0.0.10-alpha (2026-02-27): Skills, subagents, backfill, handoff
+- ✅ v0.0.10.4-alpha (2026-03-01): MCP node_modules fix
 
 ---
 


### PR DESCRIPTION
Replaces outdated 'Next Steps' in v0.0.8.6-alpha section (was planning v0.0.9 as future work) with a 'Superseded by' list showing v0.0.9, v0.0.10, v0.0.10.4 as completed.