### PR TITLE
docs(mkdocs): exclude docs/plans/ from build; add core/templates README

### DIFF
--- a/core/templates/README.md
+++ b/core/templates/README.md
@@ -1,0 +1,30 @@
+# Templates — Source Directory
+
+This is the **canonical source** for all KMGraph templates. Edit templates here.
+
+---
+
+## Why two locations?
+
+| Location | Purpose | Committed? |
+|----------|---------|------------|
+| `core/templates/` | Canonical source (this folder) | ✅ Yes |
+| `docs/templates/` | Build-time copy for MkDocs | ❌ No (gitignored) |
+
+`docs/templates/` is generated automatically by `docs/hooks.py` during `mkdocs serve` or `mkdocs build`. It is ephemeral — deleted and recreated on every build.
+
+**Do not edit files in `docs/templates/`.** Changes there will be overwritten on the next build.
+
+---
+
+## Template categories
+
+| Folder | Contents |
+|--------|---------|
+| `decisions/` | Architecture Decision Record (ADR) template |
+| `documentation/` | Doc scaffolding template |
+| `knowledge/` | Knowledge graph entry template |
+| `lessons-learned/` | Lesson capture template |
+| `meta-issue/` | Meta-issue tracking template |
+| `sessions/` | Session summary template |
+| `MEMORY-template.md` | MEMORY.md starting template |

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -6,6 +6,8 @@ repo_name: technomensch/knowledge-graph
 edit_uri: edit/main/docs/
 
 docs_dir: docs
+exclude_docs: |
+  plans/
 extra_css:
   - stylesheets/extra.css
 


### PR DESCRIPTION
## Summary

- Adds `exclude_docs: plans/` to mkdocs.yml — plan files no longer appear in site search, nav, or trigger warnings during `mkdocs serve/build`
- Adds `core/templates/README.md` explaining the dual-location system: `core/templates/` is the canonical source committed to git; `docs/templates/` is an ephemeral build-time copy generated by `docs/hooks.py` and gitignored

🤖 Generated with [Claude Code](https://claude.com/claude-code)