### PR TITLE
fix(init): v0.4.2-beta — seed triggers.md during init and personal KG creation

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "kmgraph",
-  "version": "0.4.1-beta",
+  "version": "0.4.2-beta",
   "description": "Structured knowledge capture, lesson-learned documentation, and cross-session memory for Claude Code projects. Includes KG entries, ADRs, meta-issue tracking, chat extraction, and MEMORY.md bidirectional sync.",
   "author": {
     "name": "technomensch",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Released]
 
+## v0.4.2-beta (2026-04-18)
+
+### Fixed
+
+- **`triggers.md` missing from project KG scaffold** — `template-seed` seeded `rules.md` but omitted `triggers.md`. Fresh project KG inits now receive both files.
+- **`triggers.md` wrong path in personal KG creation** — `init.md` Step 1.8.5 targeted `{KG_PATH}/triggers.md` (copy-paste error) instead of `~/.kmgraph/triggers.md`. Personal KG creation now correctly seeds the user-level triggers file. Existing KGs missing `triggers.md` can recover by running `/kmgraph:init`.
+
 ## v0.4.1-beta (2026-04-16)
 
 ### Security

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -231,6 +231,7 @@ done
 | **v0.3.5–v0.3.9** | No upgrade items expected for a clean install in this range. |
 | **v0.4.0** | Check c offers an updated meta-issue attempt template (adds hypothesis, distinct-from-prior, success-criterion, and exit-path fields). New `stuck-work-escalation` and `docs-impact-scan` skills are auto-available after plugin reload — no upgrade action required. |
 | **v0.4.1** | Security patch — no upgrade action required. Dependency overrides (`hono >=4.12.12`, `follow-redirects >=1.16.0`) are applied automatically on install. |
+| **v0.4.2** | Bug fix — `triggers.md` now seeded during init. Run `/kmgraph:init` to add `triggers.md` to any KG initialized before this version. |
 
 After the wizard completes, your existing lessons, ADRs, sessions, and chat history are untouched.
 

--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 Structured knowledge capture, lesson-learned documentation, and cross-session memory for Claude Code projects.
 
-**Version:** 0.4.1-beta
-**Status:** Beta Release — Security patch: dependency vulnerability gate, hono + follow-redirects overrides
+**Version:** 0.4.2-beta
+**Status:** Beta Release — Bug fix: triggers.md now seeded during both project and personal KG init
 
 Documentation: https://kmgraph.stayinginsync.info
 
@@ -84,6 +84,10 @@ See [Getting Started Guide](docs/GETTING-STARTED.md) for prerequisites and troub
 ---
 
 ## v0.4.x Feature Highlights
+
+**v0.4.2-beta — 2026-04-18**
+
+- **`triggers.md` seeded during init** — Fixed two bugs where `triggers.md` (the platform-agnostic rule-timing companion to `rules.md`) was never created during fresh init. `template-seed` now includes it in the root scaffold copy block; personal KG creation now seeds `~/.kmgraph/triggers.md` from the template (previously targeted wrong path `{KG_PATH}/triggers.md`).
 
 **v0.4.1-beta — 2026-04-16**
 
@@ -180,7 +184,8 @@ knowledge-graph/
 
 See [ROADMAP.md](ROADMAP.md) for detailed version history and development progress.
 
-**Current Release:** v0.4.1-beta (2026-04-16)
+**Current Release:** v0.4.2-beta (2026-04-18)
+- ✅ triggers.md seeded during init — fixed missing scaffold in project KG and wrong-path bug in personal KG creation
 - ✅ Dependency vulnerability gate — pre-PR Dependabot check with findings table and approval gate
 - ✅ hono override >=4.12.12 + follow-redirects override >=1.16.0 — security patches
 - ✅ Stuck-work escalation — Opus diagnosis gate at 3 attempts, mandatory exit-path decision at 5
@@ -199,6 +204,7 @@ See [ROADMAP.md](ROADMAP.md) for detailed version history and development progre
 - ⚠️ Beta status: API subject to breaking changes before v1.0.0 stable
 
 **Recent Versions:**
+- v0.4.2-beta (Apr 18): Bug fix — triggers.md seeded during both project and personal KG init
 - v0.4.1-beta (Apr 16): Security patch — vulnerability gate, hono + follow-redirects dependency overrides
 - v0.4.0-beta (Apr 16): Stuck-work escalation skill, docs-impact-scan skill, --log-attempt meta-issue variant
 - v0.3.4-beta (Apr 10): Behavioral rule live-capture, rules-capture skill + agent, 4-target routing
@@ -298,7 +304,7 @@ MIT License - See [LICENSE](LICENSE)
 ---
 
 **Created:** 2026-02-12
-**Current Phase:** Beta Release Cycle (v0.4.1-beta)
+**Current Phase:** Beta Release Cycle (v0.4.2-beta)
 **Next Milestone:** v0.4.x — Expanded wiki link coverage and automated knowledge graph extraction improvements
 
 📚 **Full documentation:** https://kmgraph.stayinginsync.info

--- a/commands/init-shared/template-seed.md
+++ b/commands/init-shared/template-seed.md
@@ -27,6 +27,8 @@ cp "{CLAUDE_PLUGIN_ROOT}/core/templates/knowledge/kg-category-index.md" "{KG_PAT
 # Copy root-level files (skip if already exists to preserve teammate copies)
 [ -f "{KG_PATH}/rules.md" ] && echo "rules.md already exists — skipping scaffold (teammate copy preserved)." || \
   cp "{CLAUDE_PLUGIN_ROOT}/core/templates/knowledge/rules.md" "{KG_PATH}/rules.md"
+[ -f "{KG_PATH}/triggers.md" ] && echo "triggers.md already exists — skipping scaffold." || \
+  cp "{CLAUDE_PLUGIN_ROOT}/core/templates/knowledge/triggers.md" "{KG_PATH}/triggers.md"
 [ -f "{KG_PATH}/index.md" ] && echo "index.md already exists — skipping scaffold." || \
   cp "{CLAUDE_PLUGIN_ROOT}/core/templates/knowledge/kg-index.md" "{KG_PATH}/index.md"
 # me.md is always gitignored — safe to scaffold fresh

--- a/commands/init.md
+++ b/commands/init.md
@@ -1269,24 +1269,8 @@ Examples of personal lessons:
    cp "${CLAUDE_PLUGIN_ROOT}/core/templates/knowledge/me.md" "$HOME/.kmgraph/me.md"
    [ -f "$HOME/.kmgraph/rules.md" ] && echo "rules.md already exists — skipping scaffold." || \
      cp "${CLAUDE_PLUGIN_ROOT}/core/templates/knowledge/rules.md" "$HOME/.kmgraph/rules.md"
-   # triggers.md — optional, project-specific trigger extensions only
-   # Most projects do not need this file. Create it only if you have project-specific
-   # rules that should fire at different phases than your user-level triggers.
-   # If created, entries extend (never replace) ~/.kmgraph/triggers.md.
-   if [ ! -f "{KG_PATH}/triggers.md" ]; then
-     cat > "{KG_PATH}/triggers.md" << 'EOF'
-# Triggers — Project-Level Extensions (Optional)
-#
-# This file extends ~/.kmgraph/triggers.md. Entries here are additive.
-# User-level triggers always apply. Only add entries for project-specific overrides.
-#
-# Example — narrow a user trigger:
-# ## After writing an implementation plan
-# - Apply: rules.md § Plan Protocol > Parallelism Analysis
-#   Condition: skip if plan has fewer than 3 tasks (this project always has short plans)
-EOF
-     echo "ℹ️  triggers.md stub created at {KG_PATH}/triggers.md (optional — see file for usage)"
-   fi
+   [ -f "$HOME/.kmgraph/triggers.md" ] && echo "triggers.md already exists — skipping scaffold." || \
+     cp "${CLAUDE_PLUGIN_ROOT}/core/templates/knowledge/triggers.md" "$HOME/.kmgraph/triggers.md"
    [ -f "$HOME/.kmgraph/kg-index-global.md" ] && echo "kg-index-global.md already exists — skipping scaffold." || \
      cp "${CLAUDE_PLUGIN_ROOT}/core/templates/knowledge/kg-index-global.md" "$HOME/.kmgraph/kg-index-global.md"
    ```

--- a/knowledge/lessons-learned/README.md
+++ b/knowledge/lessons-learned/README.md
@@ -4,8 +4,8 @@
 
 Comprehensive catalog of all lessons-learned documents.
 
-**Total Lessons:** 5
-**Last Updated:** 2026-04-12
+**Total Lessons:** 6
+**Last Updated:** 2026-04-17
 
 ---
 
@@ -19,9 +19,10 @@ Comprehensive catalog of all lessons-learned documents.
 
 ---
 
-### Process Lessons (1 total)
+### Process Lessons (2 total)
 
 - [Upgrade Path Missing FTS5 Stale File Cleanup](process/Lessons_Learned_Upgrade_Path_Missing_FTS5_Stale_File_Cleanup.md) — Migration moved the FTS5 DB out of the project but left no cleanup step; stale 41MB artifacts caused a V8 crash in Obsidian; add teardown + gitignore to every artifact migration
+- [Batch Worker Model Selection And Token Tracking](process/Lessons_Learned_Batch_Worker_Model_Selection_And_Token_Tracking.md) — Use Sonnet (not Haiku) for job evaluation batch workers; always pass `--output-format json` to `claude -p` to capture token usage in log files
 
 **Tags:** #process
 
@@ -48,6 +49,7 @@ Comprehensive catalog of all lessons-learned documents.
 ## Chronological Index
 
 **2026**
+- [2026-04-17] - [Batch Worker Model Selection And Token Tracking](process/Lessons_Learned_Batch_Worker_Model_Selection_And_Token_Tracking.md) - Use Sonnet not Haiku for batch job evaluation; add --output-format json to claude -p for token usage capture
 - [2026-04-12] - [Upgrade Path Missing FTS5 Stale File Cleanup](process/Lessons_Learned_Upgrade_Path_Missing_FTS5_Stale_File_Cleanup.md) - Migration left stale in-project .fts5.db files (41MB); no cleanup step in upgrader caused V8 crash in Obsidian
 - [2026-04-09] - [KMGraph Fingerprint Detection Before Migration](patterns/Lessons_Learned_KMGraph_Fingerprint_Detection_Before_Migration.md) - Fingerprint detection pattern for migration triggers using KMGraph-specific subdirectories
 - [2026-04-09] - [Template Source Files Should Encode Role, Not Deployed Output Name](patterns/Lessons_Learned_Template_Source_Naming_Role_Not_Output.md) - Role-based source naming for core/templates/ prevents silent overwrite collisions
@@ -60,8 +62,9 @@ Comprehensive catalog of all lessons-learned documents.
 
 **#architecture** (0 lessons)
 
-**#process** (1 lesson)
+**#process** (2 lessons)
 - [Upgrade Path Missing FTS5 Stale File Cleanup](process/Lessons_Learned_Upgrade_Path_Missing_FTS5_Stale_File_Cleanup.md) — #fts5 #upgrade #migration #cleanup #stale-files #installer #obsidian #v8-crash #gitignore
+- [Batch Worker Model Selection And Token Tracking](process/Lessons_Learned_Batch_Worker_Model_Selection_And_Token_Tracking.md) — #batch #claude-cli #model-selection #token-tracking #career-ops
 
 **#patterns** (3 lessons)
 - [KMGraph Fingerprint Detection Before Migration](patterns/Lessons_Learned_KMGraph_Fingerprint_Detection_Before_Migration.md) — #fingerprint #migration #detection #init #false-positive

--- a/knowledge/lessons-learned/process/Lessons_Learned_Batch_Worker_Model_Selection_And_Token_Tracking.md
+++ b/knowledge/lessons-learned/process/Lessons_Learned_Batch_Worker_Model_Selection_And_Token_Tracking.md
@@ -1,0 +1,49 @@
+---
+title: "Lesson: Use Sonnet (Not Haiku) for Batch Job Evaluation Workers — And Capture Token Usage via --output-format json"
+date: 2026-04-17
+type: lesson
+category: process
+tags: [batch, claude-cli, model-selection, token-tracking, career-ops]
+version: 1.0
+---
+
+# Lesson: Use Sonnet for Batch Job Evaluation Workers + Token Tracking via JSON Output
+
+## Problem
+
+When running career-ops batch evaluations, Haiku was briefly used for `claude -p` workers to save cost/time. It was reverted. Separately, token usage was never appearing in worker logs because `--output-format json` was not set.
+
+## Root Cause
+
+Haiku lacks the reasoning depth needed for nuanced job fit evaluation — it misses subtle signals in JDs, produces weaker red flag analysis, and gives less reliable comp research. Most batch offers are SKIP'd anyway, but the ones that score high drive real apply decisions, so evaluation accuracy is worth the Sonnet cost.
+
+`claude -p` defaults to text output. Without `--output-format json`, token counts (`input_tokens`, `output_tokens`, `cache_read_input_tokens`) never appear in log files, making usage reporting impossible after the fact.
+
+## Solution
+
+Keep the default Sonnet model for all batch workers. Add `--output-format json` to the `claude -p` invocation in `batch-runner.sh` — this captures full token usage in each worker log file at no extra token cost.
+
+```bash
+# batch-runner.sh — worker invocation
+claude -p \
+  --dangerously-skip-permissions \
+  --output-format json \
+  --append-system-prompt-file "$resolved_prompt" \
+  "$prompt"
+```
+
+Parse token usage after the run:
+```bash
+grep -h "input_tokens" batch/logs/3*.log | jq -s '[.[].usage] | {input: map(.input_tokens) | add, output: map(.output_tokens) | add, cache_read: map(.cache_read_input_tokens) | add}'
+```
+
+## How to Apply
+
+Any time `batch-runner.sh` is modified or a new batch system is built:
+1. Default to Sonnet — do not switch to Haiku for evaluation tasks
+2. Always include `--output-format json` on the `claude -p` call
+3. Token usage will be available in every log file under the `usage` JSON key
+
+## Context
+
+Discovered during a 137-offer batch run on 2026-04-17. Hiring.cafe URLs were also blocked by Cloudflare in this run — marked as `skipped_stale` with error `cloudflare-blocked`.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "knowledge-graph-plugin",
-  "version": "0.4.1-beta",
+  "version": "0.4.2-beta",
   "description": "Structured knowledge capture and cross-session memory for Claude Code projects.",
   "files": [
     ".claude-plugin/",


### PR DESCRIPTION
## Summary

- **Fixed missing `triggers.md` in project KG scaffold** — `template-seed` seeded `rules.md` but omitted `triggers.md`; fresh project inits now receive both files
- **Fixed wrong path for personal KG `triggers.md`** — `init.md` Step 1.8.5 targeted `{KG_PATH}/triggers.md` (copy-paste error) instead of `~/.kmgraph/triggers.md`
- Version bumped to 0.4.2-beta; README, INSTALL, and CHANGELOG updated

## Test plan

- [ ] Run `/kmgraph:init` on a blank project — verify `knowledge/triggers.md` is created
- [ ] Run `/kmgraph:init` and accept personal KG offer — verify `~/.kmgraph/triggers.md` is created
- [ ] Existing KG with missing `triggers.md` — re-run `/kmgraph:init`, verify it seeds the file

🤖 Generated with [Claude Code](https://claude.com/claude-code)