### PR TITLE
docs(troubleshooting): plugin cache workaround and ADR-006

### DIFF
--- a/docs/GETTING-STARTED.md
+++ b/docs/GETTING-STARTED.md
@@ -143,6 +143,32 @@ Each step serves a specific purpose:
 
 ## Troubleshooting
 
+### Plugin update does not take effect { #plugin-update-does-not-take-effect }
+
+!!! warning "Known Claude Code Limitation: Plugin Cache Not Refreshed on Update"
+    Claude Code's "Update Now" feature and `claude plugin update` command update version metadata but do **not** re-download plugin files. The installed plugin continues running from the old cached version after an update.
+
+    This is a known platform issue ([#19197](https://github.com/anthropics/claude-code/issues/19197), [#14061](https://github.com/anthropics/claude-code/issues/14061)).
+
+    **Symptoms:**
+    - Installed tab still shows the old version number
+    - New commands or skills added in the update are unavailable
+    - MCP server shows a `failed` status
+
+    **Fix — clear the cache and reinstall:**
+
+    ```bash
+    # Step 1: Remove the stale cache
+    rm -rf ~/.claude/plugins/cache/stayinginsync-knowledge-graph/
+
+    # Step 2: Reinstall via the Claude Code /plugin UI
+    # Uninstall kmgraph, then reinstall from the marketplace
+    ```
+
+    **Step 3: Reconnect the MCP server**
+
+    After reinstalling, open `/plugin` → **Installed** → **kmgraph** → **MCP Server** → **Reconnect**.
+
 ### Commands do not appear in Claude Code autocomplete
 
 - Verify the plugin is loaded: start Claude Code with `claude --plugin-dir /path/to/knowledge-graph`

--- a/docs/decisions/ADR-006-document-cache-clear-upgrade-workaround.md
+++ b/docs/decisions/ADR-006-document-cache-clear-upgrade-workaround.md
@@ -1,0 +1,53 @@
+---
+title: "ADR-006: Document Cache-Clear as Official Upgrade Path for Claude Code Plugin"
+status: Accepted
+date: 2026-03-03
+deciders: technomensch, Claude Haiku 4.5
+---
+
+# ADR-006: Document Cache-Clear as Official Upgrade Path for Claude Code Plugin
+
+## Status
+
+**Accepted** — 2026-03-03
+
+## Context
+
+Claude Code's plugin update mechanism does not invalidate the plugin cache when a version changes. Running `claude plugin update` or using "Update Now" updates metadata but leaves the physical cache directory unchanged. Users who update the plugin continue running stale files until they manually clear the cache.
+
+This is a confirmed platform bug with multiple open issues against Claude Code (#14061, #15642, #19197, #29074). There is no timeline for an upstream fix.
+
+Three mitigation options were considered for the kmgraph plugin:
+
+1. **Do nothing** — rely on users discovering the issue organically
+2. **Add a SessionStart hook version check** — detect version mismatch at session start and display a warning prompt
+3. **Document the cache-clear workaround prominently** — add instructions to GETTING-STARTED.md with the exact command
+
+A fourth option — patching the cache directory automatically during SessionStart — was considered and rejected as too invasive (writing to `~/.claude/plugins/cache/` from a plugin hook crosses a trust boundary).
+
+## Decision
+
+**Option 3 (documentation) is accepted for v0.1.0-beta.** Option 2 (hook-based version check) is deferred to the next release cycle.
+
+The GETTING-STARTED.md Troubleshooting section will include a prominent `!!! warning` admonition with:
+- The exact `rm -rf` command to clear the cache
+- Steps to reinstall via `/plugin` UI
+- A note to reconnect the MCP server after reinstalling
+
+## Rationale
+
+- **Immediate:** Documentation is deployable now without additional implementation risk
+- **Effective:** The `rm -rf` workaround is reliable and confirmed working
+- **Conservative:** Avoids writing to Claude Code's internal cache directory from plugin code
+- **Traceable:** Links to upstream Claude Code issues so users can monitor for an official fix
+
+## Consequences
+
+- Users who do not read the troubleshooting section may still encounter stale versions
+- The hook-based warning (Option 2) should be implemented in the next feature release to catch users who skip documentation
+- The upstream Claude Code issues should be upvoted to increase priority for an official fix
+
+## Related
+
+- [Lesson: Claude Code Plugin Cache Stale After Update](../lessons-learned/debugging/claude-code-plugin-cache-stale-after-update.md)
+- [GETTING-STARTED.md](../GETTING-STARTED.md) — Implementation of this decision

--- a/docs/lessons-learned/process/claude-code-plugin-cache-stale-after-update.md
+++ b/docs/lessons-learned/process/claude-code-plugin-cache-stale-after-update.md
@@ -1,0 +1,77 @@
+---
+title: "Claude Code Plugin Cache Does Not Refresh After Update"
+category: process
+tags: [claude-code, plugin, cache, update, mcp, version]
+created: 2026-03-03
+author: technomensch
+git_branch: v0.0.3-github-docs
+severity: medium
+status: workaround-documented
+---
+
+# Claude Code Plugin Cache Does Not Refresh After Update
+
+## Problem
+
+After running `claude plugin update` or using the "Update Now" button in the Claude Code plugin UI, the plugin continues to run from the old cached version. The version displayed in the Installed tab does not change, and new commands, skills, or hook changes from the updated version are not loaded.
+
+Additionally, the MCP server may show a `failed` status and require manual reconnection after an update.
+
+## Root Cause
+
+Claude Code caches installed plugins in a versioned directory:
+
+```
+~/.claude/plugins/cache/{marketplace-name}/{plugin-name}/{version}/
+```
+
+When `claude plugin update` runs, it:
+1. Updates `installed_plugins.json` with the new version number
+2. Updates the marketplace metadata
+3. **Does NOT re-download or replace the actual plugin files in the cache directory**
+
+The physical cache directory (named after the original installed version) remains unchanged. `CLAUDE_PLUGIN_ROOT` continues to point to the stale path.
+
+This is a known Claude Code bug with multiple open issues:
+- [#19197](https://github.com/anthropics/claude-code/issues/19197) — update doesn't re-download files when version changes
+- [#15642](https://github.com/anthropics/claude-code/issues/15642) — CLAUDE_PLUGIN_ROOT points to stale version after update
+- [#14061](https://github.com/anthropics/claude-code/issues/14061) — /plugin update does not invalidate cache
+- [#29074](https://github.com/anthropics/claude-code/issues/29074) — Cache not cleared on reinstall
+
+## Symptoms
+
+- Installed tab shows old version number (e.g., `0.0.10-alpha`) after updating to a newer release
+- New commands or skills added in the update are not available
+- Discover tab shows a version older than what is in the GitHub repo
+- MCP server shows `failed` status after update
+
+## Workaround
+
+**Step 1: Clear the plugin cache**
+
+```bash
+rm -rf ~/.claude/plugins/cache/stayinginsync-knowledge-graph/
+```
+
+**Step 2: Reinstall the plugin**
+
+Via the Claude Code `/plugin` UI: uninstall kmgraph, then reinstall from the marketplace.
+
+Or via CLI:
+```bash
+claude plugin uninstall kmgraph
+claude plugin install stayinginsync/knowledge-graph
+```
+
+**Step 3: Reconnect the MCP server**
+
+After reinstalling, open `/plugin` → Installed → kmgraph → MCP Server → Reconnect.
+
+## Prevention
+
+None available within the plugin — this is a platform-level limitation. Document the workaround prominently and instruct users to use the cache-clear method for all version upgrades until Anthropic resolves the upstream issue.
+
+## Related
+
+- [ADR-006](../decisions/ADR-006-document-cache-clear-upgrade-workaround.md) — Decision to document workaround rather than implement in-plugin mitigation
+- [GETTING-STARTED.md Troubleshooting](../GETTING-STARTED.md#plugin-update-does-not-take-effect) — User-facing instructions


### PR DESCRIPTION
## Summary

- Adds `!!! warning` callout to GETTING-STARTED.md Troubleshooting section with the `rm -rf` cache clear command and MCP reconnect steps for users upgrading kmgraph
- Creates lesson learned (`process/claude-code-plugin-cache-stale-after-update.md`) documenting root cause, symptoms, and workaround with links to 4 upstream Claude Code issues
- Creates ADR-006 documenting the decision to use documentation-based mitigation over in-plugin workarounds for this release

## Context

Claude Code's plugin update mechanism does not invalidate the cache. Affects all users upgrading between versions. Upstream issues: [#14061](https://github.com/anthropics/claude-code/issues/14061), [#15642](https://github.com/anthropics/claude-code/issues/15642), [#19197](https://github.com/anthropics/claude-code/issues/19197), [#29074](https://github.com/anthropics/claude-code/issues/29074).

## Test plan

- [ ] Verify warning callout renders correctly in MkDocs Material theme
- [ ] Verify lesson file is tracked by git (not gitignored)
- [ ] Verify ADR-006 links resolve correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)