### PR TITLE
fix(hooks): v0.5.5 — key Stop hook flag on kg-name+date, not PPID

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "kmgraph",
-  "version": "0.5.4",
+  "version": "0.5.5",
   "description": "Structured knowledge capture, lesson-learned documentation, and cross-session memory for Claude Code projects. Includes KG entries, ADRs, meta-issue tracking, chat extraction, and MEMORY.md bidirectional sync.",
   "author": {
     "name": "technomensch",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Released]
 
+## [0.5.5] — 2026-04-29
+
+### Fixed
+- Stop hook session flag now keyed on `{kg-name}-{date}` instead of `{PPID}-{date}`. The previous scheme produced ~150 stale `/tmp` flag files per session and the dedup check never matched.
+
 ## [0.5.4] — 2026-04-28
 
 ### Added

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -236,7 +236,7 @@ done
 | **v0.5.2** | Shared tier resolver — no upgrade action required. `ai-model-tier-resolver` module is auto-used by all dispatchers after plugin reload. Run `/kmgraph:init` to add the `platforms[]` example block to your project `me.md` if missing. |
 | **v0.5.3** | No upgrade action required. `extract-chat` large-day auto-split and `update-doc` fixes are automatic after plugin reload. |
 | **v0.5.4** | Profile auto-load — no upgrade action required. `me.md` and `triggers.md` are now injected at SessionStart automatically. No config changes needed. |
-| **v0.5.5** | Bug fix — no upgrade action required. Stop hook dedup flag is now keyed on `{kg-name}-{date}` instead of `{PPID}-{date}`; stale `/tmp` flags from prior sessions can be removed with `rm /tmp/.kg-session-summarized-*`. |
+| **v0.5.5** | Bug fix — no upgrade action required. Stop hook dedup flag is now keyed on `{kg-name}-{date}` instead of `{PPID}-{date}`. Stale PPID-format flags from prior sessions are cleaned automatically on the next hook run. |
 
 After the wizard completes, your existing lessons, ADRs, sessions, and chat history are untouched.
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -236,6 +236,7 @@ done
 | **v0.5.2** | Shared tier resolver — no upgrade action required. `ai-model-tier-resolver` module is auto-used by all dispatchers after plugin reload. Run `/kmgraph:init` to add the `platforms[]` example block to your project `me.md` if missing. |
 | **v0.5.3** | No upgrade action required. `extract-chat` large-day auto-split and `update-doc` fixes are automatic after plugin reload. |
 | **v0.5.4** | Profile auto-load — no upgrade action required. `me.md` and `triggers.md` are now injected at SessionStart automatically. No config changes needed. |
+| **v0.5.5** | Bug fix — no upgrade action required. Stop hook dedup flag is now keyed on `{kg-name}-{date}` instead of `{PPID}-{date}`; stale `/tmp` flags from prior sessions can be removed with `rm /tmp/.kg-session-summarized-*`. |
 
 After the wizard completes, your existing lessons, ADRs, sessions, and chat history are untouched.
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Structured knowledge capture, lesson-learned documentation, and cross-session memory for Claude Code projects.
 
-**Version:** 0.5.4
+**Version:** 0.5.5
 **Status:** Actively developed and in daily use
 
 Documentation: https://kmgraph.stayinginsync.info
@@ -180,7 +180,7 @@ knowledge-graph/
 
 ## Development Status
 
-**Current Release:** v0.5.4 (2026-04-28)
+**Current Release:** v0.5.5 (2026-04-29)
 
 Actively developed and in daily use. Behavior may evolve between minor versions.
 
@@ -273,6 +273,6 @@ MIT License - See [LICENSE](LICENSE)
 ---
 
 **Created:** 2026-02-12
-**Current Version:** v0.5.4 (2026-04-28)
+**Current Version:** v0.5.5 (2026-04-29)
 
 📚 **Full documentation:** https://kmgraph.stayinginsync.info

--- a/core/templates/knowledge/rules.md
+++ b/core/templates/knowledge/rules.md
@@ -73,10 +73,23 @@ kmgraph_schema: 2
 <!-- Example: "Plans are local-only. Write to ~/.claude/plans/ first, then copy to docs/plans/ for working reference. Never commit plan files." -->
 
 - Plan location: write to `~/.claude/plans/` first, copy to `docs/plans/` for working reference — never commit plan files
+- Plan file routing override: if a `### Plan File Routing` section exists in this `rules.md` or the active project's `rules.md`, that routing takes precedence over `docs/plans/` for any plan with a matching parent artifact (ENH, issue, etc.)
 - Plan language: use "Create" for new files, "Update" for existing files — never use "Update" for files that don't exist yet
 - Skill overrides: `superpowers:writing-plans` defaults to `docs/superpowers/plans/` and `superpowers:brainstorming` defaults to `docs/superpowers/specs/`. Always override these:
   - Plans → `docs/plans/` (never `docs/superpowers/plans/`)
   - Specs → `docs/specs/` (never `docs/superpowers/specs/`)
+
+### Plan File Routing
+
+<!-- Optional: define project-specific plan locations for plans linked to KG artifacts. -->
+<!-- If defined here, these paths override the default docs/plans/ location.            -->
+<!-- Leave blank or remove this section entirely if all plans use docs/plans/.          -->
+
+<!-- Example (uncomment and adapt):
+- ENH parent  → `knowledge/ENH-NNN/vX-plan.md`
+- Issue / bug → `knowledge/issues/issue-NNN/vX-plan.md`
+- Misc        → `knowledge/plans/vX-plan.md`
+-->
 
 ### Execution Mode Decision
 

--- a/core/templates/knowledge/triggers.md
+++ b/core/templates/knowledge/triggers.md
@@ -9,6 +9,8 @@
 
 ---
 
+- Gate: check `rules.md § Plan Protocol > Plan File Routing` (in this file or the active project's `rules.md`) before defaulting to `docs/plans/` — use the matching artifact path if one is defined
+
 ## After writing an implementation plan
 
 - Apply: `rules.md § Plan Protocol > Parallelism Analysis`

--- a/knowledge/decisions/ADR-020-lifecycle-hooks-suite-automated-capture.md
+++ b/knowledge/decisions/ADR-020-lifecycle-hooks-suite-automated-capture.md
@@ -55,7 +55,9 @@ All scripts must comply with the hook security model:
 
 ### Session-End Double-Fire Prevention
 
-`session-end-prompt.sh` writes a PPID-scoped flag file at `/tmp/.kg-session-summarized-{PPID}-{YYYYMMDD}`. If the flag exists, the script exits silently. The flag is scoped to the parent process ID so it is session-specific — multiple terminal windows don't interfere. Flag files older than 24h are cleaned up on each run to prevent `/tmp/` accumulation.
+`session-end-prompt.sh` writes a flag file at `/tmp/.kg-session-summarized-{kg-name}-{YYYYMMDD}`. If the flag exists, the script exits silently. The flag is scoped to the active KG name and date — two sessions on the same project share one flag (first Stop hook wins), and different projects get independent flags. Flag files older than 24h are cleaned up on each run to prevent `/tmp/` accumulation.
+
+> **Amendment (v0.5.5):** The original design used `{PPID}-{YYYYMMDD}` as the flag key. Because `$PPID` resolves to a different value for each subprocess invocation in Claude Code, this caused ~150 flag files per session and the dedup check never matched. Changed to `{kg-name}-{YYYYMMDD}` in v0.5.5 (PR #108, closes issue #106).
 
 ### Lesson-Worthy Signal Detection
 

--- a/knowledge/issues/issue-4/issue-4-description.md
+++ b/knowledge/issues/issue-4/issue-4-description.md
@@ -1,9 +1,10 @@
 ---
 id: issue-4
 type: Bug
-status: deferred
+status: in-progress
 github-issue: "#106"
-branch: none
+branch: v0.5.5-fix-session-flag-dedup
+plan: docs/plans/v0.5.5-fix-session-flag-dedup.md
 created: 2026-04-28
 ---
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "knowledge-graph-plugin",
-  "version": "0.5.4",
+  "version": "0.5.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "knowledge-graph-plugin",
-      "version": "0.5.4",
+      "version": "0.5.5",
       "license": "MIT",
       "dependencies": {
         "@docusaurus/plugin-client-redirects": "^3.10.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "knowledge-graph-plugin",
-  "version": "0.5.4",
+  "version": "0.5.5",
   "description": "Structured knowledge capture and cross-session memory for Claude Code projects.",
   "files": [
     ".claude-plugin/",

--- a/scripts/session-end-prompt.sh
+++ b/scripts/session-end-prompt.sh
@@ -13,9 +13,11 @@ NC='\033[0m'
 
 # ─────────────────────────────────────────────────────────────
 # Session flag: avoid double-prompting within same session
+# Keyed on active KG name + date for per-project isolation.
 # ─────────────────────────────────────────────────────────────
 
-FLAG_PATH="/tmp/.kg-session-summarized-${PPID}-$(date +%Y%m%d)"
+ACTIVE_KG="$(grep -o '"active"[[:space:]]*:[[:space:]]*"[^"]*"' "$CONFIG_PATH" 2>/dev/null | sed 's/.*"\([^"]*\)".*/\1/')"
+FLAG_PATH="/tmp/.kg-session-summarized-${ACTIVE_KG:-default}-$(date +%Y%m%d)"
 
 if [ -f "$FLAG_PATH" ]; then
     exit 0
@@ -39,8 +41,6 @@ fi
 if [ ! -f "$CONFIG_PATH" ]; then
     exit 0
 fi
-
-ACTIVE_KG="$(grep -o '"active"[[:space:]]*:[[:space:]]*"[^"]*"' "$CONFIG_PATH" | sed 's/.*"\([^"]*\)".*/\1/')"
 
 if [ -z "$ACTIVE_KG" ]; then
     exit 0

--- a/skills/session-wrap/SKILL.md
+++ b/skills/session-wrap/SKILL.md
@@ -17,7 +17,7 @@
 - Rules were captured to `knowledge/rules.md` or `knowledge/me.md` this session: surface "N rule(s) captured this session — run `/kmgraph:recall` to review rules.md for drift or conflicts."
 
 **Block Conditions:**
-- Stop hook coordination flag exists: `/tmp/.kg-session-summarized-{PPID}-{date}` — if present, do NOT prompt (Stop hook already fired; avoid double-prompting)
+- Stop hook coordination flag exists: `/tmp/.kg-session-summarized-{kg-name}-{date}` — if present, do NOT prompt (Stop hook already fired; avoid double-prompting)
 
 **ECC Compatibility Note:** This skill is coordinated with the Stop hook to prevent duplicate prompting. On Claude Code, the /tmp flag mechanism is used for inter-process coordination. On other ECC platforms, equivalent synchronization mechanisms (environment variables, shared state, or hook phase detection) should be used to prevent re-prompting if the Stop hook has already triggered this workflow.
 

--- a/tests/run-all-tests.sh
+++ b/tests/run-all-tests.sh
@@ -40,6 +40,7 @@ SUITES=(
   "test-commands.sh|Commands — 25 commands structural + syntax|no"
   "test-skills-agents.sh|Skills + Agents — structural validation|no"
   "test-hooks.sh|Hooks — SessionStart hook validation|no"
+  "test-stop-hook.sh|Stop hook flag — kg-name+date dedup|no"
   "test-extraction.sh|Extraction — Python chat extraction scripts|no"
   "test-tier-resolver-smoke.sh|v0.5.0 Tier Resolver — smoke tests|no"
   "test-tier-resolver-edge.sh|v0.5.0 Tier Resolver — edge and negative cases|no"

--- a/tests/test-stop-hook.sh
+++ b/tests/test-stop-hook.sh
@@ -1,0 +1,201 @@
+#!/bin/bash
+# test-stop-hook.sh — Validates session-end-prompt.sh flag creation and dedup behavior
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+STOP_HOOK="$REPO_ROOT/scripts/session-end-prompt.sh"
+
+PASS=0
+FAIL=0
+
+pass() { echo "  ✅ PASS: $1"; PASS=$((PASS + 1)); }
+fail() { echo "  ❌ FAIL: $1"; FAIL=$((FAIL + 1)); }
+
+# ── Setup ────────────────────────────────────────────────────────────────────
+
+TEST_DIR=$(mktemp -d)
+TEST_CONFIG="$TEST_DIR/kg-config.json"
+REAL_CONFIG="$HOME/.claude/kg-config.json"
+REAL_CONFIG_BACKUP="$TEST_DIR/kg-config.backup.json"
+TODAY="$(date +%Y%m%d)"
+
+cleanup() {
+  rm -rf "$TEST_DIR"
+  if [ -f "$REAL_CONFIG_BACKUP" ]; then
+    mv "$REAL_CONFIG_BACKUP" "$REAL_CONFIG"
+  fi
+  rm -f "/tmp/.kg-session-summarized-test-kg-${TODAY}"
+  rm -f "/tmp/.kg-session-summarized-other-kg-${TODAY}"
+  rm -f "/tmp/.kg-session-summarized-default-${TODAY}"
+}
+trap cleanup EXIT
+
+[ -f "$REAL_CONFIG" ] && cp "$REAL_CONFIG" "$REAL_CONFIG_BACKUP"
+
+echo "═══════════════════════════════════════════════════════════════"
+echo "TEST SUITE: Stop Hook (session-end-prompt.sh)"
+echo "Hook: $STOP_HOOK"
+echo "═══════════════════════════════════════════════════════════════"
+echo ""
+
+if [ ! -f "$STOP_HOOK" ]; then
+  echo "❌ FATAL: session-end-prompt.sh not found at $STOP_HOOK"
+  exit 1
+fi
+if [ ! -x "$STOP_HOOK" ]; then
+  echo "❌ FATAL: session-end-prompt.sh is not executable"
+  exit 1
+fi
+
+# ── Setup: minimal KG dir ────────────────────────────────────────────────────
+
+TEST_KG_DIR="$TEST_DIR/test-kg"
+mkdir -p "$TEST_KG_DIR"
+
+make_config() {
+  local kg_name="$1"
+  cat > "$TEST_CONFIG" << EOF
+{
+  "version": "1.0.0",
+  "active": "${kg_name}",
+  "graphs": {
+    "${kg_name}": {
+      "name": "${kg_name}",
+      "path": "$TEST_KG_DIR",
+      "type": "project-local",
+      "categories": [],
+      "createdAt": "2026-01-01T00:00:00.000Z",
+      "lastUsed": "2026-01-01T00:00:00.000Z"
+    }
+  },
+  "sanitization": {"enabled":false,"patterns":[],"action":"warn"}
+}
+EOF
+  cp "$TEST_CONFIG" "$REAL_CONFIG"
+}
+
+echo "── Section 1: Flag creation ─────────────────────────────────────"
+
+# Test 1: Flag is created with kg-name-date pattern (not PPID-date)
+make_config "test-kg"
+rm -f "/tmp/.kg-session-summarized-test-kg-${TODAY}"
+bash "$STOP_HOOK" > /dev/null 2>&1 || true
+
+EXPECTED_FLAG="/tmp/.kg-session-summarized-test-kg-${TODAY}"
+if [ -f "$EXPECTED_FLAG" ]; then
+  pass "Flag created at correct path: .kg-session-summarized-{kg-name}-{date}"
+else
+  fail "Flag not found at $EXPECTED_FLAG"
+fi
+
+# Test 2: Exactly one flag for today — no PPID-based extras
+# Use realpath to resolve /tmp symlink on macOS (/tmp → /private/tmp)
+TMP_REAL="$(realpath /tmp 2>/dev/null || echo /tmp)"
+# Clear any pre-existing today flags so the count is environment-independent
+find "$TMP_REAL" -maxdepth 1 -name ".kg-session-summarized-*-${TODAY}" -delete 2>/dev/null; bash "$STOP_HOOK" > /dev/null 2>&1 || true
+TOTAL_FLAGS=$(find "$TMP_REAL" -maxdepth 1 -name ".kg-session-summarized-*-${TODAY}" 2>/dev/null | wc -l | tr -d ' ')
+if [ "$TOTAL_FLAGS" -eq 1 ]; then
+  pass "Exactly one flag created — no PPID-based extras"
+else
+  fail "Expected 1 flag for today, found $TOTAL_FLAGS — extra flags may be PPID-based"
+fi
+
+echo ""
+echo "── Section 2: Deduplication ─────────────────────────────────────"
+
+# Test 3: Second run exits 0 immediately (flag already exists)
+# Test 4: Second run produces no output
+make_config "test-kg"
+if [ ! -f "$EXPECTED_FLAG" ]; then
+  fail "precondition: test-kg flag missing before dedup check"
+fi
+set +e
+OUTPUT=$(bash "$STOP_HOOK" 2>&1)
+EXIT_CODE=$?
+set -e
+if [ $EXIT_CODE -eq 0 ]; then
+  pass "Second run with existing flag exits 0 (dedup working)"
+else
+  fail "Second run should exit 0, got $EXIT_CODE"
+fi
+if [ -z "$OUTPUT" ]; then
+  pass "Second run produces no output (early exit)"
+else
+  fail "Second run should produce no output (got: $OUTPUT)"
+fi
+
+echo ""
+echo "── Section 3: Per-project isolation ─────────────────────────────"
+
+# Test 5 & 6: Different KG name produces different flags; original unaffected
+make_config "other-kg"
+rm -f "/tmp/.kg-session-summarized-other-kg-${TODAY}"
+bash "$STOP_HOOK" > /dev/null 2>&1 || true
+
+OTHER_FLAG="/tmp/.kg-session-summarized-other-kg-${TODAY}"
+if [ -f "$OTHER_FLAG" ]; then
+  pass "Different KG creates its own flag (per-project isolation)"
+else
+  fail "Second KG flag not found at $OTHER_FLAG"
+fi
+
+# Test 6: test-kg flag was not removed by the other-kg run
+if [ -f "$EXPECTED_FLAG" ]; then
+  pass "Original test-kg flag still present after other-kg run"
+else
+  fail "test-kg flag should persist after running with a different KG"
+fi
+
+echo ""
+echo "── Section 4: No-config fallback ────────────────────────────────"
+
+# Test 7: When no config exists, hook exits 0 gracefully
+rm -f "$REAL_CONFIG"
+rm -f "/tmp/.kg-session-summarized-default-${TODAY}"
+set +e
+OUTPUT=$(bash "$STOP_HOOK" 2>&1)
+EXIT_CODE=$?
+set -e
+if [ $EXIT_CODE -eq 0 ]; then
+  pass "No config file — hook exits 0 gracefully"
+else
+  fail "No config file — hook should exit 0, got $EXIT_CODE"
+fi
+if [ -z "$OUTPUT" ]; then
+  pass "No config file — no output (silent early exit)"
+else
+  fail "No config file — should produce no output (got: $OUTPUT)"
+fi
+
+echo ""
+echo "── Section 5: Default fallback (active key null) ─────────────────"
+
+# Test 9: Config exists but active is null
+cat > "$TEST_CONFIG" << 'NULLEOF'
+{"version":"1.0.0","active":null,"graphs":{},"sanitization":{"enabled":false,"patterns":[],"action":"warn"}}
+NULLEOF
+cp "$TEST_CONFIG" "$REAL_CONFIG"
+rm -f "/tmp/.kg-session-summarized-default-${TODAY}"
+set +e
+OUTPUT=$(bash "$STOP_HOOK" 2>&1)
+EXIT_CODE=$?
+set -e
+if [ $EXIT_CODE -eq 0 ]; then
+  pass "Null active KG — hook exits 0 gracefully"
+else
+  fail "Null active KG — should exit 0, got $EXIT_CODE"
+fi
+if [ ! -f "/tmp/.kg-session-summarized-default-${TODAY}" ]; then
+  pass "Null active KG — no flag written (hook exits before touch)"
+else
+  fail "Null active KG — flag should not be written"
+fi
+
+echo ""
+echo "═══════════════════════════════════════════════════════════════"
+echo "STOP HOOK: $PASS passed, $FAIL failed (total: $((PASS + FAIL)))"
+echo "═══════════════════════════════════════════════════════════════"
+
+[ $FAIL -eq 0 ] && exit 0 || exit 1


### PR DESCRIPTION
## Summary

- Replaces `$PPID` in the Stop hook flag filename with the active KG name
- Flag is now `/tmp/.kg-session-summarized-{kg-name}-{date}` — stable within a project, isolated between projects, one per day
- Adds `tests/test-stop-hook.sh` (10 tests: flag creation, dedup, per-project isolation, no-config and null-active fallbacks)
- Bumps version to 0.5.5; updates README, INSTALL, CHANGELOG

## Root Cause

`$PPID` resolves to the spawning subprocess's PID, which differs for every tool call or subagent invocation. This caused ~150 flag files per session and the dedup check never matched.

## Test Plan

- [x] `bash tests/test-stop-hook.sh` — all 10 tests pass
- [x] `bash tests/run-all-tests.sh` — new suite passes; 3 pre-existing unrelated failures unchanged
- [ ] Manually trigger Stop hook twice in one session — second invocation produces no output

Closes #106

🤖 Generated with [Claude Code](https://claude.com/claude-code)