### PR TITLE
v0.3.7.2: upgrade-inspector fixes — triggers path, platform detection, scaffold filter, doc updates

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "kmgraph",
-  "version": "0.3.7-beta",
+  "version": "0.3.7.2-beta",
   "description": "Structured knowledge capture, lesson-learned documentation, and cross-session memory for Claude Code projects. Includes KG entries, ADRs, meta-issue tracking, chat extraction, and MEMORY.md bidirectional sync.",
   "author": {
     "name": "technomensch",

--- a/commands/init-shared/upgrade-inspector.md
+++ b/commands/init-shared/upgrade-inspector.md
@@ -518,6 +518,12 @@ To migrate manually: move files from docs/{decisions,lessons-learned,...}/ to kn
 
 Before prompting, read every available source to build recommendations:
 
+**MANDATORY: Check for each platform file at `{PROJECT_ROOT}` and log its presence before extracting anything.** Print a "Sources found" line before the dry run:
+```
+Sources found: CLAUDE.md ✓  GEMINI.md ✓  .cursorrules –  AGENTS.md –  README.md ✓  package.json ✓  (+ 3 ADRs, 12 lessons, 2 sessions)
+```
+Do not skip this line. If a platform file exists but was not checked, that is a bug.
+
 | Source | What to extract |
 |--------|----------------|
 | `CLAUDE.md` (project + global) | Platform preferences, always/never rules, tool directives, workflow constraints |
@@ -532,8 +538,15 @@ Before prompting, read every available source to build recommendations:
 | KG decisions (`decisions/`) | ADRs with architectural rules |
 | KG sessions | Working style, communication patterns |
 | Existing partial `me.md` / `rules.md` | Preserve any content already filled in |
+| `rules.md` (just seeded, if applicable) | Derive trigger phase mappings for `triggers.md` |
 
 For each source found, note: filename → extracted content → which target file it informs (`me.md`, `rules.md`, or `triggers.md`).
+
+**For `triggers.md` specifically:** map each section heading in `rules.md` to a trigger phase. Example mapping:
+- `§ Plan Protocol` → "After writing an implementation plan — Apply: rules.md § Plan Protocol"
+- `§ Git Workflow` → "Before committing — Apply: rules.md § Git Workflow"
+- `§ Knowledge Capture` → "When making an architecture decision — Apply: rules.md § Knowledge Capture > When to Capture"
+- Any enforcement/guardrail section → add as a project-specific trigger with the section name
 
 ---
 
@@ -568,21 +581,41 @@ rules.md  ({KG_PATH}/rules.md)
   └─────────────────────────────────────────────────────────────────────┘
 
 triggers.md  ({KG_PATH}/triggers.md)
-  Sources: template defaults + [any phase-based lessons found]
+  Sources: rules.md sections + template defaults + [any phase-based lessons found]
   ┌─────────────────────────────────────────────────────────────────────┐
-  │ [pre-populated trigger entries]                                     │
+  │ [trigger entries derived from rules.md section headings,           │
+  │  each citing its rules.md source — not generic template defaults]   │
   │  ...                                                                │
   └─────────────────────────────────────────────────────────────────────┘
 
-── Platform files that would be updated ───────────────────────────────────
+── Platform files found ────────────────────────────────────────────────────
 
-CLAUDE.md  (rules moving to rules.md would be removed from here)
+**MANDATORY — do not skip this section.** For every platform file that exists at {PROJECT_ROOT},
+show it here with its proposed update. If no platform files exist, print:
+  (no platform config files found at {PROJECT_ROOT})
+
+For each platform file found, show:
+  1. What cross-reference comment would be added (always): `# See also: knowledge/rules.md`
+  2. Any content that overlaps with the newly created rules.md (user must explicitly approve removal)
+
+Format per file:
+
+CLAUDE.md  ✓ found at {PROJECT_ROOT}/CLAUDE.md
   ┌─────────────────────────────────────────────────────────────────────┐
-  │ [updated CLAUDE.md with cross-reference to rules.md added,         │
-  │  any duplicated content removed]                                    │
+  │ [proposed addition near top of file:]                               │
+  │ # See also: knowledge/rules.md — project conventions live there     │
+  │                                                                     │
+  │ [overlapping content detected (if any):]                            │
+  │   Line 14-18: "Never start implementation without Proceed"          │
+  │   → Already captured in rules.md § Git Workflow — remove? [y/n]    │
   └─────────────────────────────────────────────────────────────────────┘
 
-[repeat for GEMINI.md, .cursorrules, etc. if any content would move]
+GEMINI.md  ✓ found at {PROJECT_ROOT}/GEMINI.md
+  ┌─────────────────────────────────────────────────────────────────────┐
+  │ [same format]                                                       │
+  └─────────────────────────────────────────────────────────────────────┘
+
+[repeat for .cursorrules, AGENTS.md, .github/copilot-instructions.md if found]
 
 ── Nothing has been written. These are recommendations only. ──────────────
 All content can be edited before applying, and changed again at any time

--- a/commands/init-shared/upgrade-inspector.md
+++ b/commands/init-shared/upgrade-inspector.md
@@ -119,13 +119,23 @@ for tdir in knowledge lessons-learned decisions sessions; do
 done
 ```
 
-If nothing is upgradeable, say:
+**IMPORTANT — Filter before presenting:** Before displaying the upgrades list or the "nothing to upgrade" message, remove any item from `upgrades[]` whose basename matches any of the following scaffold-only filenames:
+
+- `kg-index.md`
+- `me.md`
+- `rules.md`
+- `triggers.md`
+- `index-personal.md`
+
+These files are handled exclusively by section h with an interactive backfill flow. They must **never** appear as "New template:" or "Updated template:" items in the menu, regardless of what the detection loop added. Remove them now, before any further processing.
+
+If nothing is upgradeable after filtering, say:
 ```
 ✅ Your setup is already up to date. Nothing to apply.
 ```
 And exit.
 
-If upgrades exist, present them:
+If upgrades exist after filtering, present them:
 ```
 Here's what's available for your install:
   • [item 1]

--- a/commands/init-shared/upgrade-inspector.md
+++ b/commands/init-shared/upgrade-inspector.md
@@ -39,7 +39,7 @@ fi
 # Missing root-level scaffold files
 [ ! -f "{KG_PATH}/me.md" ]                    && upgrades+=("New: me.md — your identity and working style in this project")
 [ ! -f "{KG_PATH}/rules.md" ]                 && upgrades+=("New: rules.md — project conventions and behavioral rules")
-[ ! -f "{KG_PATH}/knowledge/triggers.md" ]    && upgrades+=("New: triggers.md — when to apply rules from rules.md")
+[ ! -f "{KG_PATH}/triggers.md" ]              && upgrades+=("New: triggers.md — when to apply rules from rules.md")
 
 # rules.md platform-split check (v0.3.5 — ADR-032)
 # Content fingerprint only: Claude-specific tool names present in rules.md
@@ -537,9 +537,9 @@ For each source found, note: filename → extracted content → which target fil
 
 ---
 
-**Step 2 — Present dry run**
+**Step 2 — Present dry run (MANDATORY — do not skip or abbreviate)**
 
-Display a full preview before writing anything. Format:
+**STOP. Do not write any files yet.** Display the full preview first. The user must see and approve the proposed content before anything is written. Format:
 
 ```
 ── Dry run: here's what would be created ──────────────────────────────────
@@ -567,7 +567,7 @@ rules.md  ({KG_PATH}/rules.md)
   │  ...                                                                │
   └─────────────────────────────────────────────────────────────────────┘
 
-triggers.md  ({KG_PATH}/knowledge/triggers.md)
+triggers.md  ({KG_PATH}/triggers.md)
   Sources: template defaults + [any phase-based lessons found]
   ┌─────────────────────────────────────────────────────────────────────┐
   │ [pre-populated trigger entries]                                     │

--- a/commands/init-shared/upgrade-inspector.md
+++ b/commands/init-shared/upgrade-inspector.md
@@ -30,9 +30,10 @@ for dir in knowledge lessons-learned decisions sessions chat-history tmp; do
 done
 
 # Index reorganization — knowledge/index.md renamed to kg-category-index.md; new root kg-index.md created
+# Note: kg-index.md and index.md are treated as equivalent root nav files — if either exists, skip.
 if [ -f "{KG_PATH}/knowledge/index.md" ] && [ ! -f "{KG_PATH}/knowledge/kg-category-index.md" ]; then
   upgrades+=("Index update: renames {KG_PATH}/knowledge/index.md to kg-category-index.md and adds a new kg-index.md at the knowledge graph root as the primary entry point")
-elif [ ! -f "{KG_PATH}/index.md" ]; then
+elif [ ! -f "{KG_PATH}/index.md" ] && [ ! -f "{KG_PATH}/kg-index.md" ]; then
   upgrades+=("New: kg-index.md — the primary entry point for this knowledge graph")
 fi
 
@@ -94,15 +95,19 @@ WIKI_DONE=$(jq -r '.graphs["{kg_name}"].wiki_pass_complete // false' ~/.claude/k
   upgrades+=("Wiki pass available: convert bare ADR-NNN, ENH-NNN, #NNN, and lesson filename references to [[wiki links]] across knowledge files")
 
 # New templates (files in plugin core/templates not yet in KG)
-# Skip templates that are already covered by the scaffold file checks above:
-#   kg-index.md deploys as {KG_PATH}/index.md — already checked
-#   me.md and rules.md deploy to {KG_PATH} root — already checked
+# IMPORTANT: The following filenames must NEVER be added to upgrades[] by this loop,
+# regardless of whether they exist at the template destination path.
+# They are handled by dedicated scaffold checks above (section h) with interactive flows.
+# Do not add them as "New template:" items under any circumstances:
+#   kg-index.md  — covered by index check above (deploys as index.md or kg-index.md)
+#   me.md        — covered by section h (interactive backfill)
+#   rules.md     — covered by section h (interactive backfill)
+#   triggers.md  — covered by section h (interactive backfill, deploys to KG root)
+#   index-personal.md — personal KG only, handled separately
 scaffold_covered=("kg-index.md" "me.md" "rules.md" "index-personal.md" "triggers.md")
 for tdir in knowledge lessons-learned decisions sessions; do
   for template in "${CLAUDE_PLUGIN_ROOT}/core/templates/$tdir/"*; do
     tname=$(basename "$template")
-    # Skip if this template is covered by a scaffold check
-    # triggers.md is handled by section h (interactive flow) — not a silent copy
     skip=false
     for covered in "${scaffold_covered[@]}"; do
       [ "$tname" = "$covered" ] && skip=true && break

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -76,7 +76,7 @@ The installer sets up:
 
 - **Configuration file** — `~/.claude/kg-config.json` (stores knowledge graph locations and metadata)
 - **Directory structure** — `knowledge/`, `lessons-learned/`, `decisions/`, `sessions/`, `chat-history/`
-- **Identity files** — `knowledge/me.md` (contributor identity, gitignored) and `knowledge/rules.md` (project conventions, committed). See [Portable AI Identity](guides/me-and-rules.md).
+- **Identity files** — `knowledge/me.md` (contributor identity, gitignored), `knowledge/rules.md` (project conventions, committed), and `knowledge/triggers.md` (rule timing, when each rule applies). See [Portable AI Identity](guides/me-and-rules.md).
 - **Wiki links** — Cross-references throughout the KG are converted to Obsidian `[[wiki link]]` format, enabling graph view navigation in Obsidian and compatible editors
 - **MCP server** — Provides knowledge graph tools for non-Claude-Code platforms
 - **Templates** — Starter scaffolds for capturing lessons and decisions
@@ -94,6 +94,9 @@ When running `/kmgraph:init` on an existing installation, the wizard inspects yo
 | **c. Templates** | Template files that have been updated or added since your install |
 | **d. Platform split** | Claude-specific tool directives in `knowledge/rules.md` that belong in `CLAUDE.md` |
 | **e. Wiki pass** | Bare `ADR-NNN`, `ENH-NNN`, `#NNN`, and lesson filename references not yet converted to `[[wiki links]]` — runs once per KG, skipped on re-run if already complete |
+| **f. Docs migration** | `docs/enhancements/` or `docs/issues/` subdirectories that should be moved into the knowledge graph structure |
+| **g. FTS5 cleanup** | Stale in-project FTS5 index files (`knowledge/fts5/`) left behind by older versions |
+| **h. Identity scaffold** | Missing `me.md`, `rules.md`, or `triggers.md` — presents a dry-run preview, scans existing platform files (CLAUDE.md, GEMINI.md, .cursorrules, etc.), README, ADRs, and sessions to pre-populate recommendations, then archives any originals before writing |
 
 :::note Re-running the wizard
 `/kmgraph:init` is safe to re-run at any time. It skips steps already complete and only offers items still pending for your install.

--- a/docs/guides/me-and-rules.md
+++ b/docs/guides/me-and-rules.md
@@ -59,12 +59,13 @@ flowchart TB
     accDescr: All platform config files (CLAUDE.md, .cursorrules, GEMINI.md, copilot-instructions) point to two foundation files in knowledge/ — rules.md and me.md. Project scope overrides personal scope defaults in ~/.kmgraph/.
 ```
 
-KMGraph implements this pattern directly. Two files, scaffolded automatically during `kmgraph init`:
+KMGraph implements this pattern directly. Three files, scaffolded automatically during `kmgraph init`:
 
 | File | Purpose | Committed? |
 |---|---|---|
 | `knowledge/rules.md` | Project conventions shared by all contributors — branch naming, commit format, workflow rules | Yes |
 | `knowledge/me.md` | Who *you* are in this project — working style, domain expertise, communication preferences | No — gitignored |
+| `knowledge/triggers.md` | When to apply rules — maps workflow phases (planning, committing, architecture decisions) to the relevant `rules.md` sections | Yes |
 
 Your platform files (`CLAUDE.md`, `.cursorrules`, etc.) become one-line shims:
 
@@ -85,8 +86,10 @@ The same pattern extends to a personal scope — rules and identity that apply a
 |---|---|---|
 | Project | `knowledge/rules.md` | Project-specific conventions — committed, shared by all contributors |
 | Project | `knowledge/me.md` | Your identity in this project — gitignored, per-contributor |
+| Project | `knowledge/triggers.md` | When to apply rules — workflow phase → rules.md section mappings — committed |
 | Personal | `~/.kmgraph/rules.md` | Cross-project behavioral rules (e.g., "always use feature flags") |
 | Personal | `~/.kmgraph/me.md` | Your identity across all projects — style, expertise, preferences |
+| Personal | `~/.kmgraph/triggers.md` | Cross-project trigger timing — personal phases extend (never replace) project entries |
 
 **Precedence:** project-scoped files override personal files when they conflict. Personal files supply defaults.
 
@@ -138,15 +141,51 @@ Two contributors on the same project have different `me.md` files. Committing on
 
 ---
 
+## `knowledge/triggers.md` — When Rules Apply
+
+`triggers.md` is the third identity file. It maps workflow phases to the rules in `rules.md` — telling the AI assistant *when* to apply each rule, not just *what* the rules say.
+
+```markdown
+# Triggers — When to Apply Rules
+
+## After writing an implementation plan
+
+- Apply: `rules.md § Plan Protocol > Parallelism Analysis`
+- If plan includes changes to `commands/` or `core/templates/`:
+  apply `rules.md § Development Workflow > Plugin Cache & Local Testing`
+  (add cache sync + reload as the final implementation step)
+
+## Before committing
+
+- Apply: `rules.md § Knowledge Capture > Plan-First Rule`
+- Apply: `rules.md § Knowledge Capture > Branch-Close Rule`
+
+## When making an architecture decision
+
+- Apply: `rules.md § Knowledge Capture > When to Capture` (ADR trigger condition)
+
+## At session end
+
+- Apply: `rules.md § Knowledge Capture > Cadence & Routing` (run sync-all)
+```
+
+`triggers.md` is committed — it documents project workflow phases shared by all contributors. The AI reads it alongside `rules.md` at every phase transition to ensure the right rules are applied at the right time. All AI platforms read this file; there is no platform-specific version.
+
+During init, `triggers.md` is pre-populated by mapping the section headings in `rules.md` to trigger phases. The dry-run preview shows the derived entries so the user can confirm, edit, or skip each one.
+
+---
+
 ## Setting Up
 
-Run `kmgraph init` in any project. The wizard:
+Run `kmgraph init` in any project. When `me.md`, `rules.md`, or `triggers.md` are missing, the wizard:
 
-1. Creates `knowledge/rules.md` with the Why/Source template populated with examples
-2. Creates `knowledge/me.md` with the identity sections scaffolded
-3. Offers to populate both files from your existing `CLAUDE.md` via a section-mapping step
+1. **Scans existing sources** — reads all platform files found at the project root (`CLAUDE.md`, `GEMINI.md`, `.cursorrules`, `AGENTS.md`, etc.), plus `README`, ADRs, lessons, and sessions to extract recommendations
+2. **Presents a dry-run preview** — shows proposed content for each missing file, pre-populated from the scan, before anything is written
+3. **Archives originals** — any existing file that would be overwritten is archived to `.kg-archive-{date}/` with a note showing the archive path so it can be rolled back
+4. **Waits for approval** — the user confirms, edits, or skips each file individually before it is written
+5. **Updates platform files** — shows which cross-reference comments would be added to each platform file and flags any content that overlaps with `rules.md` for optional removal (with user approval)
 
-For the personal scope, run `/kmgraph:init-personal-kg`. It creates `~/.kmgraph/me.md` and `~/.kmgraph/rules.md` and offers to populate them from `~/.claude/CLAUDE.md`.
+For the personal scope, run `/kmgraph:init-personal-kg`. It creates `~/.kmgraph/me.md`, `~/.kmgraph/rules.md`, and `~/.kmgraph/triggers.md` and offers to populate them from `~/.claude/CLAUDE.md`.
 
 ---
 
@@ -185,10 +224,12 @@ CLAUDE.md           ← rules + identity + Claude-specific syntax, 150 lines
 ```
 knowledge/rules.md          ← single authoritative rules source (committed)
 knowledge/me.md             ← contributor identity in this project (gitignored)
+knowledge/triggers.md       ← when to apply rules — workflow phase mappings (committed)
 ~/.kmgraph/rules.md         ← cross-project personal rules (local only)
 ~/.kmgraph/me.md            ← cross-project personal identity (local only)
-CLAUDE.md                   ← shim: "read knowledge/rules.md and knowledge/me.md"
-.cursorrules                ← shim: "read knowledge/rules.md and knowledge/me.md"
+~/.kmgraph/triggers.md      ← cross-project trigger timing (local only)
+CLAUDE.md                   ← shim: "read knowledge/rules.md, me.md, and triggers.md"
+.cursorrules                ← shim: "read knowledge/rules.md, me.md, and triggers.md"
 ```
 
 One rule update. Four platforms served.

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@knowledge-graph-plugin/mcp-server",
-  "version": "0.3.7-beta",
+  "version": "0.3.7.2-beta",
   "description": "MCP server for Knowledge Management Graph — cross-platform data layer for knowledge capture, search, and management",
   "main": "dist/index.js",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "knowledge-graph-plugin",
-  "version": "0.3.7-beta",
+  "version": "0.3.7.2-beta",
   "description": "Structured knowledge capture and cross-session memory for Claude Code projects.",
   "files": [
     ".claude-plugin/",


### PR DESCRIPTION
## Summary

- fix: triggers.md deploy path — was writing to `{KG_PATH}/knowledge/triggers.md`, now correctly writes to `{KG_PATH}/triggers.md`
- fix: mandatory platform file detection in section h dry-run — CLAUDE.md, GEMINI.md, .cursorrules, AGENTS.md etc. are now always listed with proposed cross-reference updates
- fix: kg-index.md / index.md equivalence — detection now checks both filenames
- fix: scaffold_covered prose filter gate — explicit prose instruction before menu presentation prevents scaffold-only files (me.md, rules.md, triggers.md, kg-index.md, index-personal.md) from appearing as "New template:" items
- fix: triggers.md source extraction from rules.md — section h Step 1 scan includes rules.md; Step 2 dry-run shows derived trigger entries with their rules.md source section
- docs: update INSTALL.md — add triggers.md to identity files; add checks f (docs migration), g (FTS5 cleanup), h (identity scaffold) to Upgrade Checks table
- docs: update me-and-rules.md — add triggers.md as the third identity file, new § triggers.md section, updated Setting Up section for v0.3.7.2 dry-run/archive/backfill flow
- chore: bump version to 0.3.7.2-beta

## Test plan

- [ ] `/kmgraph:init` on a KG missing triggers.md: file created at `{KG_PATH}/triggers.md` (not in `knowledge/` subdir)
- [ ] Section h dry-run shows "Platform files found" and proposed cross-reference additions
- [ ] triggers.md does not appear as a "New template:" item in the upgrade menu
- [ ] me.md / rules.md do not appear as "New template:" items after filtering

🤖 Generated with [Claude Code](https://claude.com/claude-code)