### PR TITLE
docs(updates): add page structure alignment section to restructure post

### DIFF
--- a/docs-updates/2026-05-05-site-restructure-v2.mdx
+++ b/docs-updates/2026-05-05-site-restructure-v2.mdx
@@ -40,6 +40,17 @@ The home page now leads with a pillar card grid immediately after the install he
 - `4-PILLARS.md` and `4-LAYERS.md` moved to `docs/concepts/` as proper concept pages
 - `COMMAND-GUIDE.md` moved to `docs/reference/command-guide.md`
 - `CONCEPTS.md` decomposed into four focused concept pages
+- `capture-from-bugfix.md` merged into `capture-lessons-learned.md` — one canonical capture page
+
+## Page structure alignment
+
+All 24 pillar pages were aligned to a consistent internal structure:
+
+- Blockquote framing question immediately after H1
+- `## Goal`, `## Prerequisites`, `## Steps`, `## Verify` boilerplate removed — content folded into conceptual H2s
+- Heavy reference material moved to `## Reference` appendices (after `---`)
+- `## Related` last on every page, with descriptive em-dash link labels
+- `search-the-graph.md` rewritten from a prose essay to a structured H2 page
 
 ## What didn't change
 


### PR DESCRIPTION
## Summary

- Adds a "Page structure alignment" section to the 2026-05-05 docs-updates post covering the structural consistency pass done across all 24 pillar pages (blockquotes, boilerplate removal, Reference appendices, Related cleanup)

🤖 Generated with [Claude Code](https://claude.com/claude-code)