### PR TITLE
fix: v0.5.7 — enforce approval + PR gates for superpowers planning and execution skills

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "kmgraph",
-  "version": "0.5.6",
+  "version": "0.5.7",
   "description": "Structured knowledge capture, lesson-learned documentation, and cross-session memory for Claude Code projects. Includes KG entries, ADRs, meta-issue tracking, chat extraction, and MEMORY.md bidirectional sync.",
   "author": {
     "name": "technomensch",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Released]
 
+## [0.5.6] — 2026-05-05
+
+### Changed
+- `update-graph` (knowledge-extractor Step 8): removed MEMORY.md write logic; governance-worthy content now emits a plain-language flag in output only — no file writes
+- `rules-capture` skill: added trigger pairing check after rule write — phase-specific rules prompt user in plain language; unconditional rules skip silently
+- `session-wrap` skill: replaced technical file-name language in governance signal with plain-language prompts; added second signal for sessions where governance was flagged but no rules were captured
+- `sync-all`, `update-doc`, `status`, `init`: audited and removed stale governance-role MEMORY.md references
+
+### Fixed
+- Pinned `handlebars >=4.7.9` via overrides to resolve CVE-2026-33937 (Docusaurus build-chain dependency)
+
+### Added
+- ADR-048: documents governance capture routing decision (update-graph → session-wrap as action point)
+
 ## [0.5.5] — 2026-04-29
 
 ### Fixed

--- a/agents/sync-all-agent.md
+++ b/agents/sync-all-agent.md
@@ -56,14 +56,13 @@ find ${kg_path}/lessons-learned -name "*.md" -newer .claude/last-sync-timestamp 
 find ${kg_path}/lessons-learned -name "*.md" -mtime -1
 ```
 
-**Context-mode optimization:** If available, combine scan and MEMORY.md size check:
+**Context-mode optimization:** If available, combine scans:
 
 ```
 ctx_batch_execute(commands: [
   { label: "scan-lessons", command: "find ${kg_path}/lessons-learned -name '*.md' -mtime -1" },
-  { label: "scan-sessions", command: "find ${kg_path}/sessions -name '*.md' -mtime -1" },
-  { label: "memory-size", command: "wc -w < ${memory_path}" }
-], queries: ["new lessons found", "MEMORY.md token count"])
+  { label: "scan-sessions", command: "find ${kg_path}/sessions -name '*.md' -mtime -1" }
+], queries: ["new lessons found"])
 ```
 
 If no new lessons found, also check for:
@@ -113,43 +112,13 @@ If `--dry-run`: Show what would be created/updated but do not write.
 
 ---
 
-## Step 2.5: MEMORY.md Size Check
+## Step 3: Check Governance Signal Status
 
-Before syncing to MEMORY.md, check size limits:
+Check whether update-graph flagged governance signals this session that have not yet been captured via rules-capture.
 
-```bash
-memory_path=~/.claude/projects/$(basename $(pwd))/memory/MEMORY.md
+If governance signals were flagged and no rules were captured: note for session-wrap to surface the plain-language prompt to the user.
 
-if [ -f "$memory_path" ]; then
-  memory_words=$(wc -w < "$memory_path")
-  memory_tokens=$((memory_words * 13 / 10))
-
-  if [ "$memory_tokens" -gt 2000 ]; then
-    echo "MEMORY.md exceeds hard limit: ~${memory_tokens}/2,000 tokens"
-    echo "MEMORY.md token limit reached — consider reviewing and trimming entries manually"
-    SKIP_MEMORY_SYNC=true
-  elif [ "$memory_tokens" -gt 1500 ]; then
-    echo "MEMORY.md approaching limit: ~${memory_tokens}/2,000 tokens"
-    SKIP_MEMORY_SYNC=false
-  else
-    SKIP_MEMORY_SYNC=false
-  fi
-else
-  SKIP_MEMORY_SYNC=false
-fi
-```
-
----
-
-## Step 3: Check MEMORY.md Sync (ADR-011 Protocol)
-
-If new patterns, gotchas, or best practices were discovered:
-1. Check size limits (Step 2.5) — skip if hard limit exceeded
-2. Check if MEMORY.md already has the information
-3. If not and within limits, append to appropriate section
-4. Verify token count after update
-
-If `--dry-run`: Report what would be synced to MEMORY.md.
+If `--dry-run`: Report governance signal status without any action.
 
 ---
 
@@ -227,7 +196,7 @@ Knowledge Sync Complete
 -----------------------
 Lessons scanned:  N (X new, Y modified)
 KG entries:       X created, Y updated
-MEMORY.md:        Updated (N new patterns) | Skipped (over limit) | No changes
+Governance:       N signal(s) flagged (review at session wrap) | No signals
 Plan linked:      [plan name] ([task] linked) | No active plan
 Local issue:      [issue-id] (updated) | None found
 GitHub:           #[N] (comment posted) | Skipped (no remote)
@@ -248,7 +217,7 @@ DRY RUN — No changes made
 
 This agent is idempotent — running multiple times produces the same result:
 - Existing KG entries are updated, not duplicated
-- MEMORY.md checks for existing content before adding
+- Governance signals are checked before flagging (no duplicate flags per lesson)
 - GitHub comments include timestamps to prevent duplicate posts
 - Plan links are checked before adding
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "knowledge-graph-plugin",
-  "version": "0.5.6",
+  "version": "0.5.7",
   "description": "Structured knowledge capture and cross-session memory for Claude Code projects.",
   "files": [
     ".claude-plugin/",

--- a/skills/gov-plan-gate/SKILL.md
+++ b/skills/gov-plan-gate/SKILL.md
@@ -1,0 +1,27 @@
+# Skill: gov-plan-gate
+
+**Purpose:** Enforce the Approval Gate after any planning skill completes — require explicit "Proceed" or "Start" before implementation begins.
+
+**Trigger Keywords:**
+- Plan file just saved / written
+- "superpowers:writing-plans" or "superpowers:brainstorming" completed
+- "plan complete" / "plan saved" / "plan ready" in conversation
+- Any mention of execution options after planning
+
+**Behavior:**
+
+After a plan file is written, output ONLY this message:
+
+> "Plan saved at `<path>`. Review it, then say **Proceed** or **Start** to continue."
+
+Then STOP. Do not:
+- Ask "Which approach?"
+- Offer "Subagent-Driven" or "Inline Execution" options
+- Begin any implementation steps
+- Ask clarifying questions about execution
+
+**Gate Rule (from ~/.kmgraph/rules.md):**
+> "Wait for explicit 'Proceed' or 'Start' before beginning a new branch or implementation task."
+> "Wait for user confirmation after any 'Next Steps' summary."
+
+This gate applies to ALL planning outputs regardless of which skill wrote the plan.

--- a/skills/gov-plan-gate/SKILL.md
+++ b/skills/gov-plan-gate/SKILL.md
@@ -1,27 +1,35 @@
 # Skill: gov-plan-gate
 
-**Purpose:** Enforce the Approval Gate after any planning skill completes — require explicit "Proceed" or "Start" before implementation begins.
+**Purpose:** Enforce user approval gates after superpowers planning and execution skills complete — require explicit "Proceed" or "Start" before implementation begins, and explicit approval before any push or PR.
 
 **Trigger Keywords:**
 - Plan file just saved / written
 - "superpowers:writing-plans" or "superpowers:brainstorming" completed
 - "plan complete" / "plan saved" / "plan ready" in conversation
 - Any mention of execution options after planning
+- "superpowers:executing-plans" or "superpowers:finishing-a-development-branch" completed
+- About to push, create PR, or merge
 
 **Behavior:**
 
-After a plan file is written, output ONLY this message:
+**After a plan file is written**, output ONLY:
 
 > "Plan saved at `<path>`. Review it, then say **Proceed** or **Start** to continue."
 
-Then STOP. Do not:
+**Before pushing or opening a PR**, output ONLY:
+
+> "Ready to push `<branch>` and open PR. Say **Proceed** to continue."
+
+Then STOP in both cases. Do not:
 - Ask "Which approach?"
 - Offer "Subagent-Driven" or "Inline Execution" options
+- Run `git push` or `gh pr create` without explicit approval
 - Begin any implementation steps
-- Ask clarifying questions about execution
+- Ask clarifying questions about execution mode
 
-**Gate Rule (from ~/.kmgraph/rules.md):**
+**Gate Rules (from ~/.kmgraph/rules.md):**
 > "Wait for explicit 'Proceed' or 'Start' before beginning a new branch or implementation task."
+> "Stop and ask before pushing, creating PRs, merging, or any other action visible to others."
 > "Wait for user confirmation after any 'Next Steps' summary."
 
-This gate applies to ALL planning outputs regardless of which skill wrote the plan.
+These gates apply to ALL planning and execution outputs regardless of which skill ran.

--- a/skills/knowledge-graph-usage/SKILL.md
+++ b/skills/knowledge-graph-usage/SKILL.md
@@ -247,7 +247,7 @@ Context: User just completed /kmgraph:capture-lesson
 Proactive suggestion:
 "✅ Lesson captured! Extract insights to Knowledge Graph?"
 - Recommended: /kmgraph:update-graph (extracts patterns/gotchas/concepts)
-- Full pipeline: /kmgraph:sync-all (extraction + MEMORY.md + GitHub)
+- Full pipeline: /kmgraph:sync-all (extraction + governance check + GitHub)
 - Later: Skip for now, run manually later
 
 Why now: Fresh context enables better extraction. The knowledge-reviewer


### PR DESCRIPTION
## Summary

- Strengthened `pre-skill-rules-inject.sh` PreToolUse hook to cover both skill families (planning + execution); added `SKILL_TYPE` detection; injects skill-type-specific hard blocks — Execution Handoff Override (blocks "Which approach?") for planning skills, PR Gate Override (blocks auto-push/PR) for execution skills
- Added `stop-plan-gate.sh` Stop hook safety net: fires at turn end when a plan was just written, re-injects approval gate reminder
- Wired Stop hook in `~/.claude/settings.json`
- Promoted `gov-plan-gate` to kmgraph plugin skill (`skills/gov-plan-gate/SKILL.md`) — now appears as `kmgraph:gov-plan-gate` in the available-skills index
- Deleted dead shadow skills (`~/.claude/skills/writing-plans.md`, `~/.claude/skills/gov-plan-gate.md`) — personal-directory skills can't override plugin-namespaced skills in Claude Code
- Amended ADR-004 with v2 fix documentation (root cause analysis + lesson)
- Folded v0.5.6 governance audit stragglers: `sync-all-agent` (remove MEMORY.md size check + sync step), `knowledge-graph-usage` skill (update sync-all description), `CHANGELOG.md` (add missing v0.5.6 entry)

## Root cause (ADR-004 v1 failure)

The prior fix created personal-directory shadow skills that could never override plugin-namespaced skills and never appeared in the available-skills index. The PreToolUse hook injected context but didn't block the `## Execution Handoff` section of the skill, which overrode injected instructions at generation time.

## Test plan

- [ ] Invoke `superpowers:writing-plans` — confirm response ends with plan-ready message, NOT "Which approach?" or "Two execution options"
- [ ] Invoke `superpowers:executing-plans` — confirm push/PR step stops for explicit approval, does NOT auto-push
- [ ] Confirm `kmgraph:gov-plan-gate` appears in available-skills index after session restart
- [ ] Confirm `~/.claude/skills/writing-plans.md` and `~/.claude/skills/gov-plan-gate.md` no longer exist

🤖 Generated with [Claude Code](https://claude.com/claude-code)