### PR TITLE
feat: v0.5.6 — update-graph governance migration

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "kmgraph",
-  "version": "0.5.5",
+  "version": "0.5.6",
   "description": "Structured knowledge capture, lesson-learned documentation, and cross-session memory for Claude Code projects. Includes KG entries, ADRs, meta-issue tracking, chat extraction, and MEMORY.md bidirectional sync.",
   "author": {
     "name": "technomensch",

--- a/agents/knowledge-extractor.md
+++ b/agents/knowledge-extractor.md
@@ -255,26 +255,27 @@ Checklist for each new/updated entry:
 
 ---
 
-### Step 8: Check Project Memory Sync Requirements
+### Step 8: Flag Governance-Worthy Content
 
-After each entry is created/updated, check if MEMORY.md should be updated:
+After each entry is created/updated, check whether the lesson contains governance-worthy content:
 
-**Triggers for memory update:**
+**Governance triggers (detect, do not write):**
 - New gotcha pattern (common pitfall/failure mode)
 - New best practice (proven technique)
 - New common failure pattern (repeated error with fix)
 - Workflow enhancement (change to existing process)
 - Architecture decision (structural decision affecting governance)
 
-**Do NOT update memory for:** one-time project-specific patterns, informational concepts without process impact.
+**If any trigger matches**, append this plain-language note to the agent output — do NOT write to any file:
 
-**Token limits before writing:**
-```bash
-memory_words=$(wc -w < ~/.claude/projects/.../memory/MEMORY.md)
-memory_tokens=$((memory_words * 13 / 10))
-# Soft limit: 1,500 tokens (warning)
-# Hard limit: 2,000 tokens (block new entries)
 ```
+Looks like this lesson might be worth saving as a guideline.
+Bring it up at the end of your session to capture it.
+```
+
+**Do NOT flag:** one-time project-specific patterns, informational concepts without process impact.
+
+**No file writes occur in this step.** Governance capture is handled by rules-capture at session wrap.
 
 ---
 

--- a/commands/init.md
+++ b/commands/init.md
@@ -485,16 +485,17 @@ if [ -n "$MEMORY_FILE" ]; then
   fi
 fi
 
-# i. MEMORY.md feedback-entry backfill offer (upgrade only)
+# i. Legacy feedback-entry backfill offer (upgrade only)
 # Run only when upgrading an existing KG that has rules.md scaffold or content.
-# Scans project MEMORY.md for feedback-type entries not already mirrored in rules.md.
+# Scans project MEMORY.md for feedback-type entries previously stored there (legacy)
+# that have not yet been migrated to rules.md.
 
 if [ -n "$MEMORY_FILE" ] && [ -f "knowledge/rules.md" ]; then
   # Identify feedback entries: lines containing "[→ rules.md]" marker or entries
   # whose content is not already present in rules.md (keyword overlap check).
   # Display each candidate and offer to migrate:
   #
-  #   Found N feedback rule(s) in MEMORY.md not yet in knowledge/rules.md:
+  #   Found N legacy feedback rule(s) in MEMORY.md not yet migrated to knowledge/rules.md:
   #
   #   1. "Never delete branches without explicit user approval" [→ rules.md]
   #   2. "Always open the plan file in the editor after writing it" [→ rules.md]
@@ -509,7 +510,7 @@ if [ -n "$MEMORY_FILE" ] && [ -f "knowledge/rules.md" ]; then
   # Do NOT remove the MEMORY.md entry — leave it as a pointer with [→ rules.md] already appended.
   # Do NOT auto-write without per-entry confirmation.
   echo ""
-  echo "  Checking MEMORY.md for unmirrored behavioral rules..."
+  echo "  Checking MEMORY.md for legacy behavioral rules not yet migrated to rules.md..."
   # [Implementation: parse $MEMORY_FILE for lines containing '[→ rules.md]' or
   #  lines under a 'feedback' section; cross-check against knowledge/rules.md content;
   #  surface any that appear absent; offer migration per entry]
@@ -521,8 +522,9 @@ fi
 # - If MEMORY.md does not exist or path cannot be found, skip block silently.
 # - Draft format must match existing knowledge/rules.md house style:
 #   "- [Always/Never] [directive]" with optional "  - Why:" and "  - Source:" sub-bullets.
-# Note: feedback-type MEMORY.md entries (behavioral corrections → project rules.md) are
-# handled here. Step 1.6.5 covers only user-type entries (role, preferences → personal me.md).
+# Note: feedback-type MEMORY.md entries are a legacy migration path — MEMORY.md is no longer
+# the active governance store. New behavioral rules go directly to rules.md via rules-capture.
+# Step 1.6.5 covers only user-type entries (role, preferences → personal me.md).
 
 # f. Clear migration flag
 jq 'del(.graphs["'"$kg_name"'"].migration_in_progress)' \

--- a/commands/status.md
+++ b/commands/status.md
@@ -213,4 +213,4 @@ Output:
 
 - `/kmgraph:list` — View all configured KGs
 - `/kmgraph:switch` — Change active KG
-- `/kmgraph:sync-all` — Sync KG with MEMORY.md
+- `/kmgraph:sync-all` — Sync KG and review governance signals

--- a/commands/sync-all.md
+++ b/commands/sync-all.md
@@ -89,7 +89,7 @@ Parameters:
 The agent executes the full 8-step pipeline:
 1. Scan for new/modified lessons
 2. Extract knowledge graph entries
-3. Check MEMORY.md sync requirements
+3. Check governance signal status
 4. Link to active plan
 5. Update local issue
 6. Auto-update session summary
@@ -105,7 +105,7 @@ Knowledge Sync Complete
 -----------------------
 Lessons scanned:  3 (2 new, 1 modified)
 KG entries:       2 created, 1 updated
-MEMORY.md:        Updated (1 new pattern)
+Governance:       1 signal flagged (review at session wrap)
 Plan linked:      v2.0 (Step 2 → Prefix Naming lesson)
 Local issue:      issue-42 (updated)
 GitHub:           [ISSUE_ID] (comment posted)
@@ -164,7 +164,7 @@ If GitHub CLI (`gh`) is not installed or no remote is configured:
 
 This command is idempotent — running it multiple times produces the same result:
 - Existing KG entries are updated, not duplicated
-- MEMORY.md checks for existing content before adding
+- Governance signals are checked before flagging (no duplicate flags per lesson)
 - GitHub comments include timestamps to prevent duplicate posts
 - Plan links are checked before adding
 

--- a/commands/update-doc.md
+++ b/commands/update-doc.md
@@ -70,7 +70,7 @@ Resolved file: $TARGET_FILE
 
 2. Knowledge graph content
    Content created using the plugin
-   (lessons, KG entries, ADRs, session summaries, MEMORY.md)
+   (lessons, KG entries, ADRs, session summaries)
    → Confirm to update KG content
 
 3. Cancel

--- a/commands/update-graph.md
+++ b/commands/update-graph.md
@@ -10,7 +10,7 @@ Extract structured insights from lessons-learned documents and sync them to the 
 
 ## Description
 
-Delegates to the `knowledge-extractor` agent (KG Entry Extraction Mode) to read lessons, extract structured entries, create/update KG entries with bidirectional links, preserve git metadata, and sync to MEMORY.md when governance criteria are met.
+Delegates to the `knowledge-extractor` agent (KG Entry Extraction Mode) to read lessons, extract structured entries, create/update KG entries with bidirectional links, and preserve git metadata. When governance-worthy content is detected, flags it in output for capture at session wrap.
 
 **When to use:**
 - After creating/updating lesson-learned documents
@@ -89,7 +89,7 @@ The agent executes the full extraction pipeline:
 5. Create or update knowledge entries
 6. Update cross-references (bidirectional links)
 7. Verify entry quality
-8. Check project memory sync requirements
+8. Flag governance-worthy content in output
 
 ### Step 3: Display Results
 
@@ -132,7 +132,7 @@ Display the output exactly as returned by the agent. Do not reformat.
 Knowledge entries LEVERAGE lessons, not REPLACE them:
 - **Knowledge Graph** = Quick index (5-10 seconds)
 - **Lesson-Learned** = Deep understanding (5-10 minutes)
-- **MEMORY.md** = Persistent governance context
+- **Session wrap** = Governance capture point (rules-capture + triggers)
 - Together = Efficient onboarding + comprehensive learning
 
 ---
@@ -150,4 +150,4 @@ Knowledge entries LEVERAGE lessons, not REPLACE them:
 **Version:** 3.0 (Refactored to thin dispatcher + knowledge-extractor KG Entry Extraction Mode)
 **Purpose:** Keep knowledge graph synchronized with lessons-learned via extraction and linking
 **Architecture:** LEVERAGE lessons (not replace) - quick ref + deep dive + persistent context together
-**Success Criteria:** All recent lessons have corresponding quick-reference knowledge entries with valid bidirectional links + MEMORY.md updates when governance criteria met
+**Success Criteria:** All recent lessons have corresponding quick-reference knowledge entries with valid bidirectional links. Governance-worthy lessons are flagged in output for capture at session wrap.

--- a/knowledge/decisions/ADR-048-governance-capture-routing.md
+++ b/knowledge/decisions/ADR-048-governance-capture-routing.md
@@ -1,0 +1,55 @@
+---
+id: ADR-048
+title: Governance Capture Routing — update-graph flag-only, session-wrap as action point
+status: Accepted
+date: 2026-05-05
+implements: "d9b0e523 — feat(agents): replace Step 8 MEMORY.md write with governance flag output"
+---
+
+# ADR-048: Governance Capture Routing
+
+## Context
+
+`update-graph` (via `knowledge-extractor` Step 8) previously wrote governance-worthy
+content from lessons directly to `MEMORY.md`. This was the original persistent
+governance store. The governance store has since migrated to a three-file profile
+bundle (`rules.md`, `me.md`, `triggers.md`). `MEMORY.md` remains valid as Claude's
+auto-memory index but is no longer a governance write target.
+
+Two additional gaps were identified:
+1. `rules-capture` skill did not check whether a new rule also needed a trigger entry
+   (`rules.md` + `triggers.md` are a coupled pair — a rule without a trigger is incomplete).
+2. `session-wrap` used technical file-name language in its governance signal, which
+   is not appropriate for non-technical users.
+
+## Decision
+
+1. **update-graph Step 8** detects governance-worthy content but emits a plain-language
+   flag in output only — no file writes. Token limit logic removed.
+
+2. **session-wrap** is the action point for governance capture. It surfaces a
+   plain-language reminder when governance signals were flagged or rules were captured.
+
+3. **rules-capture** checks for trigger pairing after writing a rule: phase-specific
+   rules (containing "before/after/when/at/during" language) prompt the user in plain
+   language; unconditional rules ("always/never") skip the prompt silently. Matched
+   trigger entries are written to `triggers.md` at the same level (project/user) as
+   the rule.
+
+4. All stale governance-role `MEMORY.md` references in commands are audited and
+   replaced with language reflecting the current model.
+
+5. No user-facing prompt exposes file names (`rules.md`, `triggers.md`, `MEMORY.md`).
+   All user-facing language describes behavior and situations only.
+
+## Consequences
+
+- `update-graph` is simpler and more focused (KG entries only).
+- Governance capture requires deliberate user action at session end rather than
+  automatic mid-session writes.
+- `rules` + `trigger` pairs are captured together in the same flow, reducing orphaned
+  rules without corresponding trigger conditions.
+- Non-technical users experience plain-language prompts without internal file name
+  exposure.
+- `MEMORY.md` staleness checks in `status.md` are preserved — the file still exists
+  as Claude's auto-memory index.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "knowledge-graph-plugin",
-  "version": "0.5.5",
+  "version": "0.5.6",
   "description": "Structured knowledge capture and cross-session memory for Claude Code projects.",
   "files": [
     ".claude-plugin/",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,8 @@
   "overrides": {
     "follow-redirects": ">=1.16.0",
     "serialize-javascript": ">=7.0.5",
-    "dompurify": ">=3.4.0"
+    "dompurify": ">=3.4.0",
+    "handlebars": ">=4.7.9"
   },
   "dependencies": {
     "@docusaurus/plugin-client-redirects": "^3.10.0",

--- a/skills/rules-capture/SKILL.md
+++ b/skills/rules-capture/SKILL.md
@@ -303,6 +303,24 @@ context:
   agents_present: true                # from detection result; always include
 ```
 
+### 5. Check for trigger pairing
+
+After the rule is written, classify whether it is phase-specific or unconditional:
+
+**Phase-specific indicators** (any of these in the rule text):
+- "before [action]", "after [action]", "when [event]", "at [phase]", "during [workflow]"
+
+**If phase-specific:** Surface this prompt to the user:
+
+> "Should this only apply in certain situations — like before pushing, or at the start of a session? Or does it always apply?"
+
+- If the user describes a specific situation: write a corresponding entry to `triggers.md` (project-level: `knowledge/triggers.md`, user-level: `~/.kmgraph/triggers.md`) in the same capture flow. Match the level (project/user) to where the rule was written.
+- If the user says "always" or equivalent: proceed without a trigger entry.
+
+**If unconditional** ("always", "never", applies universally): skip this step silently — no trigger entry needed.
+
+**User-facing language rule:** Never mention `triggers.md`, `rules.md`, or any file name in the prompt. Describe behavior and situations only.
+
 ## Do NOT
 
 - Ask clarifying questions before showing the suggestion (suggestion comes first)

--- a/skills/session-wrap/SKILL.md
+++ b/skills/session-wrap/SKILL.md
@@ -14,7 +14,8 @@
 - `docs/plans/*.md` contains unchecked `- [ ]` items (mid-plan indicator)
 - `knowledge/decisions/*.md` has ADRs with `Status: Proposed` or `Status: Draft` (open decisions)
 - Recent commits have lesson-worthy keywords (`fix`, `solved`, `implement`, `pattern`, `debug`, `refactor`) but no corresponding lesson file in `knowledge/lessons-learned/`
-- Rules were captured to `knowledge/rules.md` or `knowledge/me.md` this session: surface "N rule(s) captured this session — run `/kmgraph:recall` to review rules.md for drift or conflicts."
+- Rules were captured to `knowledge/rules.md` or `knowledge/me.md` this session: surface "You established N guideline(s) this session. Worth checking whether any of them only apply in specific situations."
+- Governance signals were flagged by update-graph this session (lesson output contained governance flag) but no rules were captured: surface "Some lessons this session might be worth saving as guidelines. Want to capture them before wrapping up?"
 
 **Block Conditions:**
 - Stop hook coordination flag exists: `/tmp/.kg-session-summarized-{kg-name}-{date}` — if present, do NOT prompt (Stop hook already fired; avoid double-prompting)


### PR DESCRIPTION
## Summary

- Removes MEMORY.md write logic from knowledge-extractor Step 8 — replaced with plain-language flag output only
- Adds rules+trigger pairing check to rules-capture skill (phase-specific rules prompt for trigger conditions in plain language)
- Extends session-wrap governance signal with plain-language prompts (no file names exposed to users)
- Audits and removes stale governance-role MEMORY.md references from sync-all, update-doc, status, init
- Pins handlebars >=4.7.9 via overrides to resolve CVE-2026-33937 (Docusaurus build chain, not plugin runtime)
- Creates ADR-048 for governance capture routing decision
- Bumps version to 0.5.6

## What stays unchanged

- MEMORY.md itself (still exists as Claude's auto-memory index)
- archive-memory, restore-memory commands (operate on the index, still valid)
- mcp-server search and resource references to MEMORY.md (index role, still valid)
- knowledge-extractor Steps 1–7 (KG entry pipeline untouched)

## Test plan

- [ ] Run `/kmgraph:update-graph` after capturing a lesson — confirm no MEMORY.md writes occur, governance flag appears in output when lesson is governance-worthy
- [ ] Trigger rules-capture with a phase-specific rule ("before pushing, always X") — confirm trigger pairing prompt appears in plain language with no file names
- [ ] Trigger rules-capture with an unconditional rule ("always use conventional commits") — confirm no trigger prompt appears
- [ ] Run `/kmgraph:session-summary` after a session where rules were captured — confirm new plain-language signal appears
- [ ] Run `/kmgraph:status` — confirm MEMORY.md staleness check still runs, help text is updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)