### PR TITLE
v0.2.4.1-beta: CI Node.js 24 update + version sync

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "kmgraph",
-  "version": "0.2.3.4-beta",
+  "version": "0.2.4.1-beta",
   "description": "Structured knowledge capture, lesson-learned documentation, and cross-session memory for Claude Code projects. Includes KG entries, ADRs, meta-issue tracking, chat extraction, and MEMORY.md bidirectional sync.",
   "author": {
     "name": "technomensch",

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -16,7 +16,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '24'
           cache: npm
 
       - name: Install dependencies
@@ -26,7 +26,7 @@ jobs:
         run: npm run build
 
       - name: Deploy to GitHub Pages
-        uses: peaceiris/actions-gh-pages@v3
+        uses: peaceiris/actions-gh-pages@v4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./build

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Released]
 
-## [0.2.4-beta] — 2026-04-08
+## [0.2.4.1-beta] - 2026-04-09
+
+### CI
+- **GitHub Actions updated to Node.js 24** - Updated `actions/setup-node@v4` node-version from 20 to 24 and `peaceiris/actions-gh-pages` from v3 to v4. Prevents workflow failures after Node.js 20 deprecation on GitHub Actions runners (June 2026).
+
+## [0.2.4-beta] - 2026-04-08
 
 ### Documentation
 - **Diátaxis restructure** — Full docs site reorganized into Tutorials / How-to Guides / Reference / Concepts per the Diátaxis IA framework

--- a/docs/CHEAT-SHEET.md
+++ b/docs/CHEAT-SHEET.md
@@ -267,5 +267,5 @@ Use for: bulk lesson extraction (10+ lessons at once), pattern analysis
 
 ---
 
-**Version**: 0.2.3.4-beta
+**Version**: 0.2.4.1-beta
 **Last Updated**: 2026-03-30

--- a/docs/COMMAND-GUIDE.md
+++ b/docs/COMMAND-GUIDE.md
@@ -1449,5 +1449,5 @@ flowchart TD
 </div>
 ---
 
-**Version**: 0.2.3.4-beta
+**Version**: 0.2.4.1-beta
 **Updated**: 2026-03-30

--- a/docs/CONCEPTS.md
+++ b/docs/CONCEPTS.md
@@ -214,5 +214,5 @@ MEMORY.md works best under 200 lines. When it grows beyond that threshold:
 </div>
 ---
 
-**Version**: 0.2.3.4-beta
+**Version**: 0.2.4.1-beta
 **Last Updated**: 2026-04-07

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -5,7 +5,7 @@ sidebar_label: Commands
 description: Every KMGraph slash command — category, description, and key flags
 ---
 
-**Version:** 0.2.3.4-beta | All commands use the `/kmgraph:` prefix in Claude Code. Other platforms access equivalent functionality through `kg_*` MCP tools — see [INSTALL.md](../INSTALL.md) for details.
+**Version:** 0.2.4.1-beta | All commands use the `/kmgraph:` prefix in Claude Code. Other platforms access equivalent functionality through `kg_*` MCP tools — see [INSTALL.md](../INSTALL.md) for details.
 
 <img src="/img/demos/session-summary.gif" alt="KMGraph session-summary demo — snapshot of captured lessons and open plans" width="800" />
 

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@knowledge-graph-plugin/mcp-server",
-  "version": "0.2.3.4-beta",
+  "version": "0.2.4.1-beta",
   "description": "MCP server for Knowledge Management Graph — cross-platform data layer for knowledge capture, search, and management",
   "main": "dist/index.js",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "knowledge-graph-plugin",
-  "version": "0.2.3.4-beta",
+  "version": "0.2.4.1-beta",
   "description": "Structured knowledge capture and cross-session memory for Claude Code projects.",
   "files": [
     ".claude-plugin/",


### PR DESCRIPTION
## Summary

- Update GitHub Actions to Node.js 24 compatible versions (`actions/setup-node@v4` node 24, `peaceiris/actions-gh-pages@v4`)
- Bump version 0.2.3.4-beta -> 0.2.4.1-beta across all version files
- Update doc footers: CHEAT-SHEET, CONCEPTS, COMMAND-GUIDE, reference/commands
- Add CHANGELOG entry for 0.2.4.1-beta

## Motivation

GitHub Actions will force Node.js 24 by default June 2, 2026; Node.js 20 removed September 16, 2026.

## Test plan

- [ ] Deploy workflow passes with Node.js 24
- [ ] Version strings consistent across package.json, plugin.json, mcp-server/package.json, and doc footers

🤖 Generated with [Claude Code](https://claude.com/claude-code)