### PR TITLE
fix(docs): remove incorrect mkdocs exclusions that broke site

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -10,9 +10,6 @@ exclude_docs: |
   plans/**
   chat-history/**
   sessions/**
-  reference/**
-  examples/**
-  templates/**
 extra_css:
   - stylesheets/extra.css
 
@@ -85,9 +82,6 @@ plugins:
         - plans/**
         - chat-history/**
         - sessions/**
-        - reference/**
-        - examples/**
-        - templates/**
   - glightbox
   - minify
   - roamlinks


### PR DESCRIPTION
## Summary

Fixes the previous commit's overly aggressive mkdocs.yml exclusions that broke the site.

## What Was Wrong

The previous commit excluded:
- `reference/**` (Architecture docs, Manual Workflows, Platform Adaptation, etc.)
- `examples/**` (Code examples)
- `templates/**` (Knowledge graph template reference)

These are **build-time generated copies** created by `docs/hooks.py` and must be indexed by MkDocs for the site to function properly. Excluding them removed these entire sections from the navigation and search.

## What This Fixes

Keeps only the correct exclusions for **local-only folders** that should never be published:
- `plans/**` — implementation plans (local audit trail, not published)
- `chat-history/**` — extracted session history (local, not published)
- `sessions/**` — local session documentation (not published)

The `reference/`, `examples/`, and `templates/` folders now appear in the Advanced navigation and are searchable.

## Verification

✅ Advanced navigation section visible  
✅ Reference pages accessible  
✅ Grid card rendering preserved (no regression)  
✅ MkDocs build succeeds with zero exclusion-related warnings  

Closes #27

🤖 Generated with [Claude Code](https://claude.com/claude-code)