### PR TITLE
ci: update GitHub Actions to Node.js 24 compatible versions

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -16,7 +16,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '24'
           cache: npm
 
       - name: Install dependencies
@@ -26,7 +26,7 @@ jobs:
         run: npm run build
 
       - name: Deploy to GitHub Pages
-        uses: peaceiris/actions-gh-pages@v3
+        uses: peaceiris/actions-gh-pages@v4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./build


### PR DESCRIPTION
## Summary

- Updated `actions/setup-node@v4` node-version from `20` to `24`
- Updated `peaceiris/actions-gh-pages` from `@v3` to `@v4` (Node 24 support)
- `actions/checkout@v4` already supports Node 24 - no change needed

## Motivation

GitHub Actions will force Node.js 24 as default starting June 2, 2026. Node.js 20 will be removed from runners September 16, 2026. This prevents workflow failures after those dates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)