### PR TITLE
feat(init-shared): v0.3.1-beta — shared module pattern for init command deduplication

### DIFF
--- a/commands/init-personal-kg.md
+++ b/commands/init-personal-kg.md
@@ -45,7 +45,6 @@ Parameters:
 - `{kg_name}` = "personal"
 - `{KG_TYPE}` = "personal"
 - `{categories}` = ["architecture", "debugging", "patterns", "process"]
-- `{preserve_active}` = true
 
 **After upgrade-inspector completes (Option 1), always continue to Step 8 (content migration) and Step 9 (evidence seeding).** These run independently of the template upgrade check — an up-to-date template install does not mean me.md/rules.md have been populated.
 

--- a/commands/init-personal-kg.md
+++ b/commands/init-personal-kg.md
@@ -39,68 +39,15 @@ After setup, `/kmgraph:capture-lesson` shows a KG picker when saving lessons, an
 
 ### Step 1: Check for existing personal KG
 
-Read `~/.claude/kg-config.json`. Look for any entry with `type: "personal"`.
+**→ Execute shared module:** Read `commands/init-shared/upgrade-inspector.md` and follow it exactly.
+Parameters:
+- `{KG_PATH}` = resolved personal KG path
+- `{kg_name}` = "personal"
+- `{KG_TYPE}` = "personal"
+- `{categories}` = ["architecture", "debugging", "patterns", "process"]
+- `{preserve_active}` = true
 
-**If one already exists:**
-```
-A personal KG is already registered: "[name]" at [path]
-
-Options:
-1. See what's new — review improvements in this version, then decide what to apply
-2. Re-initialize it — archive existing content, reset structure, keep all lessons and ADRs
-3. Register a different path as personal KG
-4. Cancel
-```
-
-**Important:** Option 1 is the default upgrade path. Do NOT offer "use as-is / no action needed" — there may be new templates, missing files, or unpopulated me.md/rules.md to address. Always run the upgrade check.
-
-**If option 1 selected**, inspect the personal KG's actual state and report only what is missing or upgradeable for this specific install:
-
-```bash
-upgrades=()
-
-# Index reorganization — knowledge/index.md renamed to kg-category-index-global.md; new root kg-index-global.md created
-if [ -f "{personal_kg_path}/knowledge/index.md" ] && [ ! -f "{personal_kg_path}/knowledge/kg-category-index-global.md" ]; then
-  upgrades+=("Index update: renames {personal_kg_path}/knowledge/index.md to kg-category-index-global.md and adds a new kg-index-global.md at the personal KG root as the primary entry point")
-elif [ ! -f "{personal_kg_path}/kg-index-global.md" ]; then
-  upgrades+=("New: kg-index-global.md — the primary entry point for this personal knowledge graph")
-fi
-
-[ ! -f "{personal_kg_path}/me.md" ]    && upgrades+=("New: me.md — your cross-project identity and working style")
-# When writing me.md to personal KG, strip the "See also: ~/.claude/knowledge-graph/me.md" line — self-referential at personal KG level
-[ ! -f "{personal_kg_path}/rules.md" ] && upgrades+=("New: rules.md — cross-project behavioral rules and preferences")
-
-# FTS5 index — personal KG is always outside git so gitignore doesn't apply.
-# If .fts5.db exists it is intentional local state — never suggest removal or migration.
-# Only surface it if missing (offer to rebuild).
-[ ! -f "{personal_kg_path}/.fts5.db" ] && upgrades+=("Search index missing — will be rebuilt on first use")
-
-for tdir in knowledge lessons-learned decisions sessions; do
-  for template in "${CLAUDE_PLUGIN_ROOT}/core/templates/$tdir/"*; do
-    dest="{personal_kg_path}/$tdir/$(basename $template)"
-    [ ! -f "$dest" ] && upgrades+=("New template: $tdir/$(basename $template)")
-  done
-done
-```
-
-If nothing is upgradeable:
-```
-✅ Your personal KG is already up to date. Nothing to apply.
-```
-
-If upgrades exist:
-```
-Here's what's available for your personal KG:
-  • [item 1]
-  • [item 2]
-
-Apply all, pick individually, or skip?
-  1. Apply all
-  2. Let me choose which ones to apply
-  3. Skip — my setup is already how I want it
-```
-
-After applying upgrades (or if nothing to upgrade), **always continue to Step 8 (content migration) and Step 9 (evidence seeding)**. These run independently of the template upgrade check — an up-to-date template install does not mean me.md/rules.md have been populated.
+**After upgrade-inspector completes (Option 1), always continue to Step 8 (content migration) and Step 9 (evidence seeding).** These run independently of the template upgrade check — an up-to-date template install does not mean me.md/rules.md have been populated.
 
 **If option 2 selected (re-initialize):**
 
@@ -165,28 +112,19 @@ Store resolved path as `{personal_kg_path}`.
 
 ### Step 3: Create directory structure
 
-```bash
-mkdir -p "{personal_kg_path}"/{knowledge,lessons-learned,decisions,sessions}
-mkdir -p "{personal_kg_path}/lessons-learned"/{architecture,debugging,patterns,process}
-```
+**→ Execute shared module:** Read `commands/init-shared/directory-scaffold.md` and follow it exactly.
+Parameters:
+- `{KG_PATH}` = resolved personal KG path
+- `{categories}` = ["architecture", "debugging", "patterns", "process"]
 
 ---
 
 ### Step 4: Copy templates
 
-```bash
-for f in patterns.md gotchas.md concepts.md architecture.md workflows.md; do
-  src="${CLAUDE_PLUGIN_ROOT}/core/templates/knowledge/$f"
-  dest="{personal_kg_path}/knowledge/$f"
-  [ -f "$src" ] && [ ! -f "$dest" ] && cp "$src" "$dest"
-done
-# kg-category-index deploys as kg-category-index-global.md at personal KG level
-src="${CLAUDE_PLUGIN_ROOT}/core/templates/knowledge/kg-category-index.md"
-dest="{personal_kg_path}/knowledge/kg-category-index-global.md"
-[ -f "$src" ] && [ ! -f "$dest" ] && cp "$src" "$dest"
-```
-
-Only copy if template doesn't already exist (preserves user content on re-init).
+**→ Execute shared module:** Read `commands/init-shared/template-seed.md` and follow it exactly.
+Parameters:
+- `{KG_PATH}` = resolved personal KG path
+- `{CLAUDE_PLUGIN_ROOT}` = plugin root path
 
 When deploying `me.md` to the personal KG, strip the "See also: ~/.claude/knowledge-graph/me.md" line — it is a project-KG cross-reference that points to itself when deployed as the personal KG's own me.md.
 
@@ -194,34 +132,24 @@ When deploying `me.md` to the personal KG, strip the "See also: ~/.claude/knowle
 
 ### Step 5: Register in config
 
-Add or update the `"personal"` entry in `~/.claude/kg-config.json`:
-
-```json
-"personal": {
-  "name": "personal",
-  "path": "~/.claude/knowledge-graph",
-  "type": "personal",
-  "categories": [
-    {"name": "architecture", "prefix": null, "git": "ignore"},
-    {"name": "debugging",    "prefix": null, "git": "ignore"},
-    {"name": "patterns",     "prefix": null, "git": "ignore"},
-    {"name": "process",      "prefix": null, "git": "ignore"}
-  ],
-  "createdAt": "[timestamp]",
-  "lastUsed": "[timestamp]"
-}
-```
-
-Do NOT change `"active"` — project KG remains active.
+**→ Execute shared module:** Read `commands/init-shared/config-entry-write.md` and follow it exactly.
+Parameters:
+- `{KG_PATH}` = resolved personal KG path
+- `{kg_name}` = "personal"
+- `{KG_TYPE}` = "personal"
+- `{categories}` = ["architecture", "debugging", "patterns", "process"]
+- `{git_strategy}` = "all-ignore"
+- `{category_git_rules}` = all categories set to "ignore"
+- `{preserve_active}` = true
 
 ---
 
 ### Step 6: Build FTS5 index
 
-Call `kg_fts5_rebuild` with `kgPath: "{personal_kg_path}"`.
-
-- If `indexed > 0`: confirm success
-- If `indexed = 0`: normal for empty KG — log note, not an error
+**→ Execute shared module:** Read `commands/init-shared/fts5-rebuild.md` and follow it exactly.
+Parameters:
+- `{KG_PATH}` = resolved personal KG path
+- `{kg_name}` = "personal"
 
 ---
 

--- a/commands/init-shared/config-entry-write.md
+++ b/commands/init-shared/config-entry-write.md
@@ -39,8 +39,17 @@ EOF
 )
 
 # Update config with jq (or manual JSON manipulation)
+# Only include the .active assignment when {preserve_active} is false.
+# Use the appropriate form below based on the value of {preserve_active}:
+
+# If {preserve_active} is FALSE — set the active KG:
 jq ".graphs[\"{kg_name}\"] = $config_entry | .active = \"{kg_name}\"" \
   ~/.claude/kg-config.json > ~/.claude/kg-config.json.tmp
+
+# If {preserve_active} is TRUE — do NOT modify .active:
+jq ".graphs[\"{kg_name}\"] = $config_entry" \
+  ~/.claude/kg-config.json > ~/.claude/kg-config.json.tmp
+
 mv ~/.claude/kg-config.json.tmp ~/.claude/kg-config.json
 ```
 
@@ -76,4 +85,3 @@ if [ -n "$GRAPHS_WITHOUT_TYPE" ]; then
 fi
 ```
 
-If {preserve_active} is true, do not modify the "active" field in ~/.claude/kg-config.json.

--- a/commands/init-shared/config-entry-write.md
+++ b/commands/init-shared/config-entry-write.md
@@ -1,0 +1,79 @@
+---
+description: Shared config entry write module — writes or backfills a KG entry in kg-config.json
+---
+
+## Module: config-entry-write
+
+### Parameters
+
+| Parameter | Description |
+|---|---|
+| `{KG_PATH}` | Absolute path to the knowledge graph root directory |
+| `{kg_name}` | Name key used in kg-config.json |
+| `{KG_TYPE}` | Type string: "project-local" or "personal" |
+| `{categories}` | Array of category names with prefix and git rules |
+| `{git_strategy}` | Git strategy: "all-commit", "all-ignore", or "selective" |
+| `{category_git_rules}` | Per-category git rule map (used when git_strategy is "selective") |
+| `{preserve_active}` | Boolean — if true, do not modify the "active" field in config |
+
+---
+
+```bash
+# Build config entry JSON
+config_entry=$(cat <<EOF
+{
+  "name": "{kg_name}",
+  "path": "{KG_PATH}",
+  "type": "{KG_TYPE}",
+  "categories": [
+    $(for cat in "${categories[@]}"; do
+      prefix="${category_prefixes[$cat]:-null}"
+      git_rule="${category_git_rules[$cat]:-commit}"
+      echo "{ \"name\": \"$cat\", \"prefix\": $prefix, \"git\": \"$git_rule\" },"
+    done | sed '$ s/,$//')
+  ],
+  "createdAt": "$(date -u +%Y-%m-%dT%H:%M:%SZ)",
+  "lastUsed": "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+}
+EOF
+)
+
+# Update config with jq (or manual JSON manipulation)
+jq ".graphs[\"{kg_name}\"] = $config_entry | .active = \"{kg_name}\"" \
+  ~/.claude/kg-config.json > ~/.claude/kg-config.json.tmp
+mv ~/.claude/kg-config.json.tmp ~/.claude/kg-config.json
+```
+
+#### Config field check
+
+Check for config fields introduced in newer versions. Add defaults for any missing fields without overwriting existing values:
+
+```bash
+# Fields that may be missing from older installs:
+# - platforms: [] (added in v0.2.0)
+# - autoSwitch: false (added in v0.2.0)
+# - notification: { webhookUrl: "" } (added in v0.2.0)
+# - type: "project-local" (added in v0.2.2 — required for multi-KG support)
+
+jq '
+  .graphs["'"$kg_name"'"] |=
+    if .platforms == null then .platforms = [] else . end |
+    if .autoSwitch == null then .autoSwitch = false else . end |
+    if .notification == null then .notification = { "webhookUrl": "" } else . end |
+    if .type == null then .type = "project-local" else . end
+' ~/.claude/kg-config.json > ~/.claude/kg-config.json.tmp
+mv ~/.claude/kg-config.json.tmp ~/.claude/kg-config.json
+```
+
+**After the migration, check for graphs still missing `type`** (e.g., if the user has multiple registered KGs from v0.2.1):
+
+```bash
+GRAPHS_WITHOUT_TYPE=$(jq -r '.graphs | to_entries[] | select(.value.type == null) | .key' ~/.claude/kg-config.json)
+if [ -n "$GRAPHS_WITHOUT_TYPE" ]; then
+  echo "⚠️  Some registered KGs are missing a type field (defaulted to project-local):"
+  echo "$GRAPHS_WITHOUT_TYPE"
+  echo "   If any of these should be a personal KG, run /kmgraph:init-personal-kg to re-register correctly."
+fi
+```
+
+If {preserve_active} is true, do not modify the "active" field in ~/.claude/kg-config.json.

--- a/commands/init-shared/directory-scaffold.md
+++ b/commands/init-shared/directory-scaffold.md
@@ -1,0 +1,52 @@
+---
+description: Shared directory scaffold module — creates the standard KG directory tree
+---
+
+## Module: directory-scaffold
+
+### Parameters
+
+| Parameter | Description |
+|---|---|
+| `{KG_PATH}` | Absolute path to the knowledge graph root directory |
+| `{categories}` | Array of category names configured for this KG |
+
+---
+
+### Directory structure check
+
+Verify all expected directories exist. Create any that are missing:
+
+```bash
+expected_dirs=(knowledge lessons-learned decisions sessions chat-history)
+for dir in "${expected_dirs[@]}"; do
+  if [ ! -d "{KG_PATH}/$dir" ]; then
+    mkdir -p "{KG_PATH}/$dir"
+    echo "✅ Created missing directory: $dir/"
+  fi
+done
+
+# Check category subdirectories
+for category in "{categories[@]}"; do
+  if [ ! -d "{KG_PATH}/lessons-learned/$category" ]; then
+    mkdir -p "{KG_PATH}/lessons-learned/$category"
+    echo "✅ Created missing category directory: lessons-learned/$category/"
+  fi
+done
+```
+
+### Create directory structure
+
+```bash
+mkdir -p "{KG_PATH}"/{knowledge,lessons-learned,decisions,sessions,chat-history,tmp}
+
+# Create category subdirectories
+for category in "{categories[@]}"; do
+  mkdir -p "{KG_PATH}/lessons-learned/$category"
+done
+
+# Create meta-issue if governance category selected
+if [[ " {categories[@]} " =~ " governance " ]]; then
+  mkdir -p "{KG_PATH}/meta-issues"
+fi
+```

--- a/commands/init-shared/fts5-rebuild.md
+++ b/commands/init-shared/fts5-rebuild.md
@@ -1,0 +1,37 @@
+---
+description: Shared FTS5 rebuild module — offers to build/rebuild the search index for a KG
+---
+
+## Module: fts5-rebuild
+
+### Parameters
+
+| Parameter | Description |
+|---|---|
+| `{KG_PATH}` | Absolute path to the knowledge graph root directory |
+| `{kg_name}` | Name key used in kg-config.json |
+
+---
+
+If the path is confirmed correct, check whether the index needs rebuilding:
+
+```bash
+FTS5_DECLINED=$(jq -r '.graphs["{kg_name}"].fts5_declined // false' ~/.claude/kg-config.json)
+
+if [ "$FTS5_DECLINED" = "true" ]; then
+  echo "⏭️  Search index: skipped (previously declined)"
+elif [ ! -f "{KG_PATH}/.fts5.db" ]; then
+  echo "⚠️  Search index not found (local file, not version-controlled)."
+  echo ""
+  echo "  Rebuild now? This may take a moment for large knowledge graphs."
+  echo "    1. Yes — rebuild index"
+  echo "    2. Skip for now (search will use linear scan)"
+fi
+```
+
+If the user selects **Yes**, call `kg_fts5_rebuild`. **After the rebuild, validate the result:**
+
+- If `indexed` is 0: display a warning — "Search index built but 0 files were indexed. Verify the KG path points to the directory containing lessons-learned/, decisions/, and sessions/. Current path: {KG_PATH}"
+- If `indexed` > 0: confirm success — "✅ Search index built: {indexed} files indexed in {duration_ms}ms"
+
+If the user selects **Skip**, continue without rebuilding (linear scan remains available as fallback).

--- a/commands/init-shared/template-seed.md
+++ b/commands/init-shared/template-seed.md
@@ -1,0 +1,86 @@
+---
+description: Shared template seed module — non-destructive copy of core/templates/ into a KG directory
+---
+
+## Module: template-seed
+
+### Parameters
+
+| Parameter | Description |
+|---|---|
+| `{KG_PATH}` | Absolute path to the knowledge graph root directory |
+| `{CLAUDE_PLUGIN_ROOT}` | Absolute path to the plugin root (source of core/templates/) |
+
+---
+
+### Copy templates
+
+```bash
+# Copy KG templates
+cp "{CLAUDE_PLUGIN_ROOT}/core/templates/knowledge/patterns.md" "{KG_PATH}/knowledge/"
+cp "{CLAUDE_PLUGIN_ROOT}/core/templates/knowledge/gotchas.md" "{KG_PATH}/knowledge/"
+cp "{CLAUDE_PLUGIN_ROOT}/core/templates/knowledge/concepts.md" "{KG_PATH}/knowledge/"
+cp "{CLAUDE_PLUGIN_ROOT}/core/templates/knowledge/architecture.md" "{KG_PATH}/knowledge/"
+cp "{CLAUDE_PLUGIN_ROOT}/core/templates/knowledge/workflows.md" "{KG_PATH}/knowledge/"
+cp "{CLAUDE_PLUGIN_ROOT}/core/templates/knowledge/kg-category-index.md" "{KG_PATH}/knowledge/"
+
+# Copy root-level files (skip if already exists to preserve teammate copies)
+[ -f "{KG_PATH}/rules.md" ] && echo "rules.md already exists — skipping scaffold (teammate copy preserved)." || \
+  cp "{CLAUDE_PLUGIN_ROOT}/core/templates/knowledge/rules.md" "{KG_PATH}/rules.md"
+[ -f "{KG_PATH}/index.md" ] && echo "index.md already exists — skipping scaffold." || \
+  cp "{CLAUDE_PLUGIN_ROOT}/core/templates/knowledge/kg-index.md" "{KG_PATH}/index.md"
+# me.md is always gitignored — safe to scaffold fresh
+cp "{CLAUDE_PLUGIN_ROOT}/core/templates/knowledge/me.md" "{KG_PATH}/me.md"
+
+# Copy lesson/ADR templates
+cp "{CLAUDE_PLUGIN_ROOT}/core/templates/lessons-learned/README.md" "{KG_PATH}/lessons-learned/"
+cp "{CLAUDE_PLUGIN_ROOT}/core/templates/lessons-learned/lesson-template.md" "{KG_PATH}/lessons-learned/"
+cp "{CLAUDE_PLUGIN_ROOT}/core/templates/decisions/README.md" "{KG_PATH}/decisions/"
+cp "{CLAUDE_PLUGIN_ROOT}/core/templates/decisions/ADR-template.md" "{KG_PATH}/decisions/"
+
+# Copy session template
+cp "{CLAUDE_PLUGIN_ROOT}/core/templates/sessions/session-template.md" "{KG_PATH}/sessions/"
+
+# Copy MEMORY template if not exists
+if [ ! -f "~/.claude/projects/$(basename $(pwd))/memory/MEMORY.md" ]; then
+  echo "Note: MEMORY.md template available at {CLAUDE_PLUGIN_ROOT}/core/templates/MEMORY-template.md"
+  echo "Copy manually if needed for new projects."
+fi
+```
+
+#### Template update check
+
+Compare installed templates against the plugin's current templates. If newer versions exist, offer to update:
+
+```bash
+template_dirs=("knowledge" "lessons-learned" "decisions" "sessions")
+updates_available=()
+
+for tdir in "${template_dirs[@]}"; do
+  for template in "{CLAUDE_PLUGIN_ROOT}/core/templates/$tdir/"*; do
+    dest="{KG_PATH}/$tdir/$(basename $template)"
+    if [ -f "$dest" ]; then
+      if ! diff -q "$template" "$dest" > /dev/null 2>&1; then
+        updates_available+=("$tdir/$(basename $template)")
+      fi
+    else
+      updates_available+=("$tdir/$(basename $template) (new)")
+    fi
+  done
+done
+```
+
+If updates are available, present them:
+
+```
+Template updates available:
+  • knowledge/index.md (updated)
+  • sessions/session-template.md (new)
+
+Update templates? This will NOT overwrite your existing lessons or decisions.
+  1. Update all templates
+  2. Review each one
+  3. Skip template updates
+```
+
+**Important:** Never overwrite user-created files (lessons, ADRs, KG entries). Only update template/scaffold files.

--- a/commands/init-shared/upgrade-inspector.md
+++ b/commands/init-shared/upgrade-inspector.md
@@ -56,9 +56,9 @@ for tdir in knowledge lessons-learned decisions sessions; do
     for covered in "${scaffold_covered[@]}"; do
       [ "$tname" = "$covered" ] && skip=true && break
     done
-    $skip && continue
+    [ "$skip" = "true" ] && continue
     dest="{KG_PATH}/$tdir/$tname"
-    [ ! -f "$dest" ] && upgrades+=("New template: $tdir/$tname")
+    [ ! -f "$dest" ] && upgrades+=("New template: $tdir/$tname") || true
   done
 done
 ```

--- a/commands/init-shared/upgrade-inspector.md
+++ b/commands/init-shared/upgrade-inspector.md
@@ -1,0 +1,199 @@
+---
+description: Shared upgrade inspector module — detects missing dirs, templates, and config fields for an existing KG
+---
+
+## Module: upgrade-inspector
+
+### Parameters
+
+| Parameter | Description |
+|---|---|
+| `{KG_PATH}` | Absolute path to the knowledge graph root directory |
+| `{kg_name}` | Name key used in kg-config.json |
+| `{KG_TYPE}` | Type string: "project-local" or "personal" |
+| `{categories}` | Array of category names configured for this KG |
+
+---
+
+## Pre-Wizard: Existing KG Detection
+
+Before running any checks or making any changes, check if a knowledge graph already exists for this project in `~/.claude/kg-config.json`. If the current working directory matches an existing KG's path (or is a parent/child of one), present this menu instead of jumping straight to setup:
+
+```
+A knowledge graph named "[name]" already exists in the config and is set as active.
+It's [type] at [path] with categories: [list].
+
+What would you like to do?
+
+1. See what's new — review improvements in this version, then decide what to apply
+2. Create a new, separate knowledge graph (different name/location)
+3. Re-initialize "[name]" (reset categories, git strategy, etc.)
+4. Cancel — the existing KG is already set up
+```
+
+### Option 1: See What's New
+
+When the user selects option 1, **before running any checks or making any changes**, inspect the KG's actual state and report only what is missing or upgradeable for this specific install:
+
+```bash
+# Inspect what's actually missing or upgradeable
+upgrades=()
+
+# Missing directories
+for dir in knowledge lessons-learned decisions sessions chat-history tmp; do
+  [ ! -d "{KG_PATH}/$dir" ] && upgrades+=("Missing directory: $dir/")
+done
+
+# Index reorganization — knowledge/index.md renamed to kg-category-index.md; new root kg-index.md created
+if [ -f "{KG_PATH}/knowledge/index.md" ] && [ ! -f "{KG_PATH}/knowledge/kg-category-index.md" ]; then
+  upgrades+=("Index update: renames {KG_PATH}/knowledge/index.md to kg-category-index.md and adds a new kg-index.md at the knowledge graph root as the primary entry point")
+elif [ ! -f "{KG_PATH}/index.md" ]; then
+  upgrades+=("New: kg-index.md — the primary entry point for this knowledge graph")
+fi
+
+# Missing root-level scaffold files
+[ ! -f "{KG_PATH}/me.md" ]      && upgrades+=("New: me.md — your identity and working style in this project")
+[ ! -f "{KG_PATH}/rules.md" ]   && upgrades+=("New: rules.md — project conventions and behavioral rules")
+
+# Path migration available
+CONFIGURED_PATH=$(jq -r '.graphs["{kg_name}"].path' ~/.claude/kg-config.json)
+echo "$CONFIGURED_PATH" | grep -qE '/docs/?$' && \
+  [ -d "$CONFIGURED_PATH/lessons-learned" ] && \
+  upgrades+=("Migration available: move KMGraph content from docs/ to knowledge/")
+
+# New templates (files in plugin core/templates not yet in KG)
+# Skip templates that are already covered by the scaffold file checks above:
+#   kg-index.md deploys as {KG_PATH}/index.md — already checked
+#   me.md and rules.md deploy to {KG_PATH} root — already checked
+scaffold_covered=("kg-index.md" "me.md" "rules.md" "index-personal.md")
+for tdir in knowledge lessons-learned decisions sessions; do
+  for template in "${CLAUDE_PLUGIN_ROOT}/core/templates/$tdir/"*; do
+    tname=$(basename "$template")
+    # Skip if this template is covered by a scaffold check
+    skip=false
+    for covered in "${scaffold_covered[@]}"; do
+      [ "$tname" = "$covered" ] && skip=true && break
+    done
+    $skip && continue
+    dest="{KG_PATH}/$tdir/$tname"
+    [ ! -f "$dest" ] && upgrades+=("New template: $tdir/$tname")
+  done
+done
+```
+
+If nothing is upgradeable, say:
+```
+✅ Your setup is already up to date. Nothing to apply.
+```
+And exit.
+
+If upgrades exist, present them:
+```
+Here's what's available for your install:
+  • [item 1]
+  • [item 2]
+  ...
+
+Apply all, pick individually, or skip?
+  1. Apply all
+  2. Let me choose which ones to apply
+  3. Skip — my setup is already how I want it
+```
+
+If the user picks option 2 (choose individually), present each item as a separate yes/no prompt before running it.
+
+If the user picks option 3 (skip), exit with no changes.
+
+Then perform these checks in order:
+
+#### a. Directory structure check
+
+Verify all expected directories exist. Create any that are missing:
+
+```bash
+expected_dirs=(knowledge lessons-learned decisions sessions chat-history)
+for dir in "${expected_dirs[@]}"; do
+  if [ ! -d "{KG_PATH}/$dir" ]; then
+    mkdir -p "{KG_PATH}/$dir"
+    echo "✅ Created missing directory: $dir/"
+  fi
+done
+
+# Check category subdirectories
+for category in "{categories[@]}"; do
+  if [ ! -d "{KG_PATH}/lessons-learned/$category" ]; then
+    mkdir -p "{KG_PATH}/lessons-learned/$category"
+    echo "✅ Created missing category directory: lessons-learned/$category/"
+  fi
+done
+```
+
+#### b. Config field check
+
+Check for config fields introduced in newer versions. Add defaults for any missing fields without overwriting existing values:
+
+```bash
+# Fields that may be missing from older installs:
+# - platforms: [] (added in v0.2.0)
+# - autoSwitch: false (added in v0.2.0)
+# - notification: { webhookUrl: "" } (added in v0.2.0)
+# - type: "project-local" (added in v0.2.2 — required for multi-KG support)
+
+jq '
+  .graphs["{kg_name}"] |=
+    if .platforms == null then .platforms = [] else . end |
+    if .autoSwitch == null then .autoSwitch = false else . end |
+    if .notification == null then .notification = { "webhookUrl": "" } else . end |
+    if .type == null then .type = "{KG_TYPE}" else . end
+' ~/.claude/kg-config.json > ~/.claude/kg-config.json.tmp
+mv ~/.claude/kg-config.json.tmp ~/.claude/kg-config.json
+```
+
+**After the migration, check for graphs still missing `type`** (e.g., if the user has multiple registered KGs from v0.2.1):
+
+```bash
+GRAPHS_WITHOUT_TYPE=$(jq -r '.graphs | to_entries[] | select(.value.type == null) | .key' ~/.claude/kg-config.json)
+if [ -n "$GRAPHS_WITHOUT_TYPE" ]; then
+  echo "⚠️  Some registered KGs are missing a type field (defaulted to project-local):"
+  echo "$GRAPHS_WITHOUT_TYPE"
+  echo "   If any of these should be a personal KG, run /kmgraph:init-personal-kg to re-register correctly."
+fi
+```
+
+
+#### c. Template update check
+
+Compare installed templates against the plugin's current templates. If newer versions exist, offer to update:
+
+```bash
+template_dirs=("knowledge" "lessons-learned" "decisions" "sessions")
+updates_available=()
+
+for tdir in "${template_dirs[@]}"; do
+  for template in "${CLAUDE_PLUGIN_ROOT}/core/templates/$tdir/"*; do
+    dest="{KG_PATH}/$tdir/$(basename $template)"
+    if [ -f "$dest" ]; then
+      if ! diff -q "$template" "$dest" > /dev/null 2>&1; then
+        updates_available+=("$tdir/$(basename $template)")
+      fi
+    else
+      updates_available+=("$tdir/$(basename $template) (new)")
+    fi
+  done
+done
+```
+
+If updates are available, present them:
+
+```
+Template updates available:
+  • knowledge/index.md (updated)
+  • sessions/session-template.md (new)
+
+Update templates? This will NOT overwrite your existing lessons or decisions.
+  1. Update all templates
+  2. Review each one
+  3. Skip template updates
+```
+
+**Important:** Never overwrite user-created files (lessons, ADRs, KG entries). Only update template/scaffold files.

--- a/commands/init-shared/upgrade-inspector.md
+++ b/commands/init-shared/upgrade-inspector.md
@@ -15,25 +15,7 @@ description: Shared upgrade inspector module — detects missing dirs, templates
 
 ---
 
-## Pre-Wizard: Existing KG Detection
-
-Before running any checks or making any changes, check if a knowledge graph already exists for this project in `~/.claude/kg-config.json`. If the current working directory matches an existing KG's path (or is a parent/child of one), present this menu instead of jumping straight to setup:
-
-```
-A knowledge graph named "[name]" already exists in the config and is set as active.
-It's [type] at [path] with categories: [list].
-
-What would you like to do?
-
-1. See what's new — review improvements in this version, then decide what to apply
-2. Create a new, separate knowledge graph (different name/location)
-3. Re-initialize "[name]" (reset categories, git strategy, etc.)
-4. Cancel — the existing KG is already set up
-```
-
-### Option 1: See What's New
-
-When the user selects option 1, **before running any checks or making any changes**, inspect the KG's actual state and report only what is missing or upgradeable for this specific install:
+**Before running any checks or making any changes**, inspect the KG's actual state and report only what is missing or upgradeable for this specific install:
 
 ```bash
 # Inspect what's actually missing or upgradeable

--- a/commands/init.md
+++ b/commands/init.md
@@ -51,7 +51,6 @@ Parameters:
 - `{kg_name}` = name key of the matched KG in kg-config.json
 - `{KG_TYPE}` = type field from the KG config entry ("project-local" or "personal")
 - `{categories}` = categories array from the KG config entry
-- `{preserve_active}` = false
 
 
 #### 1d. Platform config check

--- a/commands/init.md
+++ b/commands/init.md
@@ -45,170 +45,14 @@ What would you like to do?
 
 ### Option 1: See What's New
 
-When the user selects option 1, **before running any checks or making any changes**, inspect the KG's actual state and report only what is missing or upgradeable for this specific install:
+**→ Execute shared module:** Read `commands/init-shared/upgrade-inspector.md` and follow it exactly.
+Parameters:
+- `{KG_PATH}` = resolved path for this KG (from `~/.claude/kg-config.json` entry for the matched KG)
+- `{kg_name}` = name key of the matched KG in kg-config.json
+- `{KG_TYPE}` = type field from the KG config entry ("project-local" or "personal")
+- `{categories}` = categories array from the KG config entry
+- `{preserve_active}` = false
 
-```bash
-# Inspect what's actually missing or upgradeable
-upgrades=()
-
-# Missing directories
-for dir in knowledge lessons-learned decisions sessions chat-history tmp; do
-  [ ! -d "$KG_PATH/$dir" ] && upgrades+=("Missing directory: $dir/")
-done
-
-# Index reorganization — knowledge/index.md renamed to kg-category-index.md; new root kg-index.md created
-if [ -f "$KG_PATH/knowledge/index.md" ] && [ ! -f "$KG_PATH/knowledge/kg-category-index.md" ]; then
-  upgrades+=("Index update: renames ${KG_PATH}/knowledge/index.md to kg-category-index.md and adds a new kg-index.md at the knowledge graph root as the primary entry point")
-elif [ ! -f "$KG_PATH/kg-index.md" ]; then
-  upgrades+=("New: kg-index.md — the primary entry point for this knowledge graph")
-fi
-
-# Missing root-level scaffold files
-[ ! -f "$KG_PATH/me.md" ]      && upgrades+=("New: me.md — your identity and working style in this project")
-[ ! -f "$KG_PATH/rules.md" ]   && upgrades+=("New: rules.md — project conventions and behavioral rules")
-
-# Path migration available
-CONFIGURED_PATH=$(jq -r '.graphs["'"$kg_name"'"].path' ~/.claude/kg-config.json)
-echo "$CONFIGURED_PATH" | grep -qE '/docs/?$' && \
-  [ -d "$CONFIGURED_PATH/lessons-learned" ] && \
-  upgrades+=("Migration available: move KMGraph content from docs/ to knowledge/")
-
-# New templates (files in plugin core/templates not yet in KG)
-# Skip templates that are already covered by the scaffold file checks above:
-#   kg-index.md deploys as $KG_PATH/index.md — already checked
-#   me.md and rules.md deploy to $KG_PATH root — already checked
-scaffold_covered=("kg-index.md" "me.md" "rules.md" "kg-index-global.md")
-for tdir in knowledge lessons-learned decisions sessions; do
-  for template in "${CLAUDE_PLUGIN_ROOT}/core/templates/$tdir/"*; do
-    tname=$(basename "$template")
-    # Skip if this template is covered by a scaffold check
-    skip=false
-    for covered in "${scaffold_covered[@]}"; do
-      [ "$tname" = "$covered" ] && skip=true && break
-    done
-    $skip && continue
-    dest="$KG_PATH/$tdir/$tname"
-    [ ! -f "$dest" ] && upgrades+=("New template: $tdir/$tname")
-  done
-done
-```
-
-If nothing is upgradeable, say:
-```
-✅ Your setup is already up to date. Nothing to apply.
-```
-And exit.
-
-If upgrades exist, present them:
-```
-Here's what's available for your install:
-  • [item 1]
-  • [item 2]
-  ...
-
-Apply all, pick individually, or skip?
-  1. Apply all
-  2. Let me choose which ones to apply
-  3. Skip — my setup is already how I want it
-```
-
-If the user picks option 2 (choose individually), present each item as a separate yes/no prompt before running it.
-
-If the user picks option 3 (skip), exit with no changes.
-
-Then perform these checks in order:
-
-#### 1a. Directory structure check
-
-Verify all expected directories exist. Create any that are missing:
-
-```bash
-expected_dirs=(knowledge lessons-learned decisions sessions chat-history)
-for dir in "${expected_dirs[@]}"; do
-  if [ ! -d "$KG_PATH/$dir" ]; then
-    mkdir -p "$KG_PATH/$dir"
-    echo "✅ Created missing directory: $dir/"
-  fi
-done
-
-# Check category subdirectories
-for category in "${categories[@]}"; do
-  if [ ! -d "$KG_PATH/lessons-learned/$category" ]; then
-    mkdir -p "$KG_PATH/lessons-learned/$category"
-    echo "✅ Created missing category directory: lessons-learned/$category/"
-  fi
-done
-```
-
-#### 1b. Config field check
-
-Check for config fields introduced in newer versions. Add defaults for any missing fields without overwriting existing values:
-
-```bash
-# Fields that may be missing from older installs:
-# - platforms: [] (added in v0.2.0)
-# - autoSwitch: false (added in v0.2.0)
-# - notification: { webhookUrl: "" } (added in v0.2.0)
-# - type: "project-local" (added in v0.2.2 — required for multi-KG support)
-
-jq '
-  .graphs["'"$kg_name"'"] |=
-    if .platforms == null then .platforms = [] else . end |
-    if .autoSwitch == null then .autoSwitch = false else . end |
-    if .notification == null then .notification = { "webhookUrl": "" } else . end |
-    if .type == null then .type = "project-local" else . end
-' ~/.claude/kg-config.json > ~/.claude/kg-config.json.tmp
-mv ~/.claude/kg-config.json.tmp ~/.claude/kg-config.json
-```
-
-**After the migration, check for graphs still missing `type`** (e.g., if the user has multiple registered KGs from v0.2.1):
-
-```bash
-GRAPHS_WITHOUT_TYPE=$(jq -r '.graphs | to_entries[] | select(.value.type == null) | .key' ~/.claude/kg-config.json)
-if [ -n "$GRAPHS_WITHOUT_TYPE" ]; then
-  echo "⚠️  Some registered KGs are missing a type field (defaulted to project-local):"
-  echo "$GRAPHS_WITHOUT_TYPE"
-  echo "   If any of these should be a personal KG, run /kmgraph:init-personal-kg to re-register correctly."
-fi
-```
-
-
-#### 1c. Template update check
-
-Compare installed templates against the plugin's current templates. If newer versions exist, offer to update:
-
-```bash
-template_dirs=("knowledge" "lessons-learned" "decisions" "sessions")
-updates_available=()
-
-for tdir in "${template_dirs[@]}"; do
-  for template in "${CLAUDE_PLUGIN_ROOT}/core/templates/$tdir/"*; do
-    dest="$KG_PATH/$tdir/$(basename $template)"
-    if [ -f "$dest" ]; then
-      if ! diff -q "$template" "$dest" > /dev/null 2>&1; then
-        updates_available+=("$tdir/$(basename $template)")
-      fi
-    else
-      updates_available+=("$tdir/$(basename $template) (new)")
-    fi
-  done
-done
-```
-
-If updates are available, present them:
-
-```
-Template updates available:
-  • knowledge/index.md (updated)
-  • sessions/session-template.md (new)
-
-Update templates? This will NOT overwrite your existing lessons or decisions.
-  1. Update all templates
-  2. Review each one
-  3. Skip template updates
-```
-
-**Important:** Never overwrite user-created files (lessons, ADRs, KG entries). Only update template/scaffold files.
 
 #### 1d. Platform config check
 
@@ -691,28 +535,10 @@ if [ "$DIRS_AT_ROOT" -eq 0 ] && [ "$DIRS_AT_DOCS" -gt 0 ]; then
 fi
 ```
 
-If the path is confirmed correct, check whether the index needs rebuilding:
-
-```bash
-FTS5_DECLINED=$(jq -r '.graphs["'"$kg_name"'"].fts5_declined // false' ~/.claude/kg-config.json)
-
-if [ "$FTS5_DECLINED" = "true" ]; then
-  echo "⏭️  Search index: skipped (previously declined)"
-elif [ ! -f "$KG_ROOT/.fts5.db" ]; then
-  echo "⚠️  Search index not found (local file, not version-controlled)."
-  echo ""
-  echo "  Rebuild now? This may take a moment for large knowledge graphs."
-  echo "    1. Yes — rebuild index"
-  echo "    2. Skip for now (search will use linear scan)"
-fi
-```
-
-If the user selects **Yes**, call `kg_fts5_rebuild`. **After the rebuild, validate the result:**
-
-- If `indexed` is 0: display a warning — "Search index built but 0 files were indexed. Verify the KG path points to the directory containing lessons-learned/, decisions/, and sessions/. Current path: {kgPath}"
-- If `indexed` > 0: confirm success — "✅ Search index built: {indexed} files indexed in {duration_ms}ms"
-
-If the user selects **Skip**, continue without rebuilding (linear scan remains available as fallback).
+**→ Execute shared module:** Read `commands/init-shared/fts5-rebuild.md` and follow it exactly.
+Parameters:
+- `{KG_PATH}` = resolved KG path (confirmed correct from the check above)
+- `{kg_name}` = name key of this KG in kg-config.json
 
 #### 1g. Knowledge extraction check
 
@@ -918,62 +744,17 @@ if [ -d "$KG_PATH" ]; then
 fi
 ```
 
-```bash
-mkdir -p "$KG_PATH"/{knowledge,lessons-learned,decisions,sessions,chat-history,tmp}
-
-# Create category subdirectories
-for category in "${categories[@]}"; do
-  mkdir -p "$KG_PATH/lessons-learned/$category"
-done
-
-# Create meta-issue if governance category selected
-if [[ " ${categories[@]} " =~ " governance " ]]; then
-  mkdir -p "$KG_PATH/meta-issues"
-fi
-```
+**→ Execute shared module:** Read `commands/init-shared/directory-scaffold.md` and follow it exactly.
+Parameters:
+- `{KG_PATH}` = resolved KG path (from Step 1.4)
+- `{categories}` = categories array collected in Step 1.2
 
 ### Step 1.6: Copy templates
 
-```bash
-# Copy KG templates
-cp "${CLAUDE_PLUGIN_ROOT}/core/templates/knowledge/patterns.md" "$KG_PATH/knowledge/"
-cp "${CLAUDE_PLUGIN_ROOT}/core/templates/knowledge/gotchas.md" "$KG_PATH/knowledge/"
-cp "${CLAUDE_PLUGIN_ROOT}/core/templates/knowledge/concepts.md" "$KG_PATH/knowledge/"
-cp "${CLAUDE_PLUGIN_ROOT}/core/templates/knowledge/architecture.md" "$KG_PATH/knowledge/"
-cp "${CLAUDE_PLUGIN_ROOT}/core/templates/knowledge/workflows.md" "$KG_PATH/knowledge/"
-cp "${CLAUDE_PLUGIN_ROOT}/core/templates/knowledge/kg-category-index.md" "$KG_PATH/knowledge/"
-
-# Copy root-level files (E6 — skip if already exists to preserve teammate copies)
-# If KG is docs/-based and migration will be offered, scaffold directly to knowledge/ so files
-# land at the final destination rather than docs/ (migration would move them, but this is cleaner).
-SCAFFOLD_ROOT="$KG_PATH"
-if echo "$KG_PATH" | grep -qE '/docs/?$'; then
-  PROJECT_ROOT_FOR_SCAFFOLD=$(echo "$KG_PATH" | sed 's|/docs/*$||')
-  mkdir -p "$PROJECT_ROOT_FOR_SCAFFOLD/knowledge"
-  SCAFFOLD_ROOT="$PROJECT_ROOT_FOR_SCAFFOLD/knowledge"
-fi
-[ -f "$SCAFFOLD_ROOT/rules.md" ] && echo "rules.md already exists — skipping scaffold (teammate copy preserved)." || \
-  cp "${CLAUDE_PLUGIN_ROOT}/core/templates/knowledge/rules.md" "$SCAFFOLD_ROOT/rules.md"
-[ -f "$SCAFFOLD_ROOT/kg-index.md" ] && echo "kg-index.md already exists — skipping scaffold." || \
-  cp "${CLAUDE_PLUGIN_ROOT}/core/templates/knowledge/kg-index.md" "$SCAFFOLD_ROOT/kg-index.md"
-# me.md is always gitignored — safe to scaffold fresh
-cp "${CLAUDE_PLUGIN_ROOT}/core/templates/knowledge/me.md" "$SCAFFOLD_ROOT/me.md"
-
-# Copy lesson/ADR templates
-cp "${CLAUDE_PLUGIN_ROOT}/core/templates/lessons-learned/README.md" "$KG_PATH/lessons-learned/"
-cp "${CLAUDE_PLUGIN_ROOT}/core/templates/lessons-learned/lesson-template.md" "$KG_PATH/lessons-learned/"
-cp "${CLAUDE_PLUGIN_ROOT}/core/templates/decisions/README.md" "$KG_PATH/decisions/"
-cp "${CLAUDE_PLUGIN_ROOT}/core/templates/decisions/ADR-template.md" "$KG_PATH/decisions/"
-
-# Copy session template
-cp "${CLAUDE_PLUGIN_ROOT}/core/templates/sessions/session-template.md" "$KG_PATH/sessions/"
-
-# Copy MEMORY template if not exists
-if [ ! -f "~/.claude/projects/$(basename $(pwd))/memory/MEMORY.md" ]; then
-  echo "Note: MEMORY.md template available at ${CLAUDE_PLUGIN_ROOT}/core/templates/MEMORY-template.md"
-  echo "Copy manually if needed for new projects."
-fi
-```
+**→ Execute shared module:** Read `commands/init-shared/template-seed.md` and follow it exactly.
+Parameters:
+- `{KG_PATH}` = resolved KG path (from Step 1.4)
+- `{CLAUDE_PLUGIN_ROOT}` = plugin root path (environment variable available in this context)
 
 ### Step 1.6.5: Content migration offer (new install only)
 
@@ -1084,31 +865,15 @@ fi
 
 ### Step 1.8: Write config entry
 
-```bash
-# Build config entry JSON
-config_entry=$(cat <<EOF
-{
-  "name": "$kg_name",
-  "path": "$KG_PATH",
-  "type": "$location_type",
-  "categories": [
-    $(for cat in "${categories[@]}"; do
-      prefix="${category_prefixes[$cat]:-null}"
-      git_rule="${category_git_rules[$cat]:-commit}"
-      echo "{ \"name\": \"$cat\", \"prefix\": $prefix, \"git\": \"$git_rule\" },"
-    done | sed '$ s/,$//')
-  ],
-  "createdAt": "$(date -u +%Y-%m-%dT%H:%M:%SZ)",
-  "lastUsed": "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
-}
-EOF
-)
-
-# Update config with jq (or manual JSON manipulation)
-jq ".graphs[\"$kg_name\"] = $config_entry | .active = \"$kg_name\"" \
-  ~/.claude/kg-config.json > ~/.claude/kg-config.json.tmp
-mv ~/.claude/kg-config.json.tmp ~/.claude/kg-config.json
-```
+**→ Execute shared module:** Read `commands/init-shared/config-entry-write.md` and follow it exactly.
+Parameters:
+- `{KG_PATH}` = resolved KG path (from Step 1.4)
+- `{kg_name}` = KG name collected in Step 1.2
+- `{KG_TYPE}` = type field — "project-local", "personal", or "cowork" (from `location_type` in Step 1.2)
+- `{categories}` = categories array collected in Step 1.2
+- `{git_strategy}` = selected git strategy from Step 1.2
+- `{category_git_rules}` = per-category git rules map from Step 1.2 (if selective strategy)
+- `{preserve_active}` = false
 
 ### Step 1.8.5: Global Personal KG Offer
 

--- a/commands/init.md
+++ b/commands/init.md
@@ -375,6 +375,29 @@ if [ -n "$MEMORY_FILE" ]; then
   fi
 fi
 
+# e2. Rewrite docs/ path references inside migrated markdown files
+find knowledge/ -name "*.md" -type f | while read f; do
+  sed -i '' \
+    -e 's|docs/lessons-learned/|knowledge/lessons-learned/|g' \
+    -e 's|docs/decisions/|knowledge/decisions/|g' \
+    -e 's|docs/sessions/|knowledge/sessions/|g' \
+    -e 's|docs/chat-history/|knowledge/chat-history/|g' \
+    -e 's|docs/knowledge/|knowledge/concepts/|g' \
+    "$f"
+done
+
+# Also update CLAUDE.md and README.md if present
+for f in CLAUDE.md README.md; do
+  [ -f "$f" ] && sed -i '' \
+    -e 's|docs/lessons-learned/|knowledge/lessons-learned/|g' \
+    -e 's|docs/decisions/|knowledge/decisions/|g' \
+    -e 's|docs/knowledge/|knowledge/concepts/|g' \
+    "$f" || true
+done
+
+echo "⚠️  Note: memory entries in ~/.claude/projects/ may still reference docs/ paths."
+echo "   Run /kmgraph:recall to find stale references after migration."
+
 # f. Clear migration flag
 jq 'del(.graphs["'"$kg_name"'"].migration_in_progress)' \
   ~/.claude/kg-config.json > ~/.claude/kg-config.json.tmp

--- a/docs/decisions/ADR-030-shared-module-pattern-for-slash-command-deduplication.md
+++ b/docs/decisions/ADR-030-shared-module-pattern-for-slash-command-deduplication.md
@@ -1,0 +1,172 @@
+---
+title: "ADR-030: Shared Module Pattern for Slash Command Deduplication"
+number: 030
+created: 2026-04-10T00:00:00Z
+status: Accepted
+author: technomensch
+email: 917847+technomensch@users.noreply.github.com
+git:
+  branch: v0.3.1-init-shared-refactor
+  commit: c9ef4b6878a3d9c67ac83a5517310fd47ab9871a
+  pr: null
+  issue: null
+implements: null
+related:
+  adrs: []
+  lessons: []
+  kg_entries: []
+tags: [architecture]
+category: architecture
+---
+
+# ADR-030: Shared Module Pattern for Slash Command Deduplication
+
+**Date:** 2026-04-10
+**Status:** Accepted
+**Implements:** v0.3.1
+**Related:** None
+
+---
+
+## Context
+
+`commands/init.md` and `commands/init-personal-kg.md` contained large duplicated instruction blocks covering the same logic: upgrade detection, directory scaffolding, template seeding, FTS5 index rebuild, and config entry writing. Any change to this shared logic required parallel edits in both files, creating maintenance risk and drift. The commands are markdown instruction files followed by Claude — not compiled code — so there is no native import or include mechanism.
+
+**Problem:**
+- Duplicated instruction blocks across two command files required paired edits for every logic change
+- Drift between the two files was a persistent risk with no structural enforcement
+- No native module/include mechanism exists for Claude markdown instruction files
+
+**Scope:**
+- In scope: `commands/init.md`, `commands/init-personal-kg.md`, and the five new shared modules under `commands/init-shared/`
+- Out of scope: other command files not sharing logic with init commands
+- Constraint: solution must work within Claude's markdown instruction execution model
+
+---
+
+## Decision
+
+Extract duplicated instruction blocks into parameterized shared module files under `commands/init-shared/`. Each module file begins with a parameter contract table listing the variables it expects. Parent commands invoke a module by instructing Claude to read the shared file and execute it with named parameter values.
+
+### Core Components
+
+1. **`upgrade-inspector.md`:** Detects whether an existing KG installation requires upgrade, and what version it is upgrading from
+2. **`directory-scaffold.md`:** Creates the required directory structure for a new or upgraded KG
+3. **`template-seed.md`:** Seeds template files from `core/templates/` into the active KG path
+4. **`fts5-rebuild.md`:** Rebuilds the FTS5 full-text search index
+5. **`config-entry-write.md`:** Writes or updates the KG config entry in `~/.claude/kg-config.json`
+
+### Implementation Approach
+
+Parent commands (`init.md`, `init-personal-kg.md`) are reduced to stubs that set named parameters and instruct Claude to read and execute each shared module in sequence. Each module opens with a parameter contract table (e.g., `KG_PATH`, `KG_NAME`) so the interface is explicit and verifiable before execution.
+
+---
+
+## Rationale
+
+### Why This Approach
+
+1. **Single source of truth:** Each shared behavior is written once and updated once; no parallel edits required
+2. **Explicit parameter contracts:** Module interface is declared at the top of each file, making dependencies verifiable
+3. **Copy-verbatim-then-minimize-diffs:** Preserves original prose and reduces token cost versus full rewrites
+
+### Alternatives Considered
+
+**Option A: Keep duplication, use comments to flag paired files**
+- Pros: No structural change required; simpler to understand at a glance
+- Cons: Relies on discipline rather than structure; drift is not prevented, only flagged
+- Rejected because: enforcement is not structural — any edit that misses the comment pairing creates silent drift
+
+### Trade-offs
+
+**Benefits:**
+- Changes to shared logic (e.g., a new upgrade check) only require editing one file
+- Parameter contracts make module dependencies explicit and reviewable
+- Reduces total token load for both parent commands
+
+**Costs:**
+- Slight indirection — readers of `init.md` must follow a stub to understand the full flow
+- Bash array notation in module bodies (`{categories[@]}`) is instructional pseudo-code, not real shell; callers must expand correctly
+
+**Mitigation:**
+- A future lesson-learned capture will document the pseudo-code array expansion requirement to prevent misuse
+
+---
+
+## Consequences
+
+### Positive
+
+1. **Reduced maintenance surface:** Shared logic changes propagate automatically to both init commands
+2. **Explicit interfaces:** Parameter contract tables make it clear what each module requires before execution
+3. **Token efficiency:** Parent command stubs are smaller; Claude reads only the modules needed per invocation
+
+### Negative
+
+1. **Indirection:** The full init flow is no longer readable in a single file; readers must follow cross-file references
+2. **Pseudo-code risk:** Array expansion in module bodies is instructional, not executable shell — callers must handle correctly
+
+### Neutral
+
+1. **Residual overlap:** Two modules (`upgrade-inspector` and `config-entry-write`) still contain overlapping "config field backfill" logic — a v0.3.2 cleanup candidate
+
+---
+
+## Implementation
+
+**Timeline:** Implemented in branch `v0.3.1-init-shared-refactor`
+
+**Affected Components:**
+- `commands/init.md`
+- `commands/init-personal-kg.md`
+- `commands/init-shared/upgrade-inspector.md` (new)
+- `commands/init-shared/directory-scaffold.md` (new)
+- `commands/init-shared/template-seed.md` (new)
+- `commands/init-shared/fts5-rebuild.md` (new)
+- `commands/init-shared/config-entry-write.md` (new)
+
+**Migration Path:**
+No migration required for end users. Internal refactor only; command behavior and output are unchanged.
+
+---
+
+## Validation
+
+**Success Criteria:**
+- Both `init.md` and `init-personal-kg.md` invoke shared modules rather than containing duplicated blocks
+- Each shared module begins with a parameter contract table
+- A two-stage review (Sonnet then Opus) confirmed correctness before merge
+
+**Review Date:** Reassess at v0.4.0 — consider whether additional commands can adopt this pattern
+
+---
+
+## Related Decisions
+
+None
+
+---
+
+## Related Documentation
+
+**Knowledge Graph:**
+- None
+
+**Lessons Learned:**
+- Lesson to be captured separately covering pseudo-code array expansion in module bodies
+
+**Implementation:**
+- `commands/init-shared/` directory — five shared module files
+
+---
+
+## Future Considerations
+
+1. **v0.3.2 cleanup:** Consolidate overlapping config field backfill logic in `upgrade-inspector` and `config-entry-write` modules
+2. **Pattern expansion:** Evaluate whether other command pairs (e.g., `capture-lesson` variants) benefit from the same shared module pattern
+
+---
+
+**Decision Made:** 2026-04-10
+**Last Updated:** 2026-04-10
+**Status:** Accepted

--- a/docs/decisions/ADR-030-shared-module-pattern-for-slash-command-deduplication.md
+++ b/docs/decisions/ADR-030-shared-module-pattern-for-slash-command-deduplication.md
@@ -126,7 +126,11 @@ Parent commands (`init.md`, `init-personal-kg.md`) are reduced to stubs that set
 - `commands/init-shared/config-entry-write.md` (new)
 
 **Migration Path:**
-No migration required for end users. Internal refactor only; command behavior and output are unchanged.
+No migration required for end users for the shared module refactor itself.
+
+**Amendment (2026-04-10): Cross-reference rewrite added to path migration**
+
+The `docs/ → knowledge/` migration execution in `commands/init.md` (section 1f.1) previously moved files and updated `.gitignore` but left internal markdown cross-references pointing at old `docs/` paths, silently breaking any `[link](docs/lessons-learned/...)` in KG files, CLAUDE.md, or README.md. A new step `e2` has been added to the migration block that runs a `find | sed` pass over all migrated `.md` files plus CLAUDE.md and README.md, rewriting `docs/{subdir}/` to `knowledge/{subdir}/`. MEMORY.md entries (under `~/.claude/projects/`) cannot be auto-rewritten and a warning is emitted instead.
 
 ---
 
@@ -168,5 +172,5 @@ None
 ---
 
 **Decision Made:** 2026-04-10
-**Last Updated:** 2026-04-10
+**Last Updated:** 2026-04-10 (amended: cross-reference rewrite added to path migration)
 **Status:** Accepted

--- a/docs/decisions/ADR-031-shared-module-pattern-for-slash-command-deduplication.md
+++ b/docs/decisions/ADR-031-shared-module-pattern-for-slash-command-deduplication.md
@@ -1,6 +1,6 @@
 ---
-title: "ADR-030: Shared Module Pattern for Slash Command Deduplication"
-number: 030
+title: "ADR-031: Shared Module Pattern for Slash Command Deduplication"
+number: 031
 created: 2026-04-10T00:00:00Z
 status: Accepted
 author: technomensch
@@ -19,7 +19,7 @@ tags: [architecture]
 category: architecture
 ---
 
-# ADR-030: Shared Module Pattern for Slash Command Deduplication
+# ADR-031: Shared Module Pattern for Slash Command Deduplication
 
 **Date:** 2026-04-10
 **Status:** Accepted

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -4,7 +4,7 @@
 
 Formal documentation of significant architecture decisions.
 
-**Total ADRs:** 27
+**Total ADRs:** 28
 **Last Updated:** 2026-04-10
 
 ---
@@ -27,11 +27,8 @@ Formal documentation of significant architecture decisions.
 ## By Category
 
 ### Architecture
-<<<<<<< HEAD
+- [ADR-031: Shared Module Pattern for Slash Command Deduplication](ADR-031-shared-module-pattern-for-slash-command-deduplication.md) — Parameterized shared modules under `commands/init-shared/` replace duplicated instruction blocks across init commands
 - [ADR-030: Migration Moves KMGraph-Named Subdirectories Only](ADR-030-migration-moves-named-subdirs-only-never-entire-docs.md) — Named subdir list prevents collision with docs sites; explicit scope over blanket directory moves
-=======
-- [ADR-030: Shared Module Pattern for Slash Command Deduplication](ADR-030-shared-module-pattern-for-slash-command-deduplication.md) — Parameterized shared modules under `commands/init-shared/` replace duplicated instruction blocks across init commands
->>>>>>> 5d61ab4c (docs(adr): create ADR-030: Shared Module Pattern for Slash Command Deduplication)
 
 ### Process
 - [ADR-029: Plan File Location in Knowledge Graph](ADR-029-plan-file-location-in-knowledge-graph.md) — Three-location plan structure: ENH folder, issue folder, or knowledge/plans/ fallback

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -17,6 +17,7 @@ Formal documentation of significant architecture decisions.
 
 ## All ADRs (Chronological)
 
+- [ADR-031: Shared Module Pattern for Slash Command Deduplication](ADR-031-shared-module-pattern-for-slash-command-deduplication.md) — **Status:** Accepted — Duplicated init command logic extracted into five parameterized shared modules under `commands/init-shared/`; parent commands invoke modules by name with explicit parameter contracts.
 - [ADR-030: Migration Moves KMGraph-Named Subdirectories Only — Never the Entire docs/ Directory](ADR-030-migration-moves-named-subdirs-only-never-entire-docs.md) — **Status:** Accepted — Migration moves only KMGraph-named subdirs (`lessons-learned/`, `decisions/`, etc.) plus scaffold files; never the entire `docs/` directory.
 - [ADR-029: Plan File Location in Knowledge Graph](ADR-029-plan-file-location-in-knowledge-graph.md) — **Status:** Accepted — Plans linked to an ENH go in `knowledge/ENH-NNN/vX-plan.md`; issue plans in `knowledge/issue-NNN/vX-plan.md`; misc bundled plans in `knowledge/plans/vX-plan.md`.
 - [ADR-025: Do not commit `enabledPlugins` blocks in `.claude/settings.json`](ADR-025-do-not-commit-enabledplugins-blocks.md) — **Status:** Accepted — Committed `enabledPlugins` blocks create orphaned scope references for cloners; rely on `.claude-plugin/plugin.json` auto-detection instead.
@@ -26,7 +27,11 @@ Formal documentation of significant architecture decisions.
 ## By Category
 
 ### Architecture
+<<<<<<< HEAD
 - [ADR-030: Migration Moves KMGraph-Named Subdirectories Only](ADR-030-migration-moves-named-subdirs-only-never-entire-docs.md) — Named subdir list prevents collision with docs sites; explicit scope over blanket directory moves
+=======
+- [ADR-030: Shared Module Pattern for Slash Command Deduplication](ADR-030-shared-module-pattern-for-slash-command-deduplication.md) — Parameterized shared modules under `commands/init-shared/` replace duplicated instruction blocks across init commands
+>>>>>>> 5d61ab4c (docs(adr): create ADR-030: Shared Module Pattern for Slash Command Deduplication)
 
 ### Process
 - [ADR-029: Plan File Location in Knowledge Graph](ADR-029-plan-file-location-in-knowledge-graph.md) — Three-location plan structure: ENH folder, issue folder, or knowledge/plans/ fallback


### PR DESCRIPTION
## Summary

- Extracts 5 duplicated instruction blocks from `commands/init.md` and `commands/init-personal-kg.md` into parameterized shared modules under `commands/init-shared/`
- Each module has an explicit parameter contract table; parent commands invoke via stub references
- Adds ADR-030 documenting the shared module pattern decision
- Fixes cross-reference rewrite during `docs/` → `knowledge/` migration path

## Modules created

| File | Extracted from |
|---|---|
| `upgrade-inspector.md` | init.md lines 29–211 |
| `directory-scaffold.md` | init.md lines 120–140 + 612–624 |
| `template-seed.md` | init.md lines 626–659 + 176–211 |
| `fts5-rebuild.md` | init.md lines 385–406 |
| `config-entry-write.md` | init.md lines 767–793 + 142–173 |

## Test plan

- [ ] Run `/kmgraph:init` on a project with an existing KG — confirm upgrade flow runs correctly via shared modules
- [ ] Run `/kmgraph:init-personal-kg` — confirm all 5 module stubs resolve correctly
- [ ] Verify `commands/init-shared/` contains exactly 5 files
- [ ] Confirm `preserve_active=true` on `config-entry-write` call in `init-personal-kg.md` — active KG must not change

## Known follow-up (v0.3.2)

- `upgrade-inspector.md` and `config-entry-write.md` share a "config field backfill" section — candidate for a 6th shared module

🤖 Generated with [Claude Code](https://claude.com/claude-code)