### PR TITLE
feat(phase2): tier abstraction — rename, me.md schema, dispatchers, local model support

### DIFF
--- a/agents/create-adr-agent.md
+++ b/agents/create-adr-agent.md
@@ -1,7 +1,6 @@
 ---
 name: create-adr-agent
 description: Creates Architecture Decision Records — interactive wizard with auto-numbered files, git metadata, template population, and index updates. Uses kg_capture MCP tool for platform-agnostic writes.
-model: sonnet
 ---
 
 # Create ADR Agent

--- a/agents/knowledge-reviewer.md
+++ b/agents/knowledge-reviewer.md
@@ -1,7 +1,6 @@
 ---
 name: knowledge-reviewer
 description: Reviews knowledge graph entries for quality, completeness, and proper bidirectional linking. Use when creating or updating KG entries to ensure they meet quality standards.
-model: sonnet
 color: cyan
 ---
 

--- a/agents/lesson-capture-agent.md
+++ b/agents/lesson-capture-agent.md
@@ -1,7 +1,6 @@
 ---
 name: lesson-capture-agent
 description: Captures a single lesson learned from the current session — problem, solution, context, and git metadata. Uses kg_capture MCP tool for platform-agnostic writes.
-model: sonnet
 ---
 
 # Lesson Capture Agent

--- a/agents/mcp-setup-agent.md
+++ b/agents/mcp-setup-agent.md
@@ -1,7 +1,6 @@
 ---
 name: mcp-setup-agent
 description: Detects IDE environment and auto-configures MCP server registration when kg_* tools fail. Enables knowledge graph operations across platforms without manual setup.
-model: opus
 ---
 
 # MCP Setup Agent

--- a/agents/platform-sync-agent.md
+++ b/agents/platform-sync-agent.md
@@ -1,7 +1,6 @@
 ---
 name: platform-sync-agent
 description: Syncs relevant portions of platform config files (CLAUDE.md, GEMINI.md, .cursorrules, etc.) when one is updated. Understands which content belongs in each platform's file — not a full copy, but a targeted sync of applicable sections.
-model: sonnet
 ---
 
 # Platform Sync Agent

--- a/agents/recall-agent.md
+++ b/agents/recall-agent.md
@@ -1,7 +1,6 @@
 ---
 name: recall-agent
 description: Searches the knowledge graph and memory systems for relevant lessons, decisions, and patterns. Use when the user asks about past work, previous decisions, or familiar problems.
-model: haiku
 ---
 
 # Recall Agent

--- a/agents/session-summary-agent.md
+++ b/agents/session-summary-agent.md
@@ -1,7 +1,6 @@
 ---
 name: session-summary-agent
 description: Creates a lightweight summary of the current session — what was built, decided, and learned. Checks for open plans, draft ADRs, and uncaptured lessons before saving. Uses kg_capture for platform-agnostic writes.
-model: sonnet
 ---
 
 # Session Summary Agent

--- a/agents/sync-all-agent.md
+++ b/agents/sync-all-agent.md
@@ -1,7 +1,6 @@
 ---
 name: sync-all-agent
 description: Executes the full knowledge sync pipeline — scans lessons, extracts KG entries, links to plans/issues, drafts GitHub comments, and refreshes search index. Called by the sync-all thin dispatcher.
-model: sonnet
 ---
 
 # Sync All Agent

--- a/commands/capture-lesson.md
+++ b/commands/capture-lesson.md
@@ -125,6 +125,10 @@ Once you have the user's answers, say:
 
 > "Looks like you just solved something worth keeping — let me capture that."
 
+#### Tier resolution
+
+Default tier: `standard-tier`. Read `me.md` YAML frontmatter (user profile first, project profile as override). Identify active platform; look up `tier_map[standard-tier]`. Apply collapse chain on failure (`powerful-tier → standard-tier → fast-tier`). Pass resolved model name as `--model [resolved]` to the subagent. If all tiers fail: halt with "No model available. Run /kmgraph:init to configure tier mappings."
+
 Then invoke `lesson-capture-agent`, passing the following pre-structured context:
 
 - **Problem statement** — from Step 1, question 1

--- a/commands/create-adr.md
+++ b/commands/create-adr.md
@@ -37,6 +37,10 @@ Before any other steps, detect the level signal from the user's invocation and r
 
 Pass the resolved flag (`--user`, `--project`, `--named=<kg>`, or `--active`) to the `create-adr-agent` invocation.
 
+#### Tier resolution
+
+Default tier: `standard-tier`. Read `me.md` YAML frontmatter (user profile first, project profile as override). Identify active platform; look up `tier_map[standard-tier]`. Apply collapse chain on failure (`powerful-tier → standard-tier → fast-tier`). Pass resolved model name as `--model [resolved]` to the subagent. If all tiers fail: halt with "No model available. Run /kmgraph:init to configure tier mappings."
+
 ---
 
 ## Step 0: Resolve Active KG Path

--- a/commands/init-personal-kg.md
+++ b/commands/init-personal-kg.md
@@ -137,6 +137,39 @@ After `template-seed.md` completes, also scaffold `triggers.md` if it does not a
 echo "✅ triggers.md scaffolded at {KG_PATH}/triggers.md"
 ```
 
+#### § Tier mapping setup
+
+After scaffolding `me.md`, prompt the user to configure tier mappings:
+
+```
+Your me.md has been created at {KG_PATH}/me.md. Let's configure which models to use for each task tier.
+
+Which platforms are you using? (select all that apply)
+  1. Claude (claude.ai / Claude Code)
+  2. Gemini (Gemini CLI / AI Studio)
+  3. Ollama (local, port 11434)
+  4. LM Studio (local, port 1234)
+  5. Skip — I'll configure this manually later
+```
+
+**For each selected cloud platform (1 or 2):** Pre-fill the default tier_map from the template — no prompts needed.
+
+**For Ollama (option 3):**
+1. Ask for host (default: `localhost`) and port (default: `11434`)
+2. Attempt discovery: `curl -s http://{host}:{port}/api/tags` (2s timeout)
+   - If success: display model list (paginated, 10 per page); ask user to assign one per tier
+   - If failure: print warning, offer manual entry
+3. Write the completed platform entry to `me.md` YAML frontmatter
+
+**For LM Studio (option 4):**
+1. Ask for host (default: `localhost`) and port (default: `1234`)
+2. Attempt discovery: `curl -s http://{host}:{port}/v1/models` (2s timeout)
+   - If success: display model list (paginated, 10 per page); ask user to assign one per tier
+   - If failure: print warning, offer manual entry
+3. Write the completed platform entry to `me.md` YAML frontmatter
+
+**Headless mode** (`CLAUDE_CODE_HEADLESS=1`): Skip all prompts. Write empty tier_map stubs. Log: `"Headless mode — tier mapping skipped. Edit {KG_PATH}/me.md YAML frontmatter to configure."`
+
 ---
 
 ### Step 5: Register in config

--- a/commands/init-shared/upgrade-inspector.md
+++ b/commands/init-shared/upgrade-inspector.md
@@ -839,6 +839,19 @@ Options:
 
 **If option (a):** delegate to the section d auto-relocate flow (read `commands/init-shared/knowledge-file-migrator.md`), passing the full section content as `{CONTAMINATION}`.
 
+After the platform section is relocated, offer the tier mapping walkthrough inline:
+
+```
+Your rules.md platform section has been moved to CLAUDE.md.
+
+Would you like to configure tier mappings in me.md now?
+  1. Yes — run tier mapping setup
+  2. Skip — I'll edit me.md manually later
+```
+
+**If option 1:** Run the tier mapping walkthrough exactly as specified in `commands/init.md § Tier mapping setup`. Target file: `{KG_PATH}/me.md` (or `~/.kmgraph/me.md` if personal KG). After completion, `me.md` will have a populated `platforms[]` block with `profile_schema: 1`.
+
 **Safety rules:**
 - Section d and k do not double-run: if section d already relocated the content in this session, the `$SCHEMA_VERSION` gate prevents section k from re-offering.
 - Archive is always taken before any write.
+- Tier mapping walkthrough is offered only after successful relocation — not independently by this section.

--- a/commands/init-shared/upgrade-inspector.md
+++ b/commands/init-shared/upgrade-inspector.md
@@ -764,6 +764,8 @@ echo "✅ Content template migration complete"
 
 **Purpose:** Detect `rules.md` files missing the `<!-- kmgraph-defaults -->` ... `<!-- /kmgraph-defaults -->` block (introduced in v0.5.0) and offer to prepend it.
 
+**Schema version gate:** If `$SCHEMA_VERSION -ge 2` (computed in section i), skip section j silently.
+
 **Detection:**
 
 ```bash

--- a/commands/init.md
+++ b/commands/init.md
@@ -1268,6 +1268,7 @@ Examples of personal lessons:
    cp "${CLAUDE_PLUGIN_ROOT}/core/templates/knowledge/kg-category-index.md" "$HOME/.kmgraph/knowledge/kg-category-index-global.md" 2>/dev/null || true
    # Root-level files — me.md, rules.md, kg-index-global.md → KG root (from user profile starters)
    cp "${CLAUDE_PLUGIN_ROOT}/core/templates/knowledge/templates/user/me.md" "$HOME/.kmgraph/me.md"
+   # Tier mapping setup — run immediately after me.md is seeded (see § Tier mapping setup below)
    [ -f "$HOME/.kmgraph/rules.md" ] && echo "rules.md already exists — skipping scaffold." || \
      cp "${CLAUDE_PLUGIN_ROOT}/core/templates/knowledge/templates/user/rules.md" "$HOME/.kmgraph/rules.md"
    [ -f "$HOME/.kmgraph/triggers.md" ] && echo "triggers.md already exists — skipping scaffold." || \
@@ -1275,6 +1276,39 @@ Examples of personal lessons:
    [ -f "$HOME/.kmgraph/kg-index-global.md" ] && echo "kg-index-global.md already exists — skipping scaffold." || \
      cp "${CLAUDE_PLUGIN_ROOT}/core/templates/knowledge/kg-index-global.md" "$HOME/.kmgraph/kg-index-global.md"
    ```
+
+#### § Tier mapping setup
+
+After seeding `me.md`, prompt the user to configure tier mappings:
+
+```
+Your me.md has been created at ~/.kmgraph/me.md. Let's configure which models to use for each task tier.
+
+Which platforms are you using? (select all that apply)
+  1. Claude (claude.ai / Claude Code)
+  2. Gemini (Gemini CLI / AI Studio)
+  3. Ollama (local, port 11434)
+  4. LM Studio (local, port 1234)
+  5. Skip — I'll configure this manually later
+```
+
+**For each selected cloud platform (1 or 2):** Pre-fill the default tier_map from the template — no prompts needed.
+
+**For Ollama (option 3):**
+1. Ask for host (default: `localhost`) and port (default: `11434`)
+2. Attempt discovery: `curl -s http://{host}:{port}/api/tags` (2s timeout)
+   - If success: display model list (paginated, 10 per page); ask user to assign one per tier
+   - If failure: print warning, offer manual entry
+3. Write the completed platform entry to `me.md` YAML frontmatter
+
+**For LM Studio (option 4):**
+1. Ask for host (default: `localhost`) and port (default: `1234`)
+2. Attempt discovery: `curl -s http://{host}:{port}/v1/models` (2s timeout)
+   - If success: display model list (paginated, 10 per page); ask user to assign one per tier
+   - If failure: print warning, offer manual entry
+3. Write the completed platform entry to `me.md` YAML frontmatter
+
+**Headless mode** (`CLAUDE_CODE_HEADLESS=1`): Skip all prompts. Write empty tier_map stubs. Log: `"Headless mode — tier mapping skipped. Edit ~/.kmgraph/me.md YAML frontmatter to configure."`
 
 4. Register in `~/.claude/kg-config.json`:
    ```json

--- a/commands/meta-issue.md
+++ b/commands/meta-issue.md
@@ -51,9 +51,9 @@ Create a meta-issue when a problem meets **2 or more** of these criteria:
 
 The meta-issue command is also invoked automatically by the `stuck-work-escalation` skill. When escalation triggers:
 
-- **At 3 attempts (or 30 min):** Meta-issue is created automatically. Opus reviews all logged attempts and provides fresh diagnosis. All future attempts must be logged here with a hypothesis before starting.
+- **At 3 attempts (or 30 min):** Meta-issue is created automatically. powerful-tier reviews all logged attempts and provides fresh diagnosis. All future attempts must be logged here with a hypothesis before starting.
 - **At 5 attempts:** Exit-path analysis is mandatory. The attempt template's exit-path section must be completed and presented to the user before any further work proceeds.
-- **Escalation cap:** Opus reviews a maximum of 3 rounds before forcing the exit-path decision regardless of attempt count.
+- **Escalation cap:** powerful-tier reviews a maximum of 3 rounds before forcing the exit-path decision regardless of attempt count.
 - **Counter reset:** If diagnosis genuinely shifts (new root cause identified), attempt counter resets — note the reset in `analysis/root-cause-evolution.md`.
 - **Scope:** Only applies to work with a definable success criterion (test passes, error gone, metric hit). Not exploratory or iterative work.
 
@@ -372,7 +372,7 @@ Bidirectional documentation
 
 **With stuck-work-escalation skill:**
 Auto-invoked at 3 attempts. Supplies attempt log and root-cause evolution
-to Opus for diagnosis. Receives exit-path decision at 5 attempts.
+to powerful-tier for diagnosis. Receives exit-path decision at 5 attempts.
 
 ---
 

--- a/commands/session-summary.md
+++ b/commands/session-summary.md
@@ -63,7 +63,7 @@ The resolved flag (`--user`, `--project`, `--named=<kg>`, or `--active`) is then
 
 ## Tier Resolution
 
-Default path: `standard-tier`. `--delegate` path (session-documenter): `powerful-tier`. Read `me.md` YAML frontmatter (user profile first, project profile as override). Identify active platform; look up `tier_map[required-tier]`. Apply collapse chain on failure (`powerful-tier → standard-tier → fast-tier`). Pass resolved model name as `--model [resolved]` to the subagent. If all tiers fail: halt with "No model available. Run /kmgraph:init to configure tier mappings."
+Default path: `standard-tier`. `--delegate` path (session-documenter): `powerful-tier`. Read `me.md` YAML frontmatter (user profile first, project profile as override). Identify active platform; look up `tier_map[standard-tier]` (default path) or `tier_map[powerful-tier]` (`--delegate` path). Apply collapse chain on failure (`powerful-tier → standard-tier → fast-tier`). Pass resolved model name as `--model [resolved]` to the subagent. If all tiers fail: halt with "No model available. Run /kmgraph:init to configure tier mappings."
 
 ## Dispatch
 

--- a/commands/session-summary.md
+++ b/commands/session-summary.md
@@ -61,6 +61,10 @@ The resolved flag (`--user`, `--project`, `--named=<kg>`, or `--active`) is then
 
 ---
 
+## Tier Resolution
+
+Default path: `standard-tier`. `--delegate` path (session-documenter): `powerful-tier`. Read `me.md` YAML frontmatter (user profile first, project profile as override). Identify active platform; look up `tier_map[required-tier]`. Apply collapse chain on failure (`powerful-tier → standard-tier → fast-tier`). Pass resolved model name as `--model [resolved]` to the subagent. If all tiers fail: halt with "No model available. Run /kmgraph:init to configure tier mappings."
+
 ## Dispatch
 
 Evaluate the flags provided:

--- a/commands/sync-all.md
+++ b/commands/sync-all.md
@@ -73,6 +73,10 @@ Detect which flags the user passed:
 
 ### Step 2: Delegate to sync-all-agent
 
+#### Tier resolution
+
+Default tier: `standard-tier`. Read `me.md` YAML frontmatter (user profile first, project profile as override). Identify active platform; look up `tier_map[standard-tier]`. Apply collapse chain on failure (`powerful-tier → standard-tier → fast-tier`). Pass resolved model name as `--model [resolved]` to the subagent. If all tiers fail: halt with "No model available. Run /kmgraph:init to configure tier mappings."
+
 Spawn the `sync-all-agent` subagent with parsed flags:
 
 ```

--- a/core/templates/AGENTS-template.md
+++ b/core/templates/AGENTS-template.md
@@ -10,7 +10,7 @@ Template for creating new KMGraph agents. Copy this file and fill in each sectio
 ---
 name: {agent-name}
 description: {One-line description of what this agent does}
-model: {opus | sonnet | haiku}
+model: {powerful-tier | standard-tier | fast-tier}
 ---
 ```
 

--- a/core/templates/knowledge/rules.md
+++ b/core/templates/knowledge/rules.md
@@ -98,8 +98,8 @@ Analyze task dependencies and output a concrete execution mode recommendation. P
 
 | Task | Mode | Model | Notes |
 |------|------|-------|-------|
-| Task 1: [name] | Subagent | Sonnet | |
-| Task 2: [name] | Inline | Haiku | Simple mechanical step |
+| Task 1: [name] | Subagent | standard-tier | |
+| Task 2: [name] | Inline | fast-tier | Simple mechanical step |
 
 Follow the table with one line: **Overall strategy:** [why this mix was chosen]
 
@@ -108,11 +108,11 @@ Follow the table with one line: **Overall strategy:** [why this mix was chosen]
 - Self-contained, reversible tasks → Subagent candidates
 - Final integration, commit, and verification steps → Inline
 
-**Model heuristics (for the Model column):**
-- **Haiku** — mechanical/structured: scaffolding, boilerplate, templates, search/lookup, simple CRUD, KG write ops (ADRs, lessons, session summaries)
-- **Sonnet** — judgment-required: non-trivial logic, code review, analysis, refactoring, debugging, pattern matching, integration tasks
-- **Opus** — high-context/architectural: tasks that depend on output from multiple prior tasks, novel architectural decisions, conflict resolution across complex subsystems
-- **Default:** Sonnet for implementation tasks; Opus only when synthesizing large prior context or making novel architectural decisions
+**Tier heuristics (for the Model column — resolved via `me.md` `tier_map` at invocation time, per ADR-041):**
+- **fast-tier** — mechanical/structured: scaffolding, boilerplate, templates, search/lookup, simple CRUD, KG write ops (ADRs, lessons, session summaries)
+- **standard-tier** — judgment-required: non-trivial logic, code review, analysis, refactoring, debugging, pattern matching, integration tasks
+- **powerful-tier** — high-context/architectural: tasks that depend on output from multiple prior tasks, novel architectural decisions, conflict resolution across complex subsystems
+- **Default:** standard-tier for implementation tasks; powerful-tier only when synthesizing large prior context or making novel architectural decisions
 
 ### Capture Checkpoints
 

--- a/core/templates/knowledge/templates/user/me.md
+++ b/core/templates/knowledge/templates/user/me.md
@@ -3,15 +3,15 @@ profile_schema: 1
 platforms:
   - name: claude
     tier_map:
-      fast-tier: ""
-      standard-tier: ""
-      powerful-tier: ""
+      fast-tier: claude-haiku-4-5-20251001
+      standard-tier: claude-sonnet-4-6
+      powerful-tier: claude-opus-4-7
   # Uncomment and fill in if using Gemini:
   # - name: gemini
   #   tier_map:
-  #     fast-tier: ""
-  #     standard-tier: ""
-  #     powerful-tier: ""
+  #     fast-tier: gemini-flash
+  #     standard-tier: gemini-pro
+  #     powerful-tier: gemini-ultra
   # Uncomment and fill in if using Ollama:
   # - name: ollama
   #   host: localhost

--- a/knowledge/decisions/ADR-034-capture-level-routing-dispatcher-agent-split.md
+++ b/knowledge/decisions/ADR-034-capture-level-routing-dispatcher-agent-split.md
@@ -109,3 +109,16 @@ The conflict case (e.g., "save to user level for the knowledge-graph project") i
 **Exception:** Skills with `required_tier: <label>` in their frontmatter override this — the subagent re-resolves that tier independently against `me.md`. Primary use case: `stuck-work-escalation` declares `required_tier: powerful-tier` and halts (does not collapse) if powerful-tier is unavailable.
 
 **Rule location:** `~/.kmgraph/rules.md § Profile > Subagent Tier Inheritance`
+
+### 2026-04-21 — Dispatcher Tier Resolution Is Authoritative; Agent Frontmatter Must Not Override (v0.5.1-beta Phase 2 remediation)
+
+**Rule:** Agent frontmatter (`agents/*.md`) MUST NOT specify a `model:` field. The dispatcher owns invocation policy (see Decision above); an agent `model:` field overrides the resolved `--model [resolved]` flag silently, bypassing the entire tier resolution chain established in ADR-041.
+
+**Correct pattern:**
+- Dispatcher: reads `me.md`, resolves tier label → concrete model name, passes `--model [resolved]` to subagent
+- Agent: receives `--model [resolved]`, uses it; no `model:` in frontmatter
+
+**Incorrect pattern (eliminated in v0.5.1-beta):**
+- Agent frontmatter: `model: sonnet` — hardcodes a platform-specific model name, ignores dispatcher resolution
+
+**Scope:** Applied to all 8 agents in `agents/*.md`. The `model:` field was removed from all agent frontmatter as part of Phase 2 remediation. See also ADR-041 Amendment (2026-04-21).

--- a/knowledge/decisions/ADR-041-tier-abstraction-label-system.md
+++ b/knowledge/decisions/ADR-041-tier-abstraction-label-system.md
@@ -67,6 +67,7 @@ During Phase 2 rollout, the resolver accepts legacy model names as aliases and e
 | Opus, claude-opus-* | `powerful-tier` |
 | Gemini Flash, flash-* | `fast-tier` |
 | Gemini Pro, pro-* | `standard-tier` |
+| Gemini Ultra, Ultra, ultra-* | `powerful-tier` |
 
 ### me.md YAML Frontmatter Schema
 
@@ -124,7 +125,19 @@ Tier labels are platform-neutral vocabulary that any LLM ecosystem supports. Map
 
 ## Amendments
 
-*(none at time of writing)*
+### 2026-04-21 — Agent Frontmatter Must Not Specify `model:` (Phase 2 remediation)
+
+**Rule:** Agent frontmatter (agents/*.md) MUST NOT include a `model:` field. Hardcoding a platform-specific model name in frontmatter overrides any `--model [resolved]` flag passed by a dispatcher, making the entire tier resolution pipeline inert.
+
+**Correct pattern:** Omit `model:` from agent frontmatter entirely. Claude Code's default behavior when `model:` is absent is to inherit from the caller — exactly what tier resolution requires.
+
+**Rationale:** The entire premise of ADR-041 is that tier→model mapping is user-owned data in `me.md`, resolved at invocation time by the dispatcher. Frontmatter `model:` hardcodes a platform-specific model name into the agent file — the exact anti-pattern this ADR eliminates. ADR-034 establishes that dispatchers own invocation policy; frontmatter `model:` inverts that ownership.
+
+**Applied to:** All 8 agents in `agents/*.md` — `model:` field removed in v0.5.1-beta Phase 2 remediation commit.
+
+### 2026-04-21 — Gemini Ultra alias added to backwards compatibility alias map (N2 fix)
+
+**Change:** Added `Gemini Ultra, Ultra, ultra-*` → `powerful-tier` row to the alias map. The original alias table included Flash and Pro but omitted Ultra, creating an inconsistency with the tier table's Gemini column (which lists Ultra for `powerful-tier`).
 
 ---
 

--- a/knowledge/rules.md
+++ b/knowledge/rules.md
@@ -176,17 +176,17 @@ Do not use numbered headings in knowledge files — use plain headings (e.g., `#
 
 | Task Category | Model | Rationale |
 |---------------|-------|-----------|
-| **Write/Capture** | Haiku | Structured data entry with templates (ADRs, lessons, sessions, comments) — 3–5x faster, ~10% token cost |
-| **Search/Recall** | Haiku | Index lookup, pointer generation — no synthesis required |
-| **Review/Validation** | Sonnet | Quality assessment (ADR review, lesson duplication detection, pattern matching) |
-| **Complex Judgment** | Sonnet/Opus | Architectural design, conflict resolution, novel pattern discovery |
+| **Write/Capture** | fast-tier | Structured data entry with templates (ADRs, lessons, sessions, comments) — 3–5x faster, ~10% token cost |
+| **Search/Recall** | fast-tier | Index lookup, pointer generation — no synthesis required |
+| **Review/Validation** | standard-tier | Quality assessment (ADR review, lesson duplication detection, pattern matching) |
+| **Complex Judgment** | standard-tier/powerful-tier | Architectural design, conflict resolution, novel pattern discovery |
 
 **Implementation:**
-- Skills (`create-adr`, `capture-lesson`, etc.) default to Haiku for write/capture operations
+- Skills (`create-adr`, `capture-lesson`, etc.) default to fast-tier for write/capture operations
 - Agents use `gov-capture-routing` skill to resolve task type and route accordingly
-- Borderline tasks → route to Sonnet when unsure (safer than under-provisioning)
+- Borderline tasks → route to standard-tier when unsure (safer than under-provisioning)
 
-**Why:** Haiku is fully capable for template-based operations. Using Sonnet for form-filling wastes resources. A session with 5 ADRs + 3 lessons saves ~60% vs. Sonnet-all-the-way.
+**Why:** fast-tier is fully capable for template-based operations. Using standard-tier for form-filling wastes resources. A session with 5 ADRs + 3 lessons saves ~60% vs. standard-tier-all-the-way.
 
 **Source:** [[ADR-038-model-selection-rule-for-kg-tasks]]
 

--- a/skills/stuck-work-escalation/SKILL.md
+++ b/skills/stuck-work-escalation/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: stuck-work-escalation
-description: Use when a bug, failing test, blocked plan task, integration failure, or reproducibility issue has resisted 3+ distinct fix attempts or 30+ minutes of effort. Activates Opus diagnosis, enforces hypothesis logging, and drives to a structured exit-path decision.
+description: Use when a bug, failing test, blocked plan task, integration failure, or reproducibility issue has resisted 3+ distinct fix attempts or 30+ minutes of effort. Activates powerful-tier diagnosis, enforces hypothesis logging, and drives to a structured exit-path decision.
+required_tier: powerful-tier
 ---
 
 Before starting, read `~/.kmgraph/rules.md` — Plan Protocol § Stuck-Work Escalation for thresholds, scope rules, and exit paths.
@@ -19,23 +20,25 @@ Does **not** apply to exploratory or iterative work (prompt tuning, CSS iteratio
 
 ## Workflow
 
-### At 3 Attempts (or 30 min) — Opus Gate
+### At 3 Attempts (or 30 min) — powerful-tier Gate
+
+> **Tier note:** This skill declares `required_tier: powerful-tier`. It does not collapse to a lower tier — if powerful-tier is unavailable, the skill halts with an explicit error rather than running on a lower-capability model.
 
 1. **Create meta-issue** (if not already open):
    `/kmgraph:meta-issue "[Problem Title]"`
 
 2. **Compile attempt log** — read all prior attempts from meta-issue or conversation. For each attempt, confirm a distinct hypothesis was tested (not a retry of the same fix).
 
-3. **Opus diagnosis** — provide Opus with:
+3. **powerful-tier diagnosis** — provide powerful-tier with:
    - Problem statement and success criterion
    - All attempts with hypotheses and results
    - Current `root-cause-evolution.md` if meta-issue exists
-   Opus reviews and provides fresh diagnosis and next hypothesis.
+   powerful-tier reviews and provides fresh diagnosis and next hypothesis.
 
-4. **Log next attempt** with Opus-recommended hypothesis:
-   `/kmgraph:meta-issue --log-attempt NNN "[Opus hypothesis]"`
+4. **Log next attempt** with powerful-tier-recommended hypothesis:
+   `/kmgraph:meta-issue --log-attempt NNN "[hypothesis]"`
 
-5. **Opus involvement continues** — Opus reviews each subsequent attempt result before the next attempt begins. Maximum 3 Opus rounds before forcing exit-path analysis (step below).
+5. **powerful-tier involvement continues** — powerful-tier reviews each subsequent attempt result before the next attempt begins. Maximum 3 powerful-tier rounds before forcing exit-path analysis (step below).
 
 ### At 5 Attempts — Exit-Path Analysis
 
@@ -52,7 +55,7 @@ Present the following to the user and require a decision:
 
 Then select a mandatory exit path:
 
-- **Continue** — only if Opus identifies a genuinely new hypothesis not yet tried
+- **Continue** — only if powerful-tier identifies a genuinely new hypothesis not yet tried
 - **Defer** — file KG issue, document blocker, move on
 - **Workaround** — ship degraded version with limitation documented
 - **Descope** — remove requirement; surface to user for confirmation


### PR DESCRIPTION
## Summary

- Tier label rename: Haiku/Sonnet/Opus → fast/standard/powerful-tier across all rules, skills, commands
- me.md YAML frontmatter schema v1 (profile_schema: 1) — default tier_map pre-filled for Claude and Gemini
- Init walkthrough: tier mapping step with Ollama and LM Studio discovery
- Dispatchers (capture-lesson, create-adr, session-summary, sync-all): tier resolution block with collapse chain and model flag passing
- stuck-work-escalation: `required_tier: powerful-tier` declared, Opus references replaced
- Unknown-model trigger already present in both profile templates (Phase 1)
- upgrade-inspector section k: offers inline tier mapping walkthrough after platform relocation
- ~/.kmgraph/rules.md: § Profile > Adding a model section added (not in repo)

## Validation

- [x] grep for Haiku/Sonnet/Opus returns clean (no directive-context hits)
- [x] profile_schema: 1 present in user/me.md template
- [x] Tier resolution block in all four dispatchers
- [x] required_tier: powerful-tier in stuck-work-escalation SKILL.md
- [x] upgrade-inspector section k references tier mapping walkthrough

## Sunset note

Alias map (Haiku→fast-tier etc.) sunsets in v0.6.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)