### PR TITLE
docs(mkdocs): add exclude patterns to git-revision-date plugin

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -7,7 +7,12 @@ edit_uri: edit/main/docs/
 
 docs_dir: docs
 exclude_docs: |
-  plans/
+  plans/**
+  chat-history/**
+  sessions/**
+  reference/**
+  examples/**
+  templates/**
 extra_css:
   - stylesheets/extra.css
 
@@ -76,6 +81,13 @@ plugins:
       separator: '[\s\-,:!=\[\]()"/]+|(?!\b)(?=[A-Z][a-z])|\.(?!\d)|&[lg]t;'
   - git-revision-date-localized:
       enable_creation_date: true
+      exclude:
+        - plans/**
+        - chat-history/**
+        - sessions/**
+        - reference/**
+        - examples/**
+        - templates/**
   - glightbox
   - minify
   - roamlinks


### PR DESCRIPTION
Adds explicit `exclude` patterns to git-revision-date-localized plugin config so it skips local-only folders (plans, chat-history, sessions, reference, examples, templates) during mkdocs build.