### PR TITLE
v0.5.3: extract-chat auto-split, update-doc Tier 1 fix, KG-mismatch guardrails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Released]
 
+## v0.5.3 (2026-04-23)
+
+### Added
+
+- **`extract-chat` large-day auto-split** — Days with exports exceeding 900 KB or 30,000 lines are automatically split into `YYYY-MM-DD/` subfolders (e.g., `chat-history/2026-04-23/part-1.md`). Prevents Obsidian from refusing to open oversized daily files. Part boundaries respect message boundaries.
+- **`update-profile` skill** — New auto-triggered skill for guided updates to user profile files (`me.md`) (ADR-045).
+- **`update-doc` Tier 1 continuation prompt (Step 7b)** — After completing a `--user-facing` update on any Tier 1 doc, the command now prompts to continue with remaining Tier 1 files, preventing README.md and CHANGELOG.md from being skipped when individual files are targeted.
+
+### Fixed
+
+- **`create-adr` and `capture-lesson` KG-mismatch guardrails** — Both commands now detect and block writes when the active KG does not match the current working directory.
+
+### Changed
+
+- **`knowledge/rules.md` doc-sync gate** — Added rule requiring `/kmgraph:update-doc --user-facing` before push or merge when user-facing docs have changed.
+
+---
+
 ## v0.5.2-beta (2026-04-21)
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Structured knowledge capture, lesson-learned documentation, and cross-session memory for Claude Code projects.
 
-**Version:** 0.5.2
+**Version:** 0.5.3
 **Status:** Actively developed and in daily use
 
 Documentation: https://kmgraph.stayinginsync.info
@@ -89,7 +89,14 @@ Pull the latest version and run `/kmgraph:init` in any project that uses it. The
 
 ## v0.5.x Feature Highlights
 
-**v0.5.x — 2026-04-21**
+**v0.5.3 — 2026-04-23**
+
+- **`extract-chat` now handles large export days automatically** — Prior to this update, lengthy chat-history files were causing Obsidian indexing to crash the vault.  After this update, exports exceeding 900 KB or 30,000 lines are split into `YYYY-MM-DD/`files. Boundaries respect message boundaries so no message is split mid-content.
+- **`update-doc` no longer silently skips README and CHANGELOG** — After updating any Tier 1 doc with `--user-facing`, the command now prompts to continue with remaining Tier 1 files in order. Previously, targeting a specific file bypassed the full release sweep entirely.
+- **KG-mismatch guardrails added to `create-adr` and `capture-lesson`** — Both commands now block writes when the active knowledge graph does not match the current working directory, preventing accidental cross-project entries.
+- **New `update-profile` skill** — Auto-triggered when updating user profile files (`me.md`), guiding the update through a structured prompt flow (ADR-045).
+
+**v0.5.2 — 2026-04-21**
 
 - **Model configuration is now future-proof** — Instead of hardcoding specific model names in `me.md`, commands and agents now reference tier labels (`fast-tier`, `standard-tier`, `powerful-tier`). When a model gets updated or renamed, only one place needs to change. Getting started is straightforward: run `/kmgraph:init` and the wizard walks through tier mapping interactively, discovers any locally running Ollama or LM Studio instances automatically, and pre-populates `~/.kmgraph/me.md` with working defaults so no manual edits are needed. Upgrading works the same way — the upgrade wizard offers the same interactive walkthrough after relocating platform config. For full manual control, add a `platforms[]` block directly to `me.md`. Unrecognized model values surface a warning instead of silently failing.
 - **ADRs now record where and when decisions were implemented** — When creating an ADR, the wizard automatically captures the commit and subject line so there is always a traceable link back to the implementation. No more guessing when or where something was decided.
@@ -169,7 +176,7 @@ knowledge-graph/
 
 ## Development Status
 
-**Current Release:** v0.5.2 (2026-04-21)
+**Current Release:** v0.5.3 (2026-04-23)
 
 Actively developed and in daily use. Behavior may evolve between minor versions.
 
@@ -262,6 +269,6 @@ MIT License - See [LICENSE](LICENSE)
 ---
 
 **Created:** 2026-02-12
-**Current Version:** v0.5.2 (2026-04-21)
+**Current Version:** v0.5.3 (2026-04-23)
 
 📚 **Full documentation:** https://kmgraph.stayinginsync.info

--- a/commands/capture-lesson.md
+++ b/commands/capture-lesson.md
@@ -22,6 +22,33 @@ Pass the resolved flag (`--user`, `--project`, `--named=<kg>`, or `--active`) to
 
 ---
 
+## Project KG Guardrail
+
+**STOP before any write if the active KG does not match the current project's KG.**
+
+After routing resolves `$target_kg`, detect the project root and its KG:
+
+```bash
+project_root=$(git rev-parse --show-toplevel 2>/dev/null)
+project_kg="${project_root}/knowledge"
+```
+
+If `$project_kg` **exists** AND its resolved path **differs** from `$target_kg`, and the user did not explicitly pass `--user` or `--named=<kg>`:
+
+> "The active KG is **[active_kg_name]** (`$target_kg`), but this project has its own KG at `{project_kg}/`.
+>
+> Which graph should receive this lesson?
+>
+> **[1]** Project KG — `{project_kg}/lessons-learned/`
+> **[2]** Active KG — `{active_kg_name}` (`$target_kg/lessons-learned/`)
+> **[3]** Cancel"
+
+Wait for user selection. Update `$target_kg` and `$target_path` to the chosen graph before continuing. Do **not** dispatch to `lesson-capture-agent` until the user has chosen.
+
+If `$project_kg` does not exist, or paths match, or user explicitly specified a target, continue without prompting.
+
+---
+
 ## Syntax Detection
 
 **Create new lesson:**

--- a/commands/create-adr.md
+++ b/commands/create-adr.md
@@ -64,6 +64,33 @@ mkdir -p {active_kg_path}/decisions/
 
 ---
 
+## Project KG Guardrail
+
+**STOP before any write if the active KG does not match the current project's KG.**
+
+After resolving `{active_kg_path}`, detect the project root and its KG:
+
+```bash
+project_root=$(git rev-parse --show-toplevel 2>/dev/null)
+project_kg="${project_root}/knowledge"
+```
+
+If `$project_kg` **exists** AND its resolved path **differs** from `{active_kg_path}`:
+
+> "The active KG is **[active_kg_name]** (`{active_kg_path}`), but this project has its own KG at `{project_kg}/`.
+>
+> Which graph should receive this ADR?
+>
+> **[1]** Project KG — `{project_kg}/decisions/`
+> **[2]** Active KG — `{active_kg_name}` (`{active_kg_path}/decisions/`)
+> **[3]** Cancel"
+
+Wait for user selection. Update `{active_kg_path}` to the chosen graph's root before continuing. Do **not** proceed to the Snapshot Gate until the user has chosen.
+
+If `$project_kg` does not exist, or paths match, continue without prompting.
+
+---
+
 ## Snapshot Gate
 
 *Runs before Step 1 — context preservation before the ADR dialog.*

--- a/commands/extract-chat.md
+++ b/commands/extract-chat.md
@@ -195,6 +195,27 @@ python3 ${CLAUDE_PLUGIN_ROOT}/core/scripts/run_extraction.py --source $source_fl
 
 ---
 
+## Large File Splitting
+
+Obsidian crashes on files larger than ~1 MB or ~34,000 lines. When a daily output file exceeds either threshold, it is automatically split into numbered part files inside a `YYYY-MM-DD/` subfolder:
+
+**Normal output (under limit):**
+```
+chat-history/YYYY-MM/YYYY-MM-DD-claude.md
+```
+
+**Split output (over limit):**
+```
+chat-history/YYYY-MM-DD/YYYY-MM-DD-claude-part1.md
+chat-history/YYYY-MM-DD/YYYY-MM-DD-claude-part2.md
+```
+
+Each part file is a valid standalone markdown document with its own header (annotated `— Part N`). Splits occur at message block boundaries so no message is cut mid-block.
+
+Incremental appends automatically target the last part file. If appending causes the last part to exceed the limit, a new part is created.
+
+---
+
 ## Incremental Append Behavior
 
 **Script behavior:**

--- a/commands/update-doc.md
+++ b/commands/update-doc.md
@@ -199,7 +199,7 @@ Fix before proceeding? (yes / skip / cancel)
 
 ## User-Facing Docs — Reference File List
 
-When running a full release docs pass (`--user-facing` with no specific file), work through this list. Tier 1 on every release; Tier 2 when related content changed; Tier 3 periodically.
+When running a full release docs pass (`--user-facing` with no specific file), work through this list immediately. When a specific Tier 1 file is updated, Step 7b prompts to continue with the rest. Tier 1 on every release; Tier 2 when related content changed; Tier 3 periodically.
 
 **Tier 1 — Every release**
 - `README.md`
@@ -520,6 +520,28 @@ Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>"
 ✅ Updated: $TARGET_FILE
    Committed: docs(user-facing): update [filename] — [brief description]
 ```
+
+---
+
+## Step 7b: Tier 1 Continuation Prompt
+
+**Run after Step 7 when `--user-facing` was active and a specific file was provided.**
+
+Check whether `$TARGET_FILE` appears in the Tier 1 list. If it does, prompt:
+
+```
+$TARGET_FILE is a Tier 1 doc. Continue with remaining Tier 1 files?
+
+Remaining:
+[list each Tier 1 file not yet updated this session]
+
+(yes / skip)
+```
+
+- **yes:** Repeat Steps 2–7b for each remaining Tier 1 file in order.
+- **skip:** Exit. Remind the user: "Remaining Tier 1 files were skipped — run `/kmgraph:update-doc --user-facing` with no file to sweep them."
+
+If `$TARGET_FILE` is not in the Tier 1 list, exit normally without this prompt.
 
 ---
 

--- a/core/scripts/chat_extractor_base.py
+++ b/core/scripts/chat_extractor_base.py
@@ -4,6 +4,7 @@ Base utilities for Chat History Extraction
 """
 import os
 import re
+import glob
 from datetime import datetime
 
 # Allow override via environment variable (set by skills) or CLI arg (set by run_extraction.py)
@@ -11,13 +12,29 @@ from datetime import datetime
 OUTPUT_DIR = os.environ.get('KG_OUTPUT_DIR',
                              os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), ""))
 
+# Obsidian crashes above ~1 MB or ~34 K lines; use headroom thresholds
+FILE_SIZE_LIMIT = 900_000   # bytes (~900 KB)
+FILE_LINE_LIMIT = 30_000    # lines
+
 def get_output_path(filename):
     """
     Returns the full path for an output file.
+    0. If a YYYY-MM-DD/ split subfolder exists for this date, returns the last part file.
     1. Checks if file exists in any subdirectory -> returns that path.
     2. If new, parses YYYY-MM derived from filename (expected YYYY-MM-DD...) -> returns path in YYYY-MM subfolder.
     3. Fallback to root if date parsing fails.
     """
+    # 0. Check for an existing split subfolder (highest priority)
+    date_match_top = re.match(r'(\d{4}-\d{2}-\d{2})', filename)
+    if date_match_top:
+        date_str = date_match_top.group(1)
+        split_dir = os.path.join(OUTPUT_DIR, date_str)
+        if os.path.isdir(split_dir):
+            stem = filename[:-3]  # strip .md
+            part_files = sorted(glob.glob(os.path.join(split_dir, f'{stem}-part*.md')))
+            if part_files:
+                return part_files[-1]  # last part for appending
+
     # 1. Search for existing file anywhere in chat-history
     for root, dirs, files in os.walk(OUTPUT_DIR):
         dirs[:] = [d for d in dirs if not d.startswith('.') and d != 'scripts']
@@ -75,6 +92,94 @@ def write_markdown_header(f, source_label, message_count, date_str=None):
     f.write(f"**Export Generated:** {datetime.now().isoformat()}\n\n")
     f.write("---\n\n")
     f.write("## Full Conversation Transcript\n\n")
+
+def split_file_if_oversized(output_path):
+    """
+    Checks output_path against FILE_SIZE_LIMIT and FILE_LINE_LIMIT.
+    If either threshold is exceeded, splits the file at block boundaries
+    (### Message N: or ### Fragment N) into numbered part files inside a
+    YYYY-MM-DD/ subfolder of OUTPUT_DIR. The original file is deleted.
+    Returns a list of created part paths, or [] if no split was needed.
+    """
+    if not os.path.exists(output_path):
+        return []
+
+    with open(output_path, 'r', encoding='utf-8') as f:
+        content = f.read()
+
+    if (len(content.encode('utf-8')) <= FILE_SIZE_LIMIT and
+            content.count('\n') <= FILE_LINE_LIMIT):
+        return []
+
+    # Split at block boundaries, keeping each delimiter attached to its block
+    blocks = re.split(r'(?=### (?:Message|Fragment) \d+)', content)
+    header = blocks[0]
+    item_blocks = blocks[1:]
+
+    if not item_blocks:
+        return []
+
+    filename = os.path.basename(output_path)
+    parent_dir = os.path.dirname(output_path)
+    parent_name = os.path.basename(parent_dir)
+
+    if re.match(r'\d{4}-\d{2}-\d{2}$', parent_name):
+        # Already inside a split subfolder — split from current part number
+        split_dir = parent_dir
+        stem = re.sub(r'-part\d+\.md$', '', filename)
+        part_match = re.search(r'-part(\d+)\.md$', filename)
+        start_part = int(part_match.group(1)) if part_match else 1
+    else:
+        date_m = re.match(r'(\d{4}-\d{2}-\d{2})', filename)
+        date_str = date_m.group(1) if date_m else 'unknown'
+        split_dir = os.path.join(OUTPUT_DIR, date_str)
+        stem = filename[:-3]  # strip .md
+        start_part = 1
+
+    os.makedirs(split_dir, exist_ok=True)
+
+    size_threshold = FILE_SIZE_LIMIT * 0.85
+    line_threshold = FILE_LINE_LIMIT * 0.85
+
+    chunks = []
+    current = []
+    current_size = len(header.encode('utf-8'))
+    current_lines = header.count('\n')
+
+    for block in item_blocks:
+        bsize = len(block.encode('utf-8'))
+        blines = block.count('\n')
+        if current and (current_size + bsize > size_threshold or
+                        current_lines + blines > line_threshold):
+            chunks.append(current)
+            current = []
+            current_size = len(header.encode('utf-8'))
+            current_lines = header.count('\n')
+        current.append(block)
+        current_size += bsize
+        current_lines += blines
+
+    if current:
+        chunks.append(current)
+
+    if len(chunks) <= 1:
+        return []
+
+    created = []
+    for i, chunk in enumerate(chunks, start_part):
+        part_header = re.sub(
+            r'(# Complete Chat Session Export)',
+            f'\\1 — Part {i}',
+            header, count=1
+        )
+        part_path = os.path.join(split_dir, f'{stem}-part{i}.md')
+        with open(part_path, 'w', encoding='utf-8') as f:
+            f.write(part_header + ''.join(chunk))
+        created.append(part_path)
+
+    os.remove(output_path)
+    return created
+
 
 def write_message_block(f, index, role, timestamp, content, thinking=None, tool_calls=None):
     """Writes a single message block to the markdown file."""

--- a/core/scripts/extract_claude.py
+++ b/core/scripts/extract_claude.py
@@ -6,7 +6,7 @@ import glob
 from datetime import datetime
 from typing import List, Dict, Any, Optional
 import re
-from chat_extractor_base import get_output_path, format_timestamp, write_markdown_header, write_message_block
+from chat_extractor_base import get_output_path, format_timestamp, write_markdown_header, write_message_block, split_file_if_oversized
 
 CLAUDE_PROJECTS_DIR = os.path.expanduser("~/.claude/projects")
 
@@ -231,7 +231,11 @@ def extract_claude_sessions(days_back=None, date_filter=None, after_date=None,
                                 msg.get('thinking')
                             )
                             global_msg_index += 1
-                results.append(f"Appended {new_msg_count} new messages to {filename}")
+                split_parts = split_file_if_oversized(output_path)
+                if split_parts:
+                    results.append(f"Appended to {filename} — split into {len(split_parts)} parts in {date}/ subfolder")
+                else:
+                    results.append(f"Appended {new_msg_count} new messages to {filename}")
             else:
                 results.append(f"No new activity for {filename} (last sync: {datetime.utcfromtimestamp(last_ts).strftime('%Y-%m-%dT%H:%M:%SZ')})")
         else:
@@ -272,8 +276,12 @@ def extract_claude_sessions(days_back=None, date_filter=None, after_date=None,
                     if session_index < len(sessions):
                         f.write("\n---\n\n")
 
-            # Accurate output message
-            if file_has_content:
+            # Check size limits and split if needed
+            split_parts = split_file_if_oversized(output_path)
+            if split_parts:
+                action = "Overwrote" if file_has_content else "Created"
+                results.append(f"{action} {filename}: split into {len(split_parts)} parts in {date}/ subfolder{backup_msg}")
+            elif file_has_content:
                 results.append(f"Overwrote {filename} with {total_messages} messages{backup_msg}")
             else:
                 results.append(f"Created {filename} with {total_messages} messages")

--- a/core/scripts/extract_gemini.py
+++ b/core/scripts/extract_gemini.py
@@ -17,7 +17,7 @@ except ImportError:
 # Common English words to filter out binary noise
 COMMON_WORDS = {' the ', ' you ', ' and ', ' that ', ' have ', ' for ', ' not ', ' with ', ' this ', ' from '}
 
-from chat_extractor_base import get_output_path, format_timestamp, write_markdown_header, write_message_block
+from chat_extractor_base import get_output_path, format_timestamp, write_markdown_header, write_message_block, split_file_if_oversized
 
 GEMINI_TMP_DIR = os.path.expanduser("~/.gemini/tmp")
 GEMINI_CONV_DIR = os.path.expanduser("~/.gemini/antigravity/conversations")
@@ -243,7 +243,11 @@ def extract_all_gemini(limit=None, date_filter=None, after_date=None, before_dat
                 
                 if session_index < len(sessions):
                     f.write("\n---\n\n")
-            
+
+        split_parts = split_file_if_oversized(output_path)
+        if split_parts:
+            results.append(f"Merged {len(sessions)} sessions ({total_items} items) into {filename} — split into {len(split_parts)} parts in {date}/ subfolder")
+        else:
             results.append(f"Merged {len(sessions)} sessions ({total_items} items) into {filename}")
             
     return results

--- a/docs/CHEAT-SHEET.md
+++ b/docs/CHEAT-SHEET.md
@@ -62,7 +62,7 @@ Active users use these for regular workflows:
 | `/kmgraph:switch` | Change active knowledge graph |
 | `/kmgraph:check-sensitive` | Scan knowledge graph for potentially sensitive information |
 | `/kmgraph:config-sanitization` | Interactive wizard for pre-commit hook setup |
-| `/kmgraph:extract-chat` | Extract chat history from Claude and Gemini logs (`--today`, `--date`, `--after`, `--before`, `--project`) |
+| `/kmgraph:extract-chat` | Extract chat history from Claude and Gemini logs (`--today`, `--date`, `--after`, `--before`, `--project`); large days auto-split into `YYYY-MM-DD/` subfolder |
 | `/kmgraph:update-doc` | Update plugin/project docs (`--user-facing`) or KG content |
 
 *→ [Full details in Command Guide](COMMAND-GUIDE.md#intermediate-commands)*

--- a/docs/COMMAND-GUIDE.md
+++ b/docs/COMMAND-GUIDE.md
@@ -322,6 +322,7 @@ The `--dry-run` mode shows which files will be modified and what cross-reference
 - Include error messages verbatim
 - Note what DIDN'T work (helps future you)
 - Level routing: use "user level" for cross-project patterns; "for this project" for codebase-specific lessons. See [Personal vs Project KGs](../PERSONAL-V-PROJECT.md) for details.
+- If the active KG differs from the project's own KG, the command stops before writing and asks which graph to use
 
 ---
 
@@ -618,6 +619,7 @@ Dispatches to the recall agent, which searches:
 - Use Proposed status for decisions still under review; Accepted for decisions already implemented
 - Link to related lessons in Step 3.8 — creates bidirectional traceability
 - If a snapshot was taken earlier in the session, the ADR's Context section can draw from it
+- If the active KG differs from the project's own KG, the wizard stops before writing and asks which graph to use
 
 ---
 
@@ -790,7 +792,8 @@ Test the hook:
 1. Determines output directory (active KG's `chat-history/` by default, or custom path)
 2. Scans Claude logs (`~/.claude/projects/` for `.jsonl` files) and/or Gemini logs (`~/.gemini/tmp/`, `~/.gemini/antigravity/conversations/` for `.json`/`.pb` files)
 3. Merges sessions by date into `YYYY-MM-DD-claude.md` and/or `YYYY-MM-DD-gemini.md`
-4. Supports incremental append — re-running adds new sessions without overwriting
+4. If a daily file exceeds 900 KB or 30,000 lines, automatically splits into numbered parts (`-part1.md`, `-part2.md`, …) inside a `YYYY-MM-DD/` subfolder to prevent Obsidian rendering failures
+5. Supports incremental append — re-running adds new sessions without overwriting; appends target the last part file if the day was previously split
 
 **Time**: Under 30 seconds
 
@@ -819,6 +822,7 @@ Test the hook:
 - Optional `blackboxprotobuf` Python library enables Gemini protobuf file support
 - Date ranges use natural language: `YYYY-MM-DD through YYYY-MM-DD` or `YYYY-MM-DD to YYYY-MM-DD`
 - Gemini date filtering: passthrough implemented; underlying Gemini extraction may have known limitations
+- Large days auto-split into a `YYYY-MM-DD/` subfolder with numbered part files; each part is a valid standalone markdown file readable in Obsidian
 
 ---
 

--- a/knowledge/decisions/ADR-044-split-oversized-chat-history-files.md
+++ b/knowledge/decisions/ADR-044-split-oversized-chat-history-files.md
@@ -1,0 +1,156 @@
+---
+title: "ADR-044: Split Oversized Daily Chat History Files for Obsidian Compatibility"
+number: 44
+created: 2026-04-23T00:00:00Z
+status: Accepted
+author: technomensch
+email: 917847+technomensch@users.noreply.github.com
+git:
+  branch: v0.5.3-hotfix-extract-chat-history
+  commit: a0f1625adaaa9c9f9adaaeec70c37282d5abbc28
+  pr: null
+  issue: null
+implements: null
+related:
+  adrs: []
+  lessons: []
+  kg_entries: []
+tags: [chat-history, obsidian, extraction, file-splitting]
+category: architecture
+---
+
+# ADR-044: Split Oversized Daily Chat History Files for Obsidian Compatibility
+
+**Date:** 2026-04-23
+**Status:** Accepted
+**Implements:** v0.5.3-hotfix-extract-chat-history
+
+---
+
+## Context
+
+**Problem:**
+- Obsidian crashes or becomes unresponsive when opening files larger than ~1 MB or ~34,000 lines
+- Heavy workdays can produce a single `YYYY-MM-DD-claude.md` or `YYYY-MM-DD-gemini.md` that exceeds both thresholds
+- When this happens, that day's chat history is inaccessible in Obsidian without manual intervention
+
+**Scope:**
+- In scope: daily output files from `extract_claude.py` and `extract_gemini.py`
+- Out of scope: the knowledge graph index files, lesson files, or ADR files (those are short by design)
+- Constraint: splitting must not break incremental append behavior or the `get_output_path` lookup contract
+
+---
+
+## Decision
+
+When a daily output file exceeds **900 KB** or **30,000 lines**, automatically split it into numbered part files (`-part1.md`, `-part2.md`, …) inside a `YYYY-MM-DD/` subfolder at the root of `chat-history/`. The original file is deleted after parts are written.
+
+### Core Components
+
+1. **Thresholds:** 900 KB / 30,000 lines — headroom below Obsidian's hard limits (1 MB / 34,000) to prevent boundary oscillation
+2. **Split directory:** `chat-history/YYYY-MM-DD/` — visually distinct from the normal `chat-history/YYYY-MM/` monthly folders
+3. **Part naming:** `YYYY-MM-DD-claude-part1.md`, `YYYY-MM-DD-claude-part2.md`, etc.
+4. **Split boundary:** `### Message N:` / `### Fragment N:` block headers — no message is cut mid-content
+5. **`get_output_path` rerouting:** When a `YYYY-MM-DD/` subfolder exists with part files, `get_output_path` returns the last part path transparently — callers need no changes
+
+### Implementation Approach
+
+- `split_file_if_oversized(output_path)` added to `chat_extractor_base.py`
+- Called after every write in `extract_claude.py` (both new-file and incremental-append paths) and `extract_gemini.py`
+- `get_output_path()` updated with a priority-0 check for existing split subfolders
+- Incremental appends target the last part; if the last part grows over the limit after appending, `split_file_if_oversized` creates the next part
+
+---
+
+## Rationale
+
+### Why This Approach
+
+1. **Post-write split:** Writing the full day's content first, then splitting, avoids changing the write logic in both extractors and keeps the split logic in one place (`chat_extractor_base.py`)
+2. **Headroom thresholds:** Using 85% of Obsidian's limits (900 KB, 30 K lines) ensures a file that lands right at the boundary does not oscillate between split and unsplit on consecutive runs
+3. **YYYY-MM-DD subfolder:** Naming the split folder after the date (rather than nesting inside `YYYY-MM/`) makes split days immediately recognizable in the directory tree and avoids ambiguity with the monthly folders
+
+### Alternatives Considered
+
+**Option A: Single flat file with truncation**
+- Pros: Simpler output structure
+- Cons: Silently discards messages; unacceptable for a history tool
+- Rejected
+
+**Option B: Pre-write splitting (accumulate messages into parts before writing)**
+- Pros: Avoids creating an oversized file at all
+- Cons: Requires restructuring both extractor's write loops; significantly more invasive
+- Rejected in favor of post-write split for this hotfix scope
+
+**Option C: YYYY-MM/YYYY-MM-DD/ nested subfolder**
+- Pros: Keeps split days inside the monthly folder
+- Cons: Harder to detect in `get_output_path` walk; nested structure less obvious
+- Rejected in favor of top-level `YYYY-MM-DD/` naming
+
+### Trade-offs
+
+**Benefits:**
+- ✅ Obsidian can open all chat history files on any workday
+- ✅ Existing small-day files and directory structure are unaffected
+- ✅ `get_output_path` rerouting is transparent to all callers
+- ✅ Each part file is a valid standalone markdown document
+
+**Costs:**
+- ❌ Split days produce a subfolder instead of a flat file — slightly more complex directory tree
+- ❌ "Part N of M" total is not written in headers (M is unknown until all chunks are accumulated)
+
+**Mitigation:**
+- Part headers annotated with `— Part N` suffix on the `# Complete Chat Session Export` line
+- `get_output_path` handles split detection automatically; no change needed in recall/search integrations
+
+---
+
+## Consequences
+
+### Positive
+
+1. **Obsidian stability:** No crashes on heavy workdays
+2. **Zero caller impact:** `get_output_path` reroutes transparently; `/kmgraph:recall` and session summaries require no changes
+3. **Self-healing on append:** Incremental appends re-trigger split if the last part grows over the limit
+
+### Negative
+
+1. **Directory structure change on large days:** `YYYY-MM-DD/` subfolder appears instead of a flat file, which may surprise tooling that scans `chat-history/` expecting only files
+
+### Neutral
+
+1. **Part files are independently valid:** Each part carries a full header and can be read in isolation
+
+---
+
+## Implementation
+
+**Timeline:** Implemented in v0.5.3-hotfix-extract-chat-history
+
+**Affected Components:**
+- `core/scripts/chat_extractor_base.py` — constants, `get_output_path`, `split_file_if_oversized`
+- `core/scripts/extract_claude.py` — import + two call sites
+- `core/scripts/extract_gemini.py` — import + one call site
+- `commands/extract-chat.md` — Large File Splitting section added
+
+---
+
+## Validation
+
+**Success Criteria:**
+- A file exceeding 900 KB or 30,000 lines is split into parts and original is removed
+- Normal days (under limits) are unaffected
+- Incremental append targets the last part file
+- Appending to a part that grows over the limit produces a new part
+
+---
+
+## Related Decisions
+
+- **[[ADR-043-pretooluse-hook-injection-superpowers-rule-enforcement]]:** Hook enforcement context for same branch
+
+---
+
+**Decision Made:** 2026-04-23
+**Last Updated:** 2026-04-23
+**Status:** Accepted

--- a/knowledge/decisions/ADR-045-update-profile-skill-not-command.md
+++ b/knowledge/decisions/ADR-045-update-profile-skill-not-command.md
@@ -1,0 +1,119 @@
+---
+title: "ADR-045: Implement Profile Update Functionality as a Skill, Not a Command"
+number: 45
+created: 2026-04-23T00:00:00Z
+status: Accepted
+author: technomensch
+email: 917847+technomensch@users.noreply.github.com
+git:
+  branch: v0.5.3-hotfix-extract-chat-history
+  commit: b3dea47f
+  pr: null
+  issue: null
+implements: null
+related:
+  adrs: []
+  lessons: []
+  kg_entries: []
+tags: [profile, skill, command, platform-agnostic, user-profile]
+category: architecture
+---
+
+# ADR-045: Implement Profile Update Functionality as a Skill, Not a Command
+
+**Date:** 2026-04-23
+**Status:** Accepted
+
+---
+
+## Context
+
+**Problem:**
+- No skill or command existed for managing user profiles (me.md + rules.md + triggers.md as a unit)
+- When told "update the user profile," AI sessions defaulted to updating only `rules.md`, leaving `triggers.md` un-updated — because "user profile" was not defined anywhere as a three-file bundle
+- The fix requires both a definition of the term and an automated routing mechanism that enforces the three-file review gate
+
+**Scope:**
+- In scope: Claude Code and platforms with skill/auto-trigger support
+- Out of scope (deferred): non-Claude Code platforms (Gemini CLI, Cursor, Windsurf, Codex CLI) where skills do not auto-trigger — those users need a slash command or MCP tool
+
+**Constraints:**
+- A new slash command requires doc updates across COMMAND-GUIDE.md, CHEAT-SHEET.md, `docs/reference/commands.md`, README, and GETTING-STARTED.md
+- A new skill requires only a single SKILL.md file — no doc surface changes
+
+---
+
+## Decision
+
+Implement profile update routing as a **skill** (`skills/update-profile/SKILL.md`) rather than a slash command.
+
+The skill auto-triggers on natural language patterns ("update my profile", "add this to my profile", "update the user profile") and routes changes across the three-file bundle — me.md, rules.md, triggers.md — at either user level (`~/.kmgraph/`) or project level (`knowledge/`).
+
+The three-file bundle definition is also written into `~/.kmgraph/rules.md § Profile > Profile Structure` so it is available to AI sessions as a behavioral rule independent of the skill.
+
+---
+
+## Rationale
+
+### Why Skill Over Command
+
+1. **Minimal doc surface:** A skill requires no changes to COMMAND-GUIDE, CHEAT-SHEET, reference/commands.md, README, or GETTING-STARTED. A command requires all five.
+2. **Natural language activation:** Skills fire on conversational phrases without requiring the user to remember a slash command. "Update my profile" is more natural than `/kmgraph:update-profile`.
+3. **Behavioral enforcement:** The three-file gate (all three files reviewed before done) is a behavioral constraint — the right layer for a skill, not a slash command.
+
+### Why a Command Is Still the Right Future Path for Other Platforms
+
+Platform-agnostic users (Gemini CLI, Cursor, Windsurf, Codex CLI) cannot invoke Claude Code skills. If those users say "update my profile," they get no routing assistance. A future `kg_update_profile` MCP tool or platform command would close this gap without the current doc-update cost — because by that time, the three-file definition will already be established in the profile files, reducing the docs change to a reference addition only.
+
+### Alternatives Considered
+
+**Command only:**
+- Pros: works across all platforms, explicit invocation
+- Cons: significant doc updates; adds to an already long command list; "update my profile" should not require a slash command for natural usage
+- Rejected for v0.5.3; deferred to platform-agnostic roadmap
+
+**Skill + Command in parallel:**
+- Pros: full coverage now
+- Cons: duplicates the doc surface cost immediately; premature given the user base is currently Claude Code-only
+- Rejected for same reason
+
+---
+
+## Consequences
+
+### Positive
+- ✅ Claude Code sessions now correctly route "update my profile" to all three files
+- ✅ Zero doc update cost for this release
+- ✅ Clear deferred path: a platform-agnostic command/MCP tool can be added when needed
+
+### Negative
+- ❌ Gemini CLI, Cursor, Windsurf, and Codex CLI users get no auto-trigger; they must rely on the `rules.md § Profile > Profile Structure` definition being in context
+- Mitigated: the definition in `~/.kmgraph/rules.md` is always loaded, so platforms that load rules files will still have the three-file definition even without the skill trigger
+
+### Neutral
+- The skill approach is consistent with how other behavioral enforcements (rules-capture, lesson-capture, adr-guide) are implemented in kmgraph
+
+---
+
+## Implementation
+
+**Branch:** v0.5.3-hotfix-extract-chat-history
+
+**Delivered:**
+- `skills/update-profile/SKILL.md` — trigger patterns, routing table, three-file gate
+- `~/.kmgraph/rules.md § Profile > Profile Structure` — definition of "user profile" as three-file bundle
+- `~/.kmgraph/triggers.md § When updating a user profile` — gate: all three files reviewed before done
+- `knowledge/triggers.md § Before pushing to origin / Before creating a PR` — doc sync hard STOP gates (companion change in same branch)
+
+---
+
+## Future Considerations
+
+1. **Platform-agnostic command:** When non-Claude Code platform usage grows, add `kg_update_profile` as an MCP tool or cross-platform command. The three-file definition will already be in place, reducing the docs cost significantly.
+2. **Profile validation:** A future enhancement could validate that every rule in `rules.md` has a corresponding trigger in `triggers.md` — surfacing orphaned rules automatically.
+
+---
+
+**Decision Made:** 2026-04-23
+**Last Updated:** 2026-04-23
+**Status:** Accepted

--- a/knowledge/decisions/README.md
+++ b/knowledge/decisions/README.md
@@ -4,7 +4,7 @@
 
 Formal documentation of significant architecture decisions.
 
-**Total ADRs:** 44
+**Total ADRs:** 45
 **Last Updated:** 2026-04-23
 
 ---
@@ -17,6 +17,7 @@ Formal documentation of significant architecture decisions.
 
 ## All ADRs (Chronological)
 
+- [ADR-045: Implement Profile Update Functionality as a Skill, Not a Command](ADR-045-update-profile-skill-not-command.md) — **Status:** Accepted — Skill over command: zero doc-update cost, natural language activation; platform-agnostic command deferred to future roadmap when non-CC usage grows.
 - [ADR-044: Split Oversized Daily Chat History Files for Obsidian Compatibility](ADR-044-split-oversized-chat-history-files.md) — **Status:** Accepted — When a daily chat history file exceeds 900 KB or 30,000 lines, split into numbered parts in a YYYY-MM-DD/ subfolder; get_output_path reroutes transparently.
 - [ADR-043: PreToolUse Hook Injection to Enforce User Rules During Superpowers Skill Execution](ADR-043-pretooluse-hook-injection-superpowers-rule-enforcement.md) — **Status:** Accepted — PreToolUse hook injects ~/.kmgraph/rules.md before brainstorming/writing-plans skills execute, ensuring file-location and execution-mode rules override skill defaults. (Renumbered from ADR-041 — cross-branch collision.)
 - [ADR-042: ADR `implements` Field — Mandatory Implementation Commit Reference](ADR-042-adr-implements-commit-reference-mandatory.md) — **Status:** Accepted — Every ADR must include the implementation commit hash in the `implements` YAML field; rule lives at user level in `~/.kmgraph/rules.md`; enforcement wired into create-adr-agent wizard (Phase 3).
@@ -34,6 +35,7 @@ Formal documentation of significant architecture decisions.
 ## By Category
 
 ### Architecture
+- [ADR-045](ADR-045-update-profile-skill-not-command.md) — Implement Profile Update Functionality as a Skill, Not a Command
 - [ADR-044](ADR-044-split-oversized-chat-history-files.md) — Split Oversized Daily Chat History Files for Obsidian Compatibility
 - [ADR-034: Capture Level Routing — Dispatcher/Agent Split](ADR-034-capture-level-routing-dispatcher-agent-split.md) — Dispatchers resolve NL → flags; agents handle flags only; gov-capture-routing is single source of truth; user-level bypasses kg_capture
 - [ADR-031: Use Plural `Lessons_Learned_` Prefix for Lesson Filenames](ADR-031-lessons-learned-plural-prefix-naming.md) — Plural form is semantically correct; hardcoded in `capture.ts`; changing it would require migration of 33 files

--- a/knowledge/decisions/README.md
+++ b/knowledge/decisions/README.md
@@ -4,8 +4,8 @@
 
 Formal documentation of significant architecture decisions.
 
-**Total ADRs:** 43
-**Last Updated:** 2026-04-21
+**Total ADRs:** 44
+**Last Updated:** 2026-04-23
 
 ---
 
@@ -17,6 +17,7 @@ Formal documentation of significant architecture decisions.
 
 ## All ADRs (Chronological)
 
+- [ADR-044: Split Oversized Daily Chat History Files for Obsidian Compatibility](ADR-044-split-oversized-chat-history-files.md) — **Status:** Accepted — When a daily chat history file exceeds 900 KB or 30,000 lines, split into numbered parts in a YYYY-MM-DD/ subfolder; get_output_path reroutes transparently.
 - [ADR-043: PreToolUse Hook Injection to Enforce User Rules During Superpowers Skill Execution](ADR-043-pretooluse-hook-injection-superpowers-rule-enforcement.md) — **Status:** Accepted — PreToolUse hook injects ~/.kmgraph/rules.md before brainstorming/writing-plans skills execute, ensuring file-location and execution-mode rules override skill defaults. (Renumbered from ADR-041 — cross-branch collision.)
 - [ADR-042: ADR `implements` Field — Mandatory Implementation Commit Reference](ADR-042-adr-implements-commit-reference-mandatory.md) — **Status:** Accepted — Every ADR must include the implementation commit hash in the `implements` YAML field; rule lives at user level in `~/.kmgraph/rules.md`; enforcement wired into create-adr-agent wizard (Phase 3).
 - [ADR-041: Tier Abstraction Label System for Model Selection](ADR-041-tier-abstraction-label-system.md) — **Status:** Accepted — Three tier labels (fast-tier, standard-tier, powerful-tier) abstract platform-specific model names; alias map and validation gate implemented in v0.5.2-beta Phase 3.
@@ -33,6 +34,7 @@ Formal documentation of significant architecture decisions.
 ## By Category
 
 ### Architecture
+- [ADR-044](ADR-044-split-oversized-chat-history-files.md) — Split Oversized Daily Chat History Files for Obsidian Compatibility
 - [ADR-034: Capture Level Routing — Dispatcher/Agent Split](ADR-034-capture-level-routing-dispatcher-agent-split.md) — Dispatchers resolve NL → flags; agents handle flags only; gov-capture-routing is single source of truth; user-level bypasses kg_capture
 - [ADR-031: Use Plural `Lessons_Learned_` Prefix for Lesson Filenames](ADR-031-lessons-learned-plural-prefix-naming.md) — Plural form is semantically correct; hardcoded in `capture.ts`; changing it would require migration of 33 files
 - [ADR-030: Migration Moves KMGraph-Named Subdirectories Only](ADR-030-migration-moves-named-subdirs-only-never-entire-docs.md) — Named subdir list prevents collision with docs sites; explicit scope over blanket directory moves

--- a/knowledge/rules.md
+++ b/knowledge/rules.md
@@ -46,6 +46,11 @@ When a user-facing document is moved or renamed, update `sidebars.js` to reflect
 - **Why:** a stale `id:` in `sidebars.js` causes Docusaurus to throw `Unknown doc ID` and breaks the build silently until the next deploy
 - **Invoke:** `sidebar-update` skill when a rename or move is detected
 
+### Pre-Push / Pre-Merge User-Facing Doc Sync
+
+Before pushing to origin OR before creating/completing a merge, run `/kmgraph:update-doc --user-facing` to verify that all user-facing docs (README, COMMAND-GUIDE, CHEAT-SHEET, GETTING-STARTED, CONCEPTS, INSTALL.md) reflect the changes on the branch.
+- **Why:** commands, behavior changes, and new features were shipped without corresponding doc updates, leaving guides inconsistent with actual behavior until a follow-up pass was required
+
 ### Pre-PR Doc Verification
 
 Before creating a PR with doc changes: run `git diff HEAD~N -- docs/` for each changed file, check for formatting regressions (stray spaces, broken tables, removed blank lines, wrong agent names), then run `mkdocs build` and confirm no new warnings

--- a/knowledge/triggers.md
+++ b/knowledge/triggers.md
@@ -17,3 +17,16 @@
 - Invoke: `sidebar-update` skill to detect the old sidebar entry and apply the update
 - Gate: do not complete the move or rename without updating `sidebars.js`
 - Also check: grep `docs/` for internal links to the old path and update them
+
+## Before pushing to origin
+
+- Apply: `rules.md § Version & Release > Pre-Push / Pre-Merge User-Facing Doc Sync`
+- Gate: **STOP** — run `/kmgraph:update-doc --user-facing` before any `git push` and confirm user-facing docs (README, COMMAND-GUIDE, CHEAT-SHEET, GETTING-STARTED, CONCEPTS, INSTALL.md) reflect all changes on this branch
+- This applies to all pushes — even small PRs can change command behavior, flags, or remove commands
+- Do not run `git push` until doc sync is confirmed
+
+## Before creating a PR
+
+- Apply: `rules.md § Version & Release > Pre-Push / Pre-Merge User-Facing Doc Sync`
+- Gate: **STOP** — confirm `/kmgraph:update-doc --user-facing` has been run on this branch before opening the PR
+- Do not open the PR until docs are confirmed current

--- a/skills/update-profile/SKILL.md
+++ b/skills/update-profile/SKILL.md
@@ -1,0 +1,97 @@
+# Skill: update-profile
+
+**Purpose:** Detect when the user asks to update their profile and route changes to all three profile files (me.md + rules.md + triggers.md) as a unit — not rules.md alone.
+
+---
+
+## What "User Profile" Means
+
+A profile is a **three-file bundle**. A change to one file is often incomplete without reviewing the others:
+
+| File | Contains |
+|------|----------|
+| `me.md` | Identity, working style, communication preferences, platform config |
+| `rules.md` | Enforcement rules, always/never behaviors, project conventions |
+| `triggers.md` | When each rule fires — workflow phase conditions, event gates |
+
+**Rule without trigger = incomplete.** A rule in `rules.md` with no corresponding entry in `triggers.md` will not fire at the right moment.
+
+---
+
+## Trigger Patterns (match any)
+
+- "update my profile" / "update the user profile" / "update the profile"
+- "update my [user/project] profile"
+- "add this to my profile" / "add this to the profile"
+- "add to my [user/project] profile"
+- "update the [user/personal/project] profile"
+- "the profile needs [X]" / "my profile should say [X]"
+- "add [X] to my profile"
+
+## Do NOT trigger on
+
+- Explicit file-level requests: "update rules.md", "add to me.md", "edit triggers.md" — these are direct edits, not profile-level operations; handle as file edits only
+- "update my settings" — not a profile operation
+- "update the docs" — handled by `doc-update-router`
+
+---
+
+## Execution Flow
+
+### Step 1: Resolve level (user vs project)
+
+Check for explicit signal in the user's message:
+
+| Signal | Level |
+|--------|-------|
+| "user profile" / "personal profile" / "my profile" (no project qualifier) | User level: `~/.kmgraph/` |
+| "project profile" / "for this project" / "in this project" | Project level: `knowledge/` |
+| Ambiguous | Ask: "User-level (`~/.kmgraph/`) or project-level (`knowledge/`) profile?" |
+
+### Step 2: Identify what changed
+
+From context, determine which of the three files need updating:
+
+- **me.md**: identity, style, communication preferences, platform changes, working habits
+- **rules.md**: a new always/never rule, behavioral directive, or project convention
+- **triggers.md**: when a rule should fire — new workflow gate, phase condition, or event entry
+
+If a new rule is being added to `rules.md`, **always check whether a trigger entry is also needed** in `triggers.md`. Surface this check even if the user only mentioned rules.md.
+
+### Step 3: Draft updates
+
+For each file that needs updating, draft the proposed content inline for user review before writing.
+
+### Step 4: Gate — all three files reviewed
+
+Before marking the profile update complete:
+
+- [ ] `me.md` — reviewed; updated if needed or confirmed no change needed
+- [ ] `rules.md` — reviewed; updated if needed or confirmed no change needed
+- [ ] `triggers.md` — reviewed; updated if needed or confirmed no change needed
+
+Do not mark done until all three are explicitly checked.
+
+### Step 5: Write
+
+Write to the correct level (`~/.kmgraph/` or `knowledge/`) using the Write or Edit tool. Commit changes in the project KG (knowledge/) if applicable.
+
+---
+
+## Routing Table
+
+| Level | File | Path |
+|-------|------|------|
+| User | me.md | `~/.kmgraph/me.md` |
+| User | rules.md | `~/.kmgraph/rules.md` |
+| User | triggers.md | `~/.kmgraph/triggers.md` |
+| Project | me.md | `knowledge/me.md` |
+| Project | rules.md | `knowledge/rules.md` |
+| Project | triggers.md | `knowledge/triggers.md` |
+
+---
+
+## Conflict Avoidance
+
+- **rules-capture** fires on implicit behavioral directives mid-session. update-profile fires on explicit profile update requests. If both could fire, update-profile takes priority — the user named the artifact explicitly.
+- **lesson-capture** and **adr-guide** — do not conflict; different artifact types.


### PR DESCRIPTION
## Summary

- `extract-chat`: large days (>900KB / >30K lines) auto-split into `YYYY-MM-DD/` subfolders
- `update-doc`: Step 7b added — Tier 1 continuation prompt prevents README/CHANGELOG from being skipped when individual files are targeted
- `create-adr` + `capture-lesson`: KG-mismatch guardrails block cross-project writes
- `update-profile` skill added (ADR-045)
- `knowledge/rules.md`: doc-sync gate added (pre-push/merge)
- README + CHANGELOG updated for v0.5.3

## Test plan

- [ ] Run `/kmgraph:extract-chat --today` on a day with large output; verify `YYYY-MM-DD/` subfolder created
- [ ] Run `/kmgraph:update-doc docs/CHEAT-SHEET.md --user-facing`; verify Step 7b prompts for remaining Tier 1 files
- [ ] Verify README shows version 0.5.3 and v0.5.3 highlights
- [ ] Verify CHANGELOG has v0.5.3 section at top

🤖 Generated with [Claude Code](https://claude.ai/claude-code)