### PR TITLE
fix(init): harden migration — rollback, portability, cross-ref rewrite

### DIFF
--- a/commands/init.md
+++ b/commands/init.md
@@ -332,9 +332,20 @@ done
 
 # d. Update kg-config.json path
 PROJECT_ROOT=$(pwd)
+OLD_PATH="$PROJECT_ROOT/docs"
 jq ".graphs[\"$kg_name\"].path = \"$PROJECT_ROOT/knowledge\"" \
   ~/.claude/kg-config.json > ~/.claude/kg-config.json.tmp
 mv ~/.claude/kg-config.json.tmp ~/.claude/kg-config.json
+
+# d2. Update sibling KG entries pointing to the same old path (exact match only)
+jq -r '.graphs | to_entries[] | select(.value.path == "'"$OLD_PATH"'") | .key' \
+  ~/.claude/kg-config.json | while read sibling; do
+  [ "$sibling" = "$kg_name" ] && continue
+  jq ".graphs[\"$sibling\"].path = \"$PROJECT_ROOT/knowledge\"" \
+    ~/.claude/kg-config.json > ~/.claude/kg-config.json.tmp
+  mv ~/.claude/kg-config.json.tmp ~/.claude/kg-config.json
+  echo "Updated sibling KG config path: $sibling → $PROJECT_ROOT/knowledge"
+done
 
 # e. Update .gitignore rules
 if [ -f .gitignore ]; then
@@ -342,7 +353,13 @@ if [ -f .gitignore ]; then
     -e 's|docs/sessions/|knowledge/sessions/|g' \
     -e 's|docs/chat-history/|knowledge/chat-history/|g' \
     -e 's|docs/lessons-learned/\(.*\)/|knowledge/lessons-learned/\1/|g' \
+    -e 's|docs/tmp/|knowledge/tmp/|g' \
+    -e 's|docs/me\.md|knowledge/me.md|g' \
     .gitignore
+  # Rewrite blanket docs/ KMGraph rule only if KMGraph confirmed to own docs/
+  # (trigger condition verified docs/lessons-learned/ exists above — safe to rewrite)
+  grep -qx 'docs/' .gitignore && \
+    sed -i '' -e 's|^docs/$|knowledge/|' .gitignore || true
 fi
 
 # e2. Rewrite docs/ path references inside migrated markdown files

--- a/commands/init.md
+++ b/commands/init.md
@@ -263,6 +263,17 @@ fi
 
 ```bash
 MIGRATION_IN_PROGRESS=$(jq -r '.graphs["'"$kg_name"'"].migration_in_progress // false' ~/.claude/kg-config.json)
+ROLLBACK_IN_PROGRESS=$(jq -r '.graphs["'"$kg_name"'"].rollback_in_progress // false' ~/.claude/kg-config.json)
+
+if [ "$ROLLBACK_IN_PROGRESS" = "true" ]; then
+  echo "⚠️  A previous rollback was interrupted."
+  echo ""
+  echo "   Options:"
+  echo "     1. Resume rollback — continue restoring files to docs/"
+  echo "     2. Skip — leave in current state (may be inconsistent)"
+  # If user selects Resume rollback: continue the rollback steps below
+  # If user selects Skip: exit without changes
+fi
 
 if [ "$MIGRATION_IN_PROGRESS" = "true" ]; then
   echo "⚠️  A previous migration was interrupted."
@@ -271,7 +282,81 @@ if [ "$MIGRATION_IN_PROGRESS" = "true" ]; then
   echo "     1. Resume — complete the move from docs/ to knowledge/"
   echo "     2. Rollback — move files back to docs/ and restore config"
   echo "     3. Skip — leave in current state (may be inconsistent)"
-  # Handle user selection before proceeding
+
+  # If user selects Resume: continue with migration steps below (fall through)
+  # If user selects Skip: exit without changes
+
+  # If user selects Rollback:
+  # Set rollback flag before starting; clears both flags on completion
+  jq '.graphs["'"$kg_name"'"].rollback_in_progress = true' \
+    ~/.claude/kg-config.json > ~/.claude/kg-config.json.tmp
+  mv ~/.claude/kg-config.json.tmp ~/.claude/kg-config.json
+
+  # rb-a. Reverse root scaffold file moves
+  for f in me.md rules.md index.md; do
+    [ -f "knowledge/$f" ] && mv "knowledge/$f" "docs/$f"
+  done
+
+  # rb-b. Reverse subdir moves (skip symlinks)
+  for subdir in lessons-learned decisions sessions chat-history tmp; do
+    if [ -L "knowledge/$subdir" ]; then
+      echo "⚠️  knowledge/$subdir is a symlink — skipping. Move manually if needed."
+      continue
+    fi
+    [ -d "knowledge/$subdir" ] && mv "knowledge/$subdir" "docs/$subdir"
+  done
+
+  # rb-b2. Reverse knowledge/concepts/ if it was moved from docs/knowledge/
+  if [ -d "knowledge/concepts" ] && [ ! -d "docs/knowledge" ]; then
+    mv "knowledge/concepts" "docs/knowledge"
+  fi
+
+  # rb-c. Restore kg-config.json path
+  PROJECT_ROOT=$(pwd)
+  jq ".graphs[\"$kg_name\"].path = \"$PROJECT_ROOT/docs\"" \
+    ~/.claude/kg-config.json > ~/.claude/kg-config.json.tmp
+  mv ~/.claude/kg-config.json.tmp ~/.claude/kg-config.json
+
+  # rb-d. Reverse .gitignore rules
+  if [ -f .gitignore ]; then
+    _sed_inplace \
+      -e 's|knowledge/sessions/|docs/sessions/|g' \
+      -e 's|knowledge/chat-history/|docs/chat-history/|g' \
+      -e 's|knowledge/lessons-learned/\(.*\)/|docs/lessons-learned/\1/|g' \
+      -e 's|knowledge/tmp/|docs/tmp/|g' \
+      -e 's|knowledge/me\.md|docs/me.md|g' \
+      .gitignore
+    grep -qx 'knowledge/' .gitignore && \
+      _sed_inplace -e 's|^knowledge/$|docs/|' .gitignore || true
+  fi
+
+  # rb-e. Reverse cross-reference rewrites in docs/ files and platform configs
+  find docs/ -name "*.md" -type f 2>/dev/null | while read f; do
+    _sed_inplace \
+      -e 's|knowledge/lessons-learned/|docs/lessons-learned/|g' \
+      -e 's|knowledge/decisions/|docs/decisions/|g' \
+      -e 's|knowledge/sessions/|docs/sessions/|g' \
+      -e 's|knowledge/chat-history/|docs/chat-history/|g' \
+      -e 's|knowledge/concepts/|docs/knowledge/|g' \
+      "$f"
+  done
+  for f in CLAUDE.md README.md GEMINI.md .cursorrules .windsurfrules .github/copilot-instructions.md .aider.conf.yml; do
+    [ -f "$f" ] && _sed_inplace \
+      -e 's|knowledge/lessons-learned/|docs/lessons-learned/|g' \
+      -e 's|knowledge/decisions/|docs/decisions/|g' \
+      -e 's|knowledge/sessions/|docs/sessions/|g' \
+      -e 's|knowledge/chat-history/|docs/chat-history/|g' \
+      -e 's|knowledge/concepts/|docs/knowledge/|g' \
+      "$f" || true
+  done
+
+  # rb-f. Clear both flags
+  jq 'del(.graphs["'"$kg_name"'"].migration_in_progress) | del(.graphs["'"$kg_name"'"].rollback_in_progress)' \
+    ~/.claude/kg-config.json > ~/.claude/kg-config.json.tmp
+  mv ~/.claude/kg-config.json.tmp ~/.claude/kg-config.json
+
+  echo "✅ Rollback complete. KG restored to docs/. Run /kmgraph:status to verify."
+  # Exit — do not proceed with forward migration
 fi
 ```
 
@@ -289,8 +374,8 @@ KG_PATH_ENDS_DOCS=$(echo "$CONFIGURED_PATH" | grep -E '/docs/?$')
 if [ "$KG_TYPE" = "project-local" ] && [ -n "$KG_PATH_ENDS_DOCS" ] && [ -d "$CONFIGURED_PATH/lessons-learned" ]; then
   echo "Your knowledge graph is stored in docs/ — the new recommended location is knowledge/."
   echo ""
-  echo "Move it now?"
-  echo "  1. Yes — move KMGraph subdirs to knowledge/, update config"
+  echo "Move it now? This is reversible — if anything goes wrong, run /kmgraph:init again to roll back."
+  echo "  1. Yes — move KMGraph subdirs to knowledge/, update config and all cross-references"
   echo "  2. No — keep in docs/ (no changes)"
 fi
 ```

--- a/commands/init.md
+++ b/commands/init.md
@@ -280,6 +280,8 @@ fi
 - Configured path ends in `/docs` or `/docs/`
 - `docs/lessons-learned/` exists at that path (confirms KMGraph content, not just any docs folder)
 
+Note: Migration applies to project-local KGs only. Personal KGs (`~/.claude/knowledge-graph/`) use a fixed path and never have a `docs/` layout — they are intentionally excluded by the type check above.
+
 ```bash
 KG_TYPE=$(jq -r '.graphs["'"$kg_name"'"].type' ~/.claude/kg-config.json)
 KG_PATH_ENDS_DOCS=$(echo "$CONFIGURED_PATH" | grep -E '/docs/?$')
@@ -296,6 +298,15 @@ fi
 **Migration logic (if user selects Yes):**
 
 ```bash
+# Portable in-place sed (macOS uses -i '', GNU/Linux uses -i)
+_sed_inplace() {
+  if sed --version 2>/dev/null | grep -q GNU; then
+    sed -i "$@"
+  else
+    sed -i '' "$@"
+  fi
+}
+
 # a. Create new location
 mkdir -p knowledge/
 
@@ -349,7 +360,7 @@ done
 
 # e. Update .gitignore rules
 if [ -f .gitignore ]; then
-  sed -i '' \
+  _sed_inplace \
     -e 's|docs/sessions/|knowledge/sessions/|g' \
     -e 's|docs/chat-history/|knowledge/chat-history/|g' \
     -e 's|docs/lessons-learned/\(.*\)/|knowledge/lessons-learned/\1/|g' \
@@ -359,12 +370,12 @@ if [ -f .gitignore ]; then
   # Rewrite blanket docs/ KMGraph rule only if KMGraph confirmed to own docs/
   # (trigger condition verified docs/lessons-learned/ exists above — safe to rewrite)
   grep -qx 'docs/' .gitignore && \
-    sed -i '' -e 's|^docs/$|knowledge/|' .gitignore || true
+    _sed_inplace -e 's|^docs/$|knowledge/|' .gitignore || true
 fi
 
 # e2. Rewrite docs/ path references inside migrated markdown files
 find knowledge/ -name "*.md" -type f | while read f; do
-  sed -i '' \
+  _sed_inplace \
     -e 's|docs/lessons-learned/|knowledge/lessons-learned/|g' \
     -e 's|docs/decisions/|knowledge/decisions/|g' \
     -e 's|docs/sessions/|knowledge/sessions/|g' \
@@ -375,7 +386,7 @@ done
 
 # Also update platform config files if present
 for f in CLAUDE.md README.md GEMINI.md .cursorrules .windsurfrules .github/copilot-instructions.md .aider.conf.yml; do
-  [ -f "$f" ] && sed -i '' \
+  [ -f "$f" ] && _sed_inplace \
     -e 's|docs/lessons-learned/|knowledge/lessons-learned/|g' \
     -e 's|docs/decisions/|knowledge/decisions/|g' \
     -e 's|docs/sessions/|knowledge/sessions/|g' \

--- a/commands/init.md
+++ b/commands/init.md
@@ -373,17 +373,28 @@ find knowledge/ -name "*.md" -type f | while read f; do
     "$f"
 done
 
-# Also update CLAUDE.md and README.md if present
-for f in CLAUDE.md README.md; do
+# Also update platform config files if present
+for f in CLAUDE.md README.md GEMINI.md .cursorrules .windsurfrules .github/copilot-instructions.md .aider.conf.yml; do
   [ -f "$f" ] && sed -i '' \
     -e 's|docs/lessons-learned/|knowledge/lessons-learned/|g' \
     -e 's|docs/decisions/|knowledge/decisions/|g' \
+    -e 's|docs/sessions/|knowledge/sessions/|g' \
+    -e 's|docs/chat-history/|knowledge/chat-history/|g' \
     -e 's|docs/knowledge/|knowledge/concepts/|g' \
     "$f" || true
 done
 
-echo "⚠️  Note: memory entries in ~/.claude/projects/ may still reference docs/ paths."
-echo "   Run /kmgraph:recall to find stale references after migration."
+# Scan project MEMORY.md for stale docs/ references and surface them
+PROJECT_DIR_NAME=$(basename "$(pwd)")
+MEMORY_FILE=$(find "$HOME/.claude/projects/" -path "*${PROJECT_DIR_NAME}*/memory/MEMORY.md" 2>/dev/null | head -1)
+if [ -n "$MEMORY_FILE" ]; then
+  STALE=$(grep -n "docs/" "$MEMORY_FILE" | grep -E "docs/(lessons-learned|decisions|sessions|knowledge)" || true)
+  if [ -n "$STALE" ]; then
+    echo "⚠️  Stale docs/ references found in your MEMORY.md ($MEMORY_FILE):"
+    echo "$STALE"
+    echo "   Update manually or re-run /kmgraph:init after editing."
+  fi
+fi
 
 # f. Clear migration flag
 jq 'del(.graphs["'"$kg_name"'"].migration_in_progress)' \

--- a/commands/init.md
+++ b/commands/init.md
@@ -305,16 +305,30 @@ jq '.graphs["'"$kg_name"'"].migration_in_progress = true' \
 mv ~/.claude/kg-config.json.tmp ~/.claude/kg-config.json
 
 # c. Move ONLY known KMGraph subdirs (never the entire docs/)
-for subdir in lessons-learned decisions sessions chat-history; do
+for subdir in lessons-learned decisions sessions chat-history tmp; do
+  if [ -L "docs/$subdir" ]; then
+    echo "⚠️  docs/$subdir is a symlink — skipping automatic move. Move manually if needed."
+    continue
+  fi
   [ -d "docs/$subdir" ] && mv "docs/$subdir" "knowledge/$subdir"
 done
 
-# Special case: docs/knowledge/ would create knowledge/knowledge/ nesting — rename instead
+# Special case: docs/knowledge/ would create knowledge/knowledge/ nesting — merge or rename
 if [ -d "docs/knowledge" ]; then
-  echo "⚠️  docs/knowledge/ detected. Moving to knowledge/concepts/ to avoid nesting."
-  echo "   If you prefer a different name, rename knowledge/concepts/ manually."
-  mv "docs/knowledge" "knowledge/concepts"
+  if [ -d "knowledge/concepts" ]; then
+    echo "⚠️  docs/knowledge/ detected but knowledge/concepts/ already exists — merging."
+    rsync -a --ignore-existing "docs/knowledge/" "knowledge/concepts/" && rm -rf "docs/knowledge"
+  else
+    echo "⚠️  docs/knowledge/ detected. Moving to knowledge/concepts/ to avoid nesting."
+    echo "   If you prefer a different name, rename knowledge/concepts/ manually."
+    mv "docs/knowledge" "knowledge/concepts"
+  fi
 fi
+
+# Move root-level scaffold files if present
+for f in me.md rules.md index.md; do
+  [ -f "docs/$f" ] && mv "docs/$f" "knowledge/$f"
+done
 
 # d. Update kg-config.json path
 PROJECT_ROOT=$(pwd)
@@ -362,7 +376,7 @@ mv ~/.claude/kg-config.json.tmp ~/.claude/kg-config.json
 echo "✅ Graph moved to knowledge/. Config updated. Run /kmgraph:status to verify."
 ```
 
-**Safety constraint:** Only named KMGraph subdirectories (`lessons-learned/`, `decisions/`, `sessions/`, `chat-history/`) are moved. Never touch other `docs/` contents.
+**Safety constraint:** Only named KMGraph subdirectories (`lessons-learned/`, `decisions/`, `sessions/`, `chat-history/`, `tmp/`) and root scaffold files (`me.md`, `rules.md`, `index.md`) are moved. Never touch other `docs/` contents. Symlinked subdirs are skipped with a warning.
 
 #### 1f. FTS5 index check
 


### PR DESCRIPTION
## Summary
- Hardens migration move loop against tmp files, symlinks, merge conflicts, scaffold files
- Adds portable sed helper and documents personal KG exclusion
- Expands cross-reference rewrite to all platform files with active MEMORY.md scan
- Tightens gitignore patterns and sibling config update during migration
- Implements rollback logic for interrupted migrations

## Merge order
Step 3 of 5 — merge after v0.3.1, before v0.3.3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)