### PR TITLE
feat(governance): v0.5.9.1 — Review Audit Protocol, ENH-016, hook fixes

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "kmgraph",
-  "version": "0.5.9",
+  "version": "0.5.9.1",
   "description": "Structured knowledge capture, lesson-learned documentation, and cross-session memory for Claude Code projects. Includes KG entries, ADRs, meta-issue tracking, chat extraction, and profile-file rule capture.",
   "author": {
     "name": "technomensch",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `core/rules-registry/review-audit-protocol.md`, `core/templates/.../governance-rules.md`, `~/.kmgraph/governance-rules.md`, `scripts/pre-skill-rules-inject.sh`: HALT ambiguity — Step 4 was interpreted as stop-per-finding with bare "proceed?"; clarified to ONE halt after complete audit trail; decision blocks now require finding description, severity, recommended action, and decision options
 
 ### Knowledge Graph
+- issue-7: Bash permission prompt UX bug tracked — solution designed for v0.6.0 (`knowledge/issues/issue-7/`)
 - ADR-049: Review Audit Protocol — Post-Plan/Pre-Push Review Governance (Accepted; branch updated to `v0.5.9.1-review-audit-protocol`)
 - ENH-019 spec committed (deferred, no implementation in this release)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Released]
 
-## [0.5.9.1] — 2026-05-28
+## [0.5.9.1] — 2026-05-28 (rev 2)
 
 ### Added
 - `core/rules-registry/review-audit-protocol.md`: canonical rule source for post-plan/pre-push review governance — full protocol (4 steps), 5 decision options, cascade check stub, audit trail table format
@@ -29,6 +29,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `scripts/pre-skill-rules-inject.sh`: review skill matchers added (`caveman:caveman-review`, `pr-review-toolkit:*`, `code-review`); Review Audit Protocol HARD BLOCK injected; review-specific trigger sections extracted from triggers.md
 - ENH-016 status updated: Planned → In Progress
 - ENH-015: added "Related ENHs / Known Gaps" section cross-referencing ENH-020
+
+### Fixed
+- `core/rules-registry/review-audit-protocol.md`, `core/templates/.../governance-rules.md`, `~/.kmgraph/governance-rules.md`, `scripts/pre-skill-rules-inject.sh`: HALT ambiguity — Step 4 was interpreted as stop-per-finding with bare "proceed?"; clarified to ONE halt after complete audit trail; decision blocks now require finding description, severity, recommended action, and decision options
 
 ### Knowledge Graph
 - ADR-049: Review Audit Protocol — Post-Plan/Pre-Push Review Governance (Accepted; branch updated to `v0.5.9.1-review-audit-protocol`)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Released]
 
+## [0.5.9.1] — 2026-05-28
+
+### Added
+- `core/rules-registry/review-audit-protocol.md`: canonical rule source for post-plan/pre-push review governance — full protocol (4 steps), 5 decision options, cascade check stub, audit trail table format
+- `core/templates/knowledge/templates/user/governance-rules.md`: genericized governance-rules template for distributed users (strips personal ENH refs)
+- `knowledge/enhancements/ENH-020/`: spec for Preventive Cascade Template + Profile Ecosystem Docs (status: deferred; extends ENH-015)
+- `scripts/rules-size-check.sh`: PostToolUse hook — fires after writing rules files; recommends split when >120 lines AND 2+ separable domains; weekly suppression via flag file
+- ENH-016 line-count check in `scripts/hooks-master.sh`: SessionStart split recommendation for `~/.kmgraph/rules.md` exceeding threshold
+
+### Changed
+- `hooks/hooks.json`: post-plan-validate-checklist matcher extended from `Write` to `Write|Edit`; lesson-check matcher extended from `Write|Edit` to `Write|Edit|Bash`; new `rules-size-check.sh` PostToolUse hook added
+- `scripts/post-plan-validate-checklist.sh`: added idempotency gate (session-scoped flag file per plan path) to suppress checklist spam on iterative edits
+- `scripts/post-tool-lesson-check.sh`: Bash-tool path added — detects lesson signals in Bash output (requires 2+ of: bug/resolved/workaround); suppresses on `git commit`
+- `scripts/pre-skill-rules-inject.sh`: review skill matchers added (`caveman:caveman-review`, `pr-review-toolkit:*`, `code-review`); Review Audit Protocol HARD BLOCK injected; review-specific trigger sections extracted from triggers.md
+- ENH-016 status updated: Planned → In Progress
+- ENH-015: added "Related ENHs / Known Gaps" section cross-referencing ENH-020
+
+### Knowledge Graph
+- ADR-049: Review Audit Protocol — Post-Plan/Pre-Push Review Governance (Accepted; branch updated to `v0.5.9.1-review-audit-protocol`)
+- ENH-019 spec committed (deferred, no implementation in this release)
+
 ## [0.5.9] — 2026-05-27
 
 ### Added

--- a/core/rules-registry/review-audit-protocol.md
+++ b/core/rules-registry/review-audit-protocol.md
@@ -1,0 +1,92 @@
+# Review Audit Protocol
+
+**Source:** `core/rules-registry/review-audit-protocol.md`
+**Personal deployment:** `~/.kmgraph/governance-rules.md § Review Audit Protocol`
+**Distributed deployment:** `core/templates/knowledge/templates/user/governance-rules.md`
+
+---
+
+## Trigger
+
+Fires for:
+- Post-plan audit (before pushing a completed branch)
+- Pre-push review (final check before `git push`)
+- PR audit (reviewing an open pull request)
+- Any explicit "full review" or "audit" request
+
+Does NOT fire for:
+- Casual inspection ("does this look right?", "review this file", "what do you think?")
+- Inline quick checks during implementation
+
+---
+
+## Protocol
+
+### Step 1: Complete review pass without interruption
+
+Perform the full review pass top-to-bottom without stopping. For each finding that warrants investigation, dispatch a background agent (`cavecrew-investigator` or appropriate subagent type) as you go. Do NOT stop to discuss, implement, or wait for agent results mid-pass.
+
+### Step 2: Batched recall gate (after pass completes)
+
+Present findings list and ask:
+
+> "Run recall to check for prior context on any before deciding? **[all / select / skip]**"
+
+Batch all selected findings into a single recall call. Do not run recall per-finding.
+
+### Step 3: Display all results inline
+
+Show agent investigation reports and recall results inline in the conversation. Do not collapse, summarize into headings only, or redirect to external files. Full content visible.
+
+### Step 4: Present audit trail table and decision prompt — HALT
+
+Display the audit trail table (format below) and the decision prompt for each finding. Stop and wait for user decisions. Do not proceed to implementation until the user resolves all findings.
+
+---
+
+## Decision Options (per finding)
+
+| Option | Meaning | Protocol |
+|--------|---------|----------|
+| `fix now` | Fix immediately | Run cascade check stub first (see below); agent implements; review resumes after fix |
+| `ignore` | Dismiss intentionally | Record in audit trail with reason; review continues |
+| `track` | Route to issue tracking | Invoke `/kmgraph:start-issue-tracking`; review resumes |
+| `dig deeper` | Investigate further | Agent investigates; return to finding after report |
+| `discuss` | Open focused discussion | Take session snapshot first (`/kmgraph:session-summary --snapshot`); then discuss; resume review after |
+
+---
+
+## Cascade Check Stub (fires before `fix now`)
+
+Before implementing any fix found during review, ask:
+
+1. Does this change affect initialization scripts, user profile files, or existing graphs?
+2. Is this user-local or project-wide?
+3. Which tiers / platforms does this affect?
+
+Defer to active governance framework for full protocol:
+- **Now:** ENH-015 Decision Governance Protocol (`~/.kmgraph/governance-rules.md`)
+- **When complete:** ENH-020 Preventive Cascade Template + Profile Ecosystem Docs
+
+If any question is YES or UNKNOWN, classify scope before proceeding. Do not start implementation until scope is clear.
+
+---
+
+## Final Report Format
+
+Present after all decisions are made:
+
+| Finding | Severity | Recall match | Decision | Status |
+|---------|----------|--------------|----------|--------|
+| _description_ | critical / high / medium / low | yes / no | fix now / ignore / track / dig deeper / discuss | resolved / open / deferred |
+
+All findings included regardless of resolution. Audit trail is permanent — do not omit dismissed items.
+
+---
+
+## Related
+
+- ADR-049: Review Audit Protocol — Post-Plan/Pre-Push Review Governance
+- ENH-015: Decision Governance Protocol (cascade framework authority)
+- ENH-020: Preventive Cascade Template + Profile Ecosystem Docs (pending)
+- `~/.kmgraph/triggers.md` — trigger condition for this rule

--- a/core/rules-registry/review-audit-protocol.md
+++ b/core/rules-registry/review-audit-protocol.md
@@ -24,7 +24,7 @@ Does NOT fire for:
 
 ### Step 1: Complete review pass without interruption
 
-Perform the full review pass top-to-bottom without stopping. For each finding that warrants investigation, dispatch a background agent (`cavecrew-investigator` or appropriate subagent type) as you go. Do NOT stop to discuss, implement, or wait for agent results mid-pass.
+Perform the full review pass top-to-bottom without stopping. For each finding that warrants investigation, dispatch a background agent (`cavecrew-investigator` or appropriate subagent type) as you go. Do NOT stop to discuss, implement, or wait for agent results mid-pass. Do NOT ask 'proceed?' mid-review.
 
 ### Step 2: Batched recall gate (after pass completes)
 
@@ -38,9 +38,23 @@ Batch all selected findings into a single recall call. Do not run recall per-fin
 
 Show agent investigation reports and recall results inline in the conversation. Do not collapse, summarize into headings only, or redirect to external files. Full content visible.
 
-### Step 4: Present audit trail table and decision prompt — HALT
+### Step 4: Present complete audit trail — HALT ONCE
 
-Display the audit trail table (format below) and the decision prompt for each finding. Stop and wait for user decisions. Do not proceed to implementation until the user resolves all findings.
+After all agent reports and recall results are displayed, present the COMPLETE audit trail table covering ALL findings. This is a single halt, not one per finding.
+
+For each finding, present a structured decision block:
+
+---
+**Finding [N]: [one-line description]**
+**Severity:** [critical / high / medium / low]
+**Detail:** [what was found — specific file:line or behavior]
+**Recommended action:** [specific fix or recommendation]
+**Decision:** fix now / ignore / track / dig deeper / discuss
+---
+
+HALT after the full table. Wait for the user to respond with a decision for each finding before implementing anything.
+
+Do NOT stop mid-review to ask about individual findings. Do NOT ask bare "proceed?" questions. Every halt must include the finding description and recommended action.
 
 ---
 

--- a/core/rules-registry/review-audit-protocol.md
+++ b/core/rules-registry/review-audit-protocol.md
@@ -24,7 +24,7 @@ Does NOT fire for:
 
 ### Step 1: Complete review pass without interruption
 
-Perform the full review pass top-to-bottom without stopping. For each finding that warrants investigation, dispatch a background agent (`cavecrew-investigator` or appropriate subagent type) as you go. Do NOT stop to discuss, implement, or wait for agent results mid-pass. Do NOT ask 'proceed?' mid-review.
+Perform the full review pass top-to-bottom without stopping. For each finding that warrants investigation, dispatch a background read-only subagent as you go. Do NOT stop to discuss, implement, or wait for agent results mid-pass. Do NOT ask 'proceed?' mid-review.
 
 ### Step 2: Batched recall gate (after pass completes)
 

--- a/core/templates/knowledge/templates/user/governance-rules.md
+++ b/core/templates/knowledge/templates/user/governance-rules.md
@@ -1,0 +1,92 @@
+# Rules — Governance
+
+> Quick navigation: [Review Audit Protocol](#review-audit-protocol) · [Plan Execution Strict Mode](#plan-execution--strict-mode) · [Review Protocol](#review-protocol)
+
+---
+
+## Review Audit Protocol
+
+> **Source:** `core/rules-registry/review-audit-protocol.md`
+
+### Trigger
+
+Fires for: post-plan audit (before pushing), pre-push review, PR audit, explicit "full review" or "audit" request.
+Does NOT fire for casual inspection ("does this look right?", "review this file").
+
+### Protocol
+
+1. **Complete review pass without interruption.** For each finding needing investigation, dispatch a background agent as you go. Do NOT stop to discuss, implement, or wait for results mid-pass.
+2. **Batched recall gate** (after pass): present findings list, ask: *"Run recall to check for prior context? [all / select / skip]"* — batch all selected findings into one recall call.
+3. **Display results inline** — agent reports and recall results shown inline, not collapsed.
+4. **Present audit trail table + decision prompt per finding — HALT.** Stop and wait for user decisions before any implementation.
+
+### Decision Options (per finding)
+
+| Option | Action |
+|--------|--------|
+| `fix now` | Run cascade check stub first; implement; resume |
+| `ignore` | Dismiss and record in audit trail with reason |
+| `track` | Route to issue tracking; resume |
+| `dig deeper` | Agent investigates; return after report |
+| `discuss` | Session snapshot first; discuss; resume |
+
+### Cascade Check Stub (fires before `fix now`)
+
+Before implementing any fix, ask:
+1. Does this change affect initialization scripts, user profile files, or existing graphs?
+2. Is this user-local or project-wide?
+3. Which tiers / platforms does this affect?
+
+Defer to your active governance framework for full cascade protocol.
+
+### Final Report Format
+
+| Finding | Severity | Recall match | Decision | Status |
+|---------|----------|--------------|----------|--------|
+
+All findings included regardless of resolution. Audit trail is permanent.
+
+---
+
+## Plan Execution — Strict Mode
+
+> **Trigger:** "execute plan", "implement plan", "start [plan-file]", or any reference to a plan file
+
+When triggered, enter strict execution mode and enforce this protocol:
+
+```
+═══════════════════════════════════════════════════════════════
+STRICT EXECUTION MODE
+Allowed: File read, file edit, file write, shell (verification only)
+Forbidden: Improvements, assumptions, gap-filling, unauthorized fixes
+═══════════════════════════════════════════════════════════════
+```
+
+**8-step protocol:**
+
+1. **State Initialization** — Output STRICT EXECUTION MODE banner before any action
+2. **Literal Mapping** — Quote each plan instruction before executing (no assumptions)
+3. **Data Integrity Audit** — Read file after every edit; verify ONLY plan-specified changes were made. Revert if unauthorized additions found.
+4. **HALT on Ambiguity** — Output HALT block if plan is unclear. Stop and ask user for clarification.
+5. **Checkpoints** — After every 3 file edits, output checkpoint and await user acknowledgment before continuing.
+6. **Rollback Protocol** — If integrity audit fails, revert file and re-apply. If second attempt fails, trigger HALT.
+7. **Completion Verification** — Quote each success criterion and verify it. Output completion status.
+8. **Commit Gate** — After all tasks complete, create conventional commit with issue reference.
+
+**Mid-execution discovery protocol:** Do NOT silently fix OR silently skip discoveries outside the plan. Every discovery requires a decision.
+
+---
+
+## Review Protocol
+
+### ADR Pre-Check Before Surfacing a Finding
+
+> **When:** Before reporting any finding during a plan review, code review, remediation, or post-mortem
+
+Before surfacing a finding, search the project's `knowledge/decisions/` for ADRs that cover the same topic:
+
+1. **Match found — finding fully addressed:** suppress the finding; note the ADR
+2. **Match found — finding presents new evidence:** surface the finding and explicitly reference the ADR
+3. **No match:** surface the finding normally
+
+A finding that duplicates a closed decision without new evidence is noise, not a valid finding.

--- a/core/templates/knowledge/templates/user/governance-rules.md
+++ b/core/templates/knowledge/templates/user/governance-rules.md
@@ -15,10 +15,10 @@ Does NOT fire for casual inspection ("does this look right?", "review this file"
 
 ### Protocol
 
-1. **Complete review pass without interruption.** For each finding needing investigation, dispatch a background agent as you go. Do NOT stop to discuss, implement, or wait for results mid-pass.
+1. **Complete review pass without interruption.** For each finding needing investigation, dispatch a background agent as you go. Do NOT stop to discuss, implement, or wait for results mid-pass. Do NOT ask "proceed?" mid-review.
 2. **Batched recall gate** (after pass): present findings list, ask: *"Run recall to check for prior context? [all / select / skip]"* — batch all selected findings into one recall call.
 3. **Display results inline** — agent reports and recall results shown inline, not collapsed.
-4. **Present audit trail table + decision prompt per finding — HALT.** Stop and wait for user decisions before any implementation.
+4. **Present COMPLETE audit trail — HALT ONCE.** After displaying all results, present the full audit trail table covering ALL findings at once. For each finding, include a structured decision block: finding description, severity, recommended action, and decision options. HALT after the full table — do NOT stop mid-review per finding. Do NOT ask bare "proceed?" questions.
 
 ### Decision Options (per finding)
 

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -15,11 +15,11 @@
     ],
     "PostToolUse": [
       {
-        "matcher": "Write|Edit",
+        "matcher": "Write|Edit|Bash",
         "hooks": [
           {
             "type": "command",
-            "comment": "After file writes: check for lesson-worthy signals and prompt capture",
+            "comment": "After file writes or Bash: check for lesson-worthy signals and prompt capture",
             "command": "${CLAUDE_PLUGIN_ROOT}/scripts/post-tool-lesson-check.sh",
             "timeout": 10
           }
@@ -48,12 +48,23 @@
         ]
       },
       {
-        "matcher": "Write",
+        "matcher": "Write|Edit",
         "hooks": [
           {
             "type": "command",
-            "comment": "After writing a plan file: output Post-Plan Validation Checklist as advisory reminder",
+            "comment": "After writing or editing a plan file: output Post-Plan Validation Checklist as advisory reminder",
             "command": "${CLAUDE_PLUGIN_ROOT}/scripts/post-plan-validate-checklist.sh",
+            "timeout": 5
+          }
+        ]
+      },
+      {
+        "matcher": "Write|Edit",
+        "hooks": [
+          {
+            "type": "command",
+            "comment": "After writing a rules file: check if line count exceeds split threshold and recommend split",
+            "command": "${CLAUDE_PLUGIN_ROOT}/scripts/rules-size-check.sh",
             "timeout": 5
           }
         ]

--- a/knowledge/decisions/ADR-049-review-audit-protocol-post-plan-pre-push-review-governance.md
+++ b/knowledge/decisions/ADR-049-review-audit-protocol-post-plan-pre-push-review-governance.md
@@ -59,7 +59,7 @@ Implement a formal review audit protocol with the following locked behaviors:
 
 **Cascade check stub:** Before any `fix now` action, ask: does this affect initialization scripts, user profile files, or existing graphs? User-local or project-wide? Full cascade protocol deferred to ENH-015 and ENH-020 (pending creation — see plan task 1.1).
 
-**Halt pattern:** HALT after findings are displayed; resume only after user provides a decision per finding.
+**Halt pattern:** HALT ONCE after the complete audit trail table is displayed — a single halt covering all findings, not one halt per finding. Each decision block must include: finding description, severity, recommended action, and the five decision options. Bare "proceed?" prompts without context are explicitly prohibited.
 
 **Final report:** An audit trail table recording ALL findings regardless of resolution — permanent record required at the end of every audit.
 

--- a/knowledge/decisions/ADR-049-review-audit-protocol-post-plan-pre-push-review-governance.md
+++ b/knowledge/decisions/ADR-049-review-audit-protocol-post-plan-pre-push-review-governance.md
@@ -6,7 +6,7 @@ status: Accepted
 author: technomensch
 email: 917847+technomensch@users.noreply.github.com
 git:
-  branch: v0.5.9-decision-governance
+  branch: v0.5.9.1-review-audit-protocol
   commit: ad7f015188b11392a42a1f37c746a20915ddb915
   pr: null
   issue: null

--- a/knowledge/decisions/ADR-049-review-audit-protocol-post-plan-pre-push-review-governance.md
+++ b/knowledge/decisions/ADR-049-review-audit-protocol-post-plan-pre-push-review-governance.md
@@ -1,0 +1,101 @@
+---
+title: "ADR-049: Review Audit Protocol — Post-Plan/Pre-Push Review Governance"
+number: 049
+created: "2026-05-28T00:00:00Z"
+status: Accepted
+author: technomensch
+email: 917847+technomensch@users.noreply.github.com
+git:
+  branch: v0.5.9-decision-governance
+  commit: ad7f015188b11392a42a1f37c746a20915ddb915
+  pr: null
+  issue: null
+implements: null
+related:
+  adrs:
+    - "[[ADR-043-pretooluse-hook-injection-superpowers-rule-enforcement]]"
+    - "[[ADR-033-triggersmd-platform-agnostic-rule-timing-companion-file]]"
+  lessons: []
+  kg_entries:
+    - ENH-015
+    - ENH-020 (pending)
+  issues:
+    - "[[issue-6]]  — Bug: post-plan validation not enforced (advisory-only hook, static stub); GitHub #125"
+tags:
+  - process
+  - governance
+  - review
+category: process
+---
+
+# ADR-049: Review Audit Protocol — Post-Plan/Pre-Push Review Governance
+
+## Status
+
+Accepted — Implementation pending on branch `v0.5.9.1-review-audit-protocol`.
+
+## Context
+
+During the session on 2026-05-28, a formal review workflow was designed for post-plan/pre-push audits. Previously there was no defined protocol for how findings discovered during reviews should be handled. Reviews would get sidetracked mid-pass as findings were addressed ad-hoc, no audit trail was produced, and recall checks against prior context were left to the reviewer's discretion. This created inconsistent review quality and lost traceability.
+
+## Decision
+
+Implement a formal review audit protocol with the following locked behaviors:
+
+**Trigger scope:** The protocol activates for post-plan/pre-push audits, PR audits, and explicit "full review" or "audit" requests only. It does NOT apply to casual code inspection.
+
+**Non-blocking investigation:** When findings are encountered mid-review, the reviewer must not get sidetracked. Background agents are dispatched to investigate (non-blocking). The full review pass completes first before any findings are acted upon.
+
+**Recall gate:** After the review pass completes, the reviewer presents the findings list and asks: "Run recall to check for prior context? [all / select / skip]" — all selected recalls are batched into one call.
+
+**Display:** Agent reports and recall results are displayed inline, never collapsed.
+
+**Per-finding decision options:**
+- `fix now` — triggers cascade check stub first
+- `ignore` — dismissed and recorded in audit trail
+- `track` — routes to start-issue-tracking
+- `dig deeper` — agent investigates further
+- `discuss` — session snapshot taken first
+
+**Cascade check stub:** Before any `fix now` action, ask: does this affect initialization scripts, user profile files, or existing graphs? User-local or project-wide? Full cascade protocol deferred to ENH-015 and ENH-020 (pending creation — see plan task 1.1).
+
+**Halt pattern:** HALT after findings are displayed; resume only after user provides a decision per finding.
+
+**Final report:** An audit trail table recording ALL findings regardless of resolution — permanent record required at the end of every audit.
+
+## Rationale
+
+The absence of a formal review protocol caused reviews to be inconsistent and produced no audit artifacts. Key design choices:
+
+- **Non-blocking investigation over ad-hoc interruption** — completing the full pass before acting ensures comprehensive coverage; partial fixes mid-review risk missing related issues.
+- **Recall gate as explicit step** — batching recall into one decision point avoids context noise and respects reviewer control over when prior knowledge is loaded.
+- **HALT pattern** — prevents silent auto-resolution; each finding requires an explicit user decision, creating accountability and traceability.
+- **Cascade check stub** — lightweight pre-fix gate that surfaces blast radius before committing to a fix, deferring full logic to ENH-015/ENH-020 rather than duplicating it here.
+- **Audit trail table** — ensures permanent record even for "ignore" decisions, supporting future retrospectives.
+
+## Consequences
+
+**Positive:**
+- Reviews produce a consistent, replayable audit trail.
+- No findings are silently dropped or addressed without a recorded decision.
+- Cascade risk is surfaced before fixes are applied.
+- Recall context is loaded efficiently via batching rather than per-finding noise.
+
+**Negative:**
+- Review sessions are longer due to HALT gates and explicit per-finding decisions.
+- Requires reviewers (human or agent) to follow the protocol consistently — enforcement depends on rules deployment.
+
+**Neutral:**
+- Protocol only activates on formal audit triggers, not casual inspection — low overhead for routine work.
+
+## Rule Deployment
+
+The protocol is authored in `core/rules-registry/review-audit-protocol.md` and deployed to:
+- `~/.kmgraph/governance-rules.md` — personal deployment with ENH references by name
+- `core/templates/` — genericized variant planned for v0.5.9.1
+
+## Related
+
+- ENH-015 — Cascade governance framework (full cascade protocol)
+- ENH-020 — Preventive cascade template (extends ENH-015)
+- `v0.5.9.1-review-audit-protocol` — implementation branch

--- a/knowledge/enhancements/ENH-015/ENH-015-specification.md
+++ b/knowledge/enhancements/ENH-015/ENH-015-specification.md
@@ -197,6 +197,23 @@ Pre-v0.5.9: only File Location, Parallelism, Approval Gates, RECALL_HARD_BLOCK, 
 - **kg-recall:** Triggers on retrospective questions ("have we", "did we"). Rule 1 triggers on prospective ("should we"). Complementary, no conflict.
 - **gov-execute-plan zero-deviation constraint:** In-plan cascade check fires as a prerequisite gate BEFORE execution begins — not during. Does not conflict with zero-deviation enforcement.
 
+## Related ENHs / Known Gaps
+
+### ENH-020 — Preventive Cascade Template + Profile Ecosystem Docs
+
+**Status:** Deferred
+
+The cascade rules in ENH-015 fire _post-decision_ (after the user confirms "proceed"), not _pre-implementation_. ENH-020 closes this gap by adding a preventive cascade evaluation step that fires before implementation begins.
+
+**What ENH-020 adds:**
+- Pre-implementation scope classification prompt
+- Profile file ecosystem reference document
+- Initialization impact matrix
+
+Until ENH-020 is implemented, the review-audit-protocol rule (`core/rules-registry/review-audit-protocol.md`) includes a cascade check stub that defers to ENH-015 and ENH-020.
+
+See: `knowledge/enhancements/ENH-020/ENH-020-specification.md`
+
 ## Not In Scope
 
 - Modifying `superpowers:writing-plans` or `superpowers:brainstorming` skill files directly — these are third-party; all enforcement is via the hook layer (`pre-skill-rules-inject.sh`)

--- a/knowledge/enhancements/ENH-016/ENH-016-specification.md
+++ b/knowledge/enhancements/ENH-016/ENH-016-specification.md
@@ -1,7 +1,7 @@
 # ENH-016: Rules File Auto-Split Recommendation
 
 **Status:** Planned
-**Version:** TBD (post-v0.5.9)
+**Version:** v0.5.9.1
 **Created:** 2026-05-25
 
 ## Problem

--- a/knowledge/enhancements/ENH-016/ENH-016-specification.md
+++ b/knowledge/enhancements/ENH-016/ENH-016-specification.md
@@ -1,6 +1,6 @@
 # ENH-016: Rules File Auto-Split Recommendation
 
-**Status:** Planned
+**Status:** In Progress
 **Version:** v0.5.9.1
 **Created:** 2026-05-25
 

--- a/knowledge/enhancements/ENH-019/ENH-019-specification.md
+++ b/knowledge/enhancements/ENH-019/ENH-019-specification.md
@@ -1,0 +1,83 @@
+---
+id: ENH-019
+type: Enhancement
+status: deferred
+github-issue: "TBD"
+branch: "none"
+created: 2026-05-27
+target-release: "TBD (consider for v0.6.0)"
+---
+
+# ENH-019: kmgraph Usage Analytics & Stats Dashboard
+
+## Summary
+
+Add a `/kmgraph:stats` command (and companion `kg_stats` MCP tool) that produces a usage analytics report similar to context-mode's `/ctx-stats` output — surfacing knowledge graph activity, capture patterns, session history, and growth metrics directly in the AI conversation.
+
+## Motivation
+
+The ctx-mode `/ctx-stats` report (seen during the 2026-05-27 session) demonstrated the value of surfacing session-level and cross-session metrics inline. kmgraph has equivalent raw material — capture counts, lesson history, ADR creation dates, plan activity, session summaries — but no way to surface it as a digestible report. A stats command would close that gap and make the knowledge graph's value tangible to users.
+
+## Scope Boundary
+
+**This ENH is intentionally under-specified.** A brainstorming session is required before any implementation begins. Do not design or build until that session is complete.
+
+## What Needs to Be Decided (Brainstorming Session Agenda)
+
+### 1. Data Capture & Storage
+
+**Strong prior constraint:** The current tool stack already includes 3 SQLite DBs — context-mode content DB, context-mode session DB, and the kmgraph FTS5 DB. Adding a 4th for stats would compound maintenance burden and installation complexity. **Derived-only (scan existing markdown files + frontmatter) is the strongly preferred default** — only move to a dedicated DB if derived-only proves too slow or insufficient.
+
+Questions for brainstorm:
+- What data does kmgraph already log implicitly? (capture timestamps, lesson counts, ADR dates, session summary metadata)
+- Is frontmatter + file timestamps sufficient to answer common stat queries without a DB?
+- What would need to be added explicitly? (e.g., per-session capture counts, tool call frequency)
+- If a DB is truly needed: can it reuse the existing FTS5 DB rather than adding a new file?
+- SQLite vs. flat file vs. derived-only? Trade-offs for portability and cross-platform support.
+
+### 2. What Stats Would Users Want to See?
+Potential candidates (to be validated against real usage — see Research Guidance below):
+- Total captures (all-time, last 30 days, this session)
+- Captures by type (lessons, ADRs, plans, session summaries, rules)
+- Active projects count and per-project breakdown
+- Session frequency / average session duration
+- Most-used commands
+- Knowledge graph growth over time (entries added per week/month)
+- "Last seen" for each capture type (when was the last lesson captured?)
+- Cross-platform capture breakdown (Claude Code vs. Gemini CLI vs. MCP direct)
+
+### 3. Display Format
+- Inline text report (like ctx-stats) vs. browser dashboard vs. both?
+- What's the right level of verbosity — one-liner summary vs. full breakdown?
+- Should it support a `--since` flag for time-bounded queries?
+
+## Research Guidance for Brainstorm Session
+
+**Before the brainstorm session, run `/kmgraph:kg-recall` to search prior chat history for:**
+- Sessions where users asked "what have I captured", "how much have I used this", or similar introspective questions
+- Any feedback about visibility into kmgraph activity
+- Real examples of what information users wanted but couldn't get
+
+Search queries to use:
+- `"how many lessons"`, `"capture history"`, `"what did I capture"`
+- `"kmgraph activity"`, `"session count"`, `"knowledge graph stats"`
+- `"ctx-stats"`, `"usage report"`, `"analytics"`
+
+These real-world examples should drive which stats fields are prioritized.
+
+## Relation to v0.6.0
+
+This ENH was identified during v0.5.9 work. Before committing to include it in v0.6.0:
+
+1. Review `docs/plans/v0.6.0-multi-platform-expansion.md` — the primary 0.6.0 plan — to assess fit.
+2. The multi-platform focus of 0.6.0 (8 platforms, npm publish, marketplace submissions) means this feature would need to work cross-platform from day one if shipped in that release.
+3. Cross-platform stats require the storage/capture questions above to be answered first.
+
+**Recommendation:** Hold this ENH until after the 0.6.0 brainstorm session. If the brainstorm concludes the implementation is lightweight and platform-agnostic, it can be folded in. If not, target 0.6.1 or later.
+
+## Files
+
+- `ENH-019-specification.md` — this file
+- `solution-approach.md` — to be written after brainstorm session
+- `test-cases.md` — to be written after brainstorm session
+- `progress-log.md` — to be written at implementation start

--- a/knowledge/enhancements/ENH-020/ENH-020-specification.md
+++ b/knowledge/enhancements/ENH-020/ENH-020-specification.md
@@ -1,0 +1,57 @@
+---
+id: ENH-020
+title: Preventive Cascade Template + Profile Ecosystem Docs
+status: deferred
+priority: medium
+created: 2026-05-28
+branch: v0.5.9.1-review-audit-protocol
+extends: ENH-015
+---
+
+# ENH-020: Preventive Cascade Template + Profile Ecosystem Docs
+
+## Summary
+
+Add a preventive cascade evaluation step that fires _before_ implementation begins, complementing ENH-015's post-decision cascade rules. Includes a canonical reference document for the profile file ecosystem (what each file is, where it lives, which platforms use it).
+
+## Status: Deferred
+
+Requires a dedicated brainstorm session before implementation. This spec captures scope decisions made during 2026-05-27/28 session.
+
+## Problem
+
+ENH-015 cascade rules fire post-decision (after the user says "proceed"), not pre-implementation. There is no gate that asks "does this change affect initialization scripts, user profile files, or existing graphs?" before implementation starts.
+
+The profile file ecosystem (me.md, rules.md, triggers.md, governance-rules.md, plan-rules.md, plugin.json, CLAUDE.md, etc.) lacks a canonical reference document. Contributors and AI assistants must infer the ecosystem from scattered examples.
+
+## Scope
+
+### Cascade Check Trigger
+
+- Fires when: a plan is approved, or "fix now" is selected during a review audit
+- Prompt questions:
+  - Does this change affect initialization scripts, user profile files, or existing graphs?
+  - Is this user-local or project-wide?
+  - Which tiers / platforms does this affect?
+- Output: go/no-go decision with scope classification
+
+### Profile File Ecosystem Reference
+
+- Canonical doc listing all profile files: path, owner (user-local vs project), platform(s), purpose
+- Initialization impact matrix: which files are written/read during `kg init`, `kg upgrade`, `kg migrate`
+- "Is this user-local or project-wide?" decision tree
+
+### Scope Boundary Prompt
+
+- Standardized prompt template for scope classification
+- Integrates with ENH-015 cascade framework
+- Available as a cascade check stub (implemented minimally in v0.5.9.1 review-audit-protocol rule)
+
+## Related ENHs
+
+- [[ENH-015]] - Decision Governance Protocol (this extends, does not replace)
+- Review Audit Protocol (`core/rules-registry/review-audit-protocol.md`) references this ENH as the cascade check authority once implemented
+
+## Known Gap (v0.5.9.1)
+
+The review-audit-protocol rule in v0.5.9.1 includes a cascade check _stub_ that defers to ENH-015 and "ENH-020 when complete." Until ENH-020 is implemented, the stub provides partial coverage only.

--- a/knowledge/enhancements/ENH-020/progress-log.md
+++ b/knowledge/enhancements/ENH-020/progress-log.md
@@ -1,0 +1,13 @@
+---
+id: ENH-020
+file: progress-log
+---
+
+# ENH-020 Progress Log
+
+## 2026-05-28
+
+- Spec created during v0.5.9.1 branch work
+- Status: deferred — requires brainstorm session
+- Cascade check stub included in review-audit-protocol.md (core/rules-registry) as placeholder
+- Context: gap identified during ENH-015 implementation review — cascade rules fire post-decision, not pre-implementation

--- a/knowledge/enhancements/ENH-020/solution-approach.md
+++ b/knowledge/enhancements/ENH-020/solution-approach.md
@@ -1,0 +1,21 @@
+---
+id: ENH-020
+file: solution-approach
+status: stub
+---
+
+# ENH-020 Solution Approach
+
+_Stub — requires brainstorm session before filling in._
+
+## Candidate Approaches
+
+1. Hook-based pre-implementation gate (PreToolUse on Write/Edit for implementation files)
+2. Skill-based cascade check invoked explicitly at plan approval
+3. Inline prompt template in governance-rules.md
+
+## Open Questions
+
+- Should the cascade check be automated (hook) or prompted (skill)?
+- Where does the profile ecosystem reference doc live? (`core/docs/` vs `core/templates/`)
+- How does this integrate with the existing ENH-015 decision gate?

--- a/knowledge/enhancements/ENH-020/test-cases.md
+++ b/knowledge/enhancements/ENH-020/test-cases.md
@@ -1,0 +1,17 @@
+---
+id: ENH-020
+file: test-cases
+status: stub
+---
+
+# ENH-020 Test Cases
+
+_Stub — to be filled in after brainstorm session._
+
+## Scenarios to Cover
+
+- [ ] Cascade check fires when plan approved for init-script change
+- [ ] Cascade check fires on "fix now" during review audit
+- [ ] Cascade check does NOT fire for non-profile changes
+- [ ] Profile ecosystem doc is reachable from governance-rules.md
+- [ ] Scope classification output is unambiguous

--- a/knowledge/issues/issue-7/implementation-log.md
+++ b/knowledge/issues/issue-7/implementation-log.md
@@ -1,0 +1,18 @@
+---
+id: issue-7
+file: implementation-log
+---
+
+# Issue-7 Implementation Log
+
+## 2026-05-28 — Issue Identified
+
+- **Session:** v0.5.9.1-review-audit-protocol implementation
+- **Trigger:** First Opus review attempt after commit 78a06359 was rejected by user
+- **Symptom:** Bash permission prompt displayed "Do you want to proceed?" with raw command; user could not distinguish from review audit HALT
+- **Immediate workaround applied:** Pre-embed `git diff` output in reviewer prompt; no Bash execution in agent
+- **Documentation:** `docs/plans/v0.5.9.1-review-audit-protocol.md § Post-Implementation Fixes`
+
+## Status
+
+Tracked. Solution designed. Implementation deferred to v0.6.0 (Option B: allow-list + Option A as canonical pattern).

--- a/knowledge/issues/issue-7/issue-7-description.md
+++ b/knowledge/issues/issue-7/issue-7-description.md
@@ -1,0 +1,62 @@
+---
+id: issue-7
+type: Bug
+status: tracked
+github-issue: "TBD"
+branch: v0.5.9.1-review-audit-protocol
+created: 2026-05-28
+related-adrs: [ADR-049]
+related-enhs: [ENH-020]
+target-release: v0.6.0
+---
+
+# Issue-7: Bash Permission Prompt Provides No Context — Indistinguishable from Review Audit HALT
+
+## Problem
+
+When a subagent dispatched as a code reviewer executes a Bash command (e.g., `git diff` to read the branch diff), Claude Code's Bash permission prompt shows:
+
+```
+Bash command
+  [raw command text]
+  Contains shell syntax (string) that cannot be statically analyzed
+  Do you want to proceed?
+  > 1. Yes
+    2. No
+```
+
+The prompt provides:
+- No description of WHY the command is being run
+- No agent context (which agent, what task, what it needs this for)
+- No indication that this is a permission gate vs. a protocol HALT
+
+This is **visually identical** to the review audit protocol's HALT behavior, which also presents options requiring "proceed" approval. Users cannot distinguish:
+
+1. "The reviewing agent needs Bash permission to read the diff" (infrastructure)
+2. "The review found something and is asking for a decision" (protocol)
+
+Both present as bare "Do you want to proceed?" without explanatory context.
+
+## Impact
+
+- Breaks review flow — user must guess what's being asked before answering
+- Defeats the review audit protocol's HALT fix (same visual language reintroduced via permission system)
+- Reviewer agents that execute Bash are interrupted mid-task by permission gates
+
+## Discovered
+
+During v0.5.9.1 implementation — first Opus review attempt was rejected because the permission prompt was indistinguishable from the HALT problem being tested. See `docs/plans/v0.5.9.1-review-audit-protocol.md § Post-Implementation Fixes`.
+
+## Current Workaround
+
+Pre-embed `git diff` output directly in the reviewer agent's prompt before dispatching. The reviewer reads the diff as conversation context and does not need to execute Bash at all.
+
+This eliminates permission prompts for diff-reading, but does not address:
+- Agents that need Bash for other read operations (file listing, grep, etc.)
+- The general UX problem of opaque permission prompts
+
+## Root Cause
+
+Claude Code's Bash permission system surfaces the raw command string but not the agent's stated purpose. The `description` parameter on Bash tool calls (when provided) may improve display, but this is not consistently used in agent dispatch patterns.
+
+Additionally: no project-level allow-list exists for read-only git commands that reviewers routinely need (git diff, git log, git show, git status). Every invocation requires manual approval.

--- a/knowledge/issues/issue-7/solution-approach.md
+++ b/knowledge/issues/issue-7/solution-approach.md
@@ -1,0 +1,99 @@
+---
+id: issue-7
+file: solution-approach
+status: designed
+---
+
+# Issue-7 Solution Approach
+
+## Design Constraint
+
+Fix must be implemented ONCE in a way that works correctly for v0.6.0 architecture — not patched now and revisited later. Any solution chosen here becomes the canonical pattern for all reviewer agent dispatch going forward.
+
+## Option A: Pre-embed Diff (current workaround — promote to canonical pattern)
+
+**What:** Before dispatching any reviewer agent, run `git diff BASE..HEAD` in the main session (which has Bash access) and embed the full diff as inline context in the agent prompt. The agent reads code via Read/Grep/Glob tools and never needs Bash for the diff.
+
+**Status:** Already working in v0.5.9.1 session.
+
+**Pros:**
+- Zero permission prompts
+- Works today, no config changes needed
+- Agent gets full diff in context without any tool calls
+
+**Cons:**
+- Large diffs exceed prompt limits
+- Reviewer cannot run targeted follow-up queries (grep, file read)
+- Doesn't address non-diff Bash needs
+
+**v0.6.0 fit:** Viable as the primary pattern. Diff size can be managed by splitting stat + focused file diffs.
+
+---
+
+## Option B: Project Bash Allow-list for Read-only Git Commands
+
+**What:** Add `.claude/settings.json` (or `settings.local.json`) with an `allowedTools` or `permissions` entry that pre-authorizes specific read-only Bash patterns for reviewer agents.
+
+**What to allow:**
+```json
+{
+  "permissions": {
+    "allow": [
+      "Bash(git diff*)",
+      "Bash(git log*)",
+      "Bash(git show*)",
+      "Bash(git status*)",
+      "Bash(git rev-parse*)"
+    ]
+  }
+}
+```
+
+**Pros:**
+- Eliminates permission prompts for safe read operations permanently
+- Reviewer agents can execute follow-up queries freely
+- Aligns with how other tools (Read, Grep) already work without prompts
+
+**Cons:**
+- Requires Claude Code settings file change
+- Allow-list must be maintained as review patterns evolve
+- Still does not add context to prompts when non-listed commands are attempted
+
+**v0.6.0 fit:** Best long-term fix. Should be part of the v0.6.0 plugin setup/installer.
+
+---
+
+## Option C: Describe Bash Commands (context injection)
+
+**What:** When dispatching agents that will need Bash, use the `description` parameter on Bash calls (if Claude Code exposes it) to provide user-visible context. Requires testing whether the permission prompt surfaces the description field.
+
+**Status:** Unverified — needs investigation into whether Claude Code's permission prompt uses the tool call description.
+
+**Pros:** Addresses root UX cause (no context in prompt)
+**Cons:** May not be supported; requires per-command annotation
+
+**v0.6.0 fit:** If verifiable, combine with Option B.
+
+---
+
+## Option D: Anthropic Feedback
+
+**What:** Document as UX feedback — the Bash permission prompt should display:
+1. Which agent is requesting it
+2. The stated purpose of the command
+3. Visual distinction from protocol HALTs (different color, header, framing)
+
+This is not implementable in the plugin but should be submitted as product feedback.
+
+**v0.6.0 fit:** File as external feedback item; do not block on it.
+
+---
+
+## Recommended Approach for v0.6.0
+
+1. **Implement Option B** — add `.claude/settings.json` allow-list for read-only git commands as part of the v0.6.0 plugin setup/default config
+2. **Document Option A** as the canonical pattern for reviewer agent dispatch when diff size is manageable
+3. **Investigate Option C** to determine if description field is surfaced in permission prompts
+4. **File Option D** as Anthropic product feedback
+
+Implementation should land in a single v0.6.0 task — not patched incrementally across point releases.

--- a/knowledge/issues/issue-7/test-cases.md
+++ b/knowledge/issues/issue-7/test-cases.md
@@ -1,0 +1,39 @@
+---
+id: issue-7
+file: test-cases
+status: defined
+---
+
+# Issue-7 Test Cases
+
+## TC-1: Allow-listed command — no prompt
+
+**Setup:** `.claude/settings.json` contains `Bash(git diff*)` in allow list.
+**Action:** Dispatch reviewer agent that runs `git diff BASE..HEAD`.
+**Expected:** No permission prompt appears. Agent receives output directly.
+**Pass criteria:** Review completes without any "Do you want to proceed?" interruption.
+
+## TC-2: Non-allow-listed command — prompt appears with context
+
+**Setup:** Agent attempts a command not on the allow list.
+**Expected:** Permission prompt appears. Prompt includes agent name or stated purpose (if Option C implemented).
+**Pass criteria:** User can determine what is being asked without guessing.
+
+## TC-3: Pre-embed diff pattern — reviewer needs no Bash
+
+**Setup:** Main session pre-runs `git diff --stat` + targeted `git diff -- <files>`, embeds in prompt.
+**Action:** Dispatch reviewer agent.
+**Expected:** Agent reads diff from context, does not execute any Bash commands.
+**Pass criteria:** No permission prompts during entire review.
+
+## TC-4: Review HALT visually distinct from permission prompt
+
+**Setup:** Reviewer reaches end of review pass, presents audit trail.
+**Expected:** HALT block includes finding description, severity, recommended action.
+**Pass criteria:** HALT block is clearly distinguishable from Bash permission prompt by content and structure.
+
+## TC-5: Regression — git commit still suppressed in lesson check
+
+**Setup:** Bash tool executes `git commit -m "..."` with "bug resolved" in message.
+**Expected:** `post-tool-lesson-check.sh` suppresses prompt (git commit suppression rule).
+**Pass criteria:** No lesson-capture prompt on commit.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "knowledge-graph-plugin",
-  "version": "0.5.9",
+  "version": "0.5.9.1",
   "description": "Structured knowledge capture and cross-session memory for Claude Code projects.",
   "files": [
     ".claude-plugin/",

--- a/scripts/hooks-master.sh
+++ b/scripts/hooks-master.sh
@@ -394,7 +394,8 @@ _check_rules_split_threshold() {
     [ "$line_count" -gt 120 ] || return 0
 
     local domain_count
-    domain_count=$(grep -c '^## ' "$filepath" 2>/dev/null || echo 0)
+    domain_count=$(grep -c '^## ' "$filepath" 2>/dev/null || true)
+    domain_count=${domain_count:-0}
     [ "$domain_count" -ge 2 ] || return 0
 
     local week_tag dismiss_flag

--- a/scripts/hooks-master.sh
+++ b/scripts/hooks-master.sh
@@ -381,6 +381,36 @@ done
 _check_profile_staleness "$HOME/.kmgraph/me.md" "~/.kmgraph/me.md"
 
 # ─────────────────────────────────────────────────────────────
+# ENH-016: Rules file auto-split recommendation
+# If rules.md exceeds 120 lines AND has 2+ separable ## domains,
+# recommend splitting. Weekly suppression via flag file.
+# ─────────────────────────────────────────────────────────────
+_check_rules_split_threshold() {
+    local filepath="$HOME/.kmgraph/rules.md"
+    [ -f "$filepath" ] || return 0
+
+    local line_count
+    line_count=$(wc -l < "$filepath")
+    [ "$line_count" -gt 120 ] || return 0
+
+    local domain_count
+    domain_count=$(grep -c '^## ' "$filepath" 2>/dev/null || echo 0)
+    [ "$domain_count" -ge 2 ] || return 0
+
+    local week_tag dismiss_flag
+    week_tag=$(date +%Y-%V)
+    dismiss_flag="$HOME/.kmgraph/.split-dismissed-${week_tag}"
+    [ -f "$dismiss_flag" ] && return 0
+
+    echo -e "${YELLOW}⚠️  rules.md has grown to ${line_count} lines across ${domain_count} domains.${NC}"
+    echo "   Consider splitting into separate files (e.g., rules.md + plan-rules.md)."
+    echo "   To suppress for this week: touch ~/.kmgraph/.split-dismissed-${week_tag}"
+    echo ""
+}
+
+_check_rules_split_threshold
+
+# ─────────────────────────────────────────────────────────────
 # SECTION 5: Profile file diffs are not surfaced in SessionStart.
 # Profile files (`~/.kmgraph/{rules,me}.md`, `{project}/knowledge/{rules,me}.md`)
 # are the authoritative behavioral stores. They are read directly by the

--- a/scripts/post-plan-validate-checklist.sh
+++ b/scripts/post-plan-validate-checklist.sh
@@ -1,8 +1,9 @@
 #!/usr/bin/env bash
-# post-plan-validate-checklist.sh — PostToolUse:Write hook
+# post-plan-validate-checklist.sh — PostToolUse:Write|Edit hook
 #
-# Fires after writing to a plan file; outputs Post-Plan Validation Checklist
+# Fires after writing or editing a plan file; outputs Post-Plan Validation Checklist
 # as an advisory reminder. Does not block — PostToolUse is advisory only.
+# Idempotency: suppresses repeat triggers on the same plan file within a session.
 
 set -euo pipefail
 
@@ -10,6 +11,21 @@ INPUT=$(cat)
 FILE_PATH=$(printf '%s' "$INPUT" | jq -r '.tool_input.file_path // ""' 2>/dev/null || true)
 
 [[ "$FILE_PATH" == *"plans/"*.md ]] || exit 0
+
+# Idempotency gate: suppress repeat triggers on the same plan file
+# Uses a session-scoped flag file based on file path hash to avoid checklist spam on iterative edits
+if command -v md5 &>/dev/null; then
+    PLAN_HASH=$(printf '%s' "$FILE_PATH" | md5)
+elif command -v md5sum &>/dev/null; then
+    PLAN_HASH=$(printf '%s' "$FILE_PATH" | md5sum | cut -d' ' -f1)
+else
+    PLAN_HASH=$(printf '%s' "$FILE_PATH" | cksum | cut -d' ' -f1)
+fi
+FLAG_FILE="/tmp/kmgraph-plan-check-${PLAN_HASH}"
+if [ -f "$FLAG_FILE" ]; then
+    exit 0
+fi
+touch "$FLAG_FILE"
 
 MSG='--- Post-Plan Validation Checklist (advisory) ---
 Plan file written. Verify against ~/.kmgraph/plan-rules.md:

--- a/scripts/post-plan-validate-checklist.sh
+++ b/scripts/post-plan-validate-checklist.sh
@@ -21,7 +21,7 @@ elif command -v md5sum &>/dev/null; then
 else
     PLAN_HASH=$(printf '%s' "$FILE_PATH" | cksum | cut -d' ' -f1)
 fi
-FLAG_FILE="/tmp/kmgraph-plan-check-${PLAN_HASH}"
+FLAG_FILE="/tmp/kmgraph-plan-check-${PLAN_HASH}-$(date +%Y%m%d)"
 if [ -f "$FLAG_FILE" ]; then
     exit 0
 fi

--- a/scripts/post-tool-lesson-check.sh
+++ b/scripts/post-tool-lesson-check.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# post-tool-lesson-check.sh - PostToolUse hook: detect lesson-worthy signals after Write/Edit
+# post-tool-lesson-check.sh - PostToolUse hook: detect lesson-worthy signals after Write/Edit/Bash
 # Security: no eval, no network, all variables quoted, subshells quoted
 
 CONFIG_PATH="$HOME/.claude/kg-config.json"
@@ -11,7 +11,37 @@ NC='\033[0m'
 # Read stdin (Claude Code passes hook context as JSON)
 INPUT="$(cat)"
 
-# Check for lesson-worthy keywords in file path or content
+# Detect tool name
+TOOL_NAME="$(printf '%s' "$INPUT" | jq -r '.tool_name // ""' 2>/dev/null || true)"
+
+# --- Bash-specific path ---
+# Require 2+ of: bug/resolved/workaround in output; exclude error (too noisy alone)
+if [ "$TOOL_NAME" = "Bash" ]; then
+    COMMAND="$(printf '%s' "$INPUT" | jq -r '.tool_input.command // ""' 2>/dev/null || true)"
+
+    # Suppress on git commit (has its own pre-commit knowledge gate)
+    if echo "$COMMAND" | grep -q "git commit"; then
+        exit 0
+    fi
+
+    OUTPUT="$(printf '%s' "$INPUT" | jq -r '.tool_response // .tool_output // ""' 2>/dev/null || true)"
+    SIGNAL_COUNT=0
+    for keyword in bug resolved workaround; do
+        if echo "$OUTPUT" | grep -qi "$keyword"; then
+            SIGNAL_COUNT=$((SIGNAL_COUNT + 1))
+        fi
+    done
+
+    if [ "$SIGNAL_COUNT" -lt 2 ]; then
+        exit 0
+    fi
+
+    echo -e "${YELLOW}📝 That looks like it might be worth keeping.${NC}"
+    echo "   /kmgraph:capture-lesson — capture what you just solved (includes optional session snapshot)"
+    exit 0
+fi
+
+# --- Write/Edit path ---
 SIGNAL_FOUND=false
 
 # Keyword checks against full input

--- a/scripts/post-tool-lesson-check.sh
+++ b/scripts/post-tool-lesson-check.sh
@@ -20,7 +20,7 @@ if [ "$TOOL_NAME" = "Bash" ]; then
     COMMAND="$(printf '%s' "$INPUT" | jq -r '.tool_input.command // ""' 2>/dev/null || true)"
 
     # Suppress on git commit (has its own pre-commit knowledge gate)
-    if echo "$COMMAND" | grep -q "git commit"; then
+    if echo "$COMMAND" | grep -qE '(^|;|&&|\|\|)[[:space:]]*git commit([[:space:]]|$)'; then
         exit 0
     fi
 

--- a/scripts/pre-skill-rules-inject.sh
+++ b/scripts/pre-skill-rules-inject.sh
@@ -115,6 +115,10 @@ if [[ "$SKILL_TYPE" == "review-request" ]] && [[ -f "$KMGRAPH_TRIGGERS" ]]; then
   SKILL_TRIGGER="${REVIEW_AUDIT_TRIGGER}
 
 ${REVIEW_FINDING_TRIGGER}"
+
+  if [[ -z "${REVIEW_AUDIT_TRIGGER}" ]] || [[ -z "${REVIEW_FINDING_TRIGGER}" ]]; then
+    echo "⚠️  pre-skill-rules-inject: review trigger sections missing from triggers.md — OVERRIDE_BLOCK may be incomplete" >&2
+  fi
 fi
 
 RECALL_HARD_BLOCK=""

--- a/scripts/pre-skill-rules-inject.sh
+++ b/scripts/pre-skill-rules-inject.sh
@@ -51,7 +51,10 @@ case "$SKILL_NAME" in
   superpowers:systematic-debugging|systematic-debugging)
     SKILL_TYPE="debugging"
     ;;
-  superpowers:requesting-code-review|requesting-code-review)
+  superpowers:requesting-code-review|requesting-code-review|\
+  caveman:caveman-review|\
+  pr-review-toolkit:*|\
+  code-review)
     SKILL_TYPE="review-request"
     ;;
   superpowers:finishing-a-development-branch|superpowers:finish-branch|\
@@ -97,6 +100,23 @@ if [[ -f "$KMGRAPH_TRIGGERS" ]]; then
   ' "$KMGRAPH_TRIGGERS" 2>/dev/null || true)
 fi
 
+# For review skills, override SKILL_TRIGGER with review-specific gates from triggers.md
+if [[ "$SKILL_TYPE" == "review-request" ]] && [[ -f "$KMGRAPH_TRIGGERS" ]]; then
+  REVIEW_AUDIT_TRIGGER=$(awk '
+    /When performing a post-plan, pre-push/ { in_section=1 }
+    in_section && /^## / && !/When performing a post-plan/ { in_section=0 }
+    in_section { print }
+  ' "$KMGRAPH_TRIGGERS" 2>/dev/null || true)
+  REVIEW_FINDING_TRIGGER=$(awk '
+    /Before surfacing a finding during a review/ { in_section=1 }
+    in_section && /^## / && !/Before surfacing a finding/ { in_section=0 }
+    in_section { print }
+  ' "$KMGRAPH_TRIGGERS" 2>/dev/null || true)
+  SKILL_TRIGGER="${REVIEW_AUDIT_TRIGGER}
+
+${REVIEW_FINDING_TRIGGER}"
+fi
+
 RECALL_HARD_BLOCK=""
 ACTIVE_KG_BLOCK=""
 PLAN_EMBED_BLOCK=""
@@ -120,11 +140,24 @@ Do not skip recall even for familiar-looking bugs — prior context prevents re-
   ROUTING_HARD_BLOCK=""
 
 elif [[ "$SKILL_TYPE" == "review-request" ]]; then
-  OVERRIDE_BLOCK='--- Review Context Injection (HARD BLOCK — supersedes skill) ---
-Before dispatching the reviewer, invoke the kmgraph:recall skill (via Skill tool) with each modified file path or its concept as input.
-Pass surfaced ADRs and lessons as REQUIRED review context in the reviewer dispatch payload.
-Do not dispatch a cold reviewer — a reviewer unaware of ADR constraints may approve violations.
---- End Review Context ---'
+  OVERRIDE_BLOCK='--- Review Audit Protocol (HARD BLOCK — supersedes skill) ---
+Before dispatching any reviewer or surfacing any finding:
+
+1. ADR Pre-Check — search knowledge/decisions/ and ~/.kmgraph/decisions/ for ADRs covering the topic.
+   - Match found + fully addressed: suppress finding; cite the ADR
+   - Match found + new evidence: surface finding with explicit ADR reference
+   - No match: surface normally
+
+2. Review Context — invoke kmgraph:recall with each modified file path or concept as input.
+   Pass surfaced ADRs and lessons as REQUIRED context in the reviewer dispatch payload.
+   Do not dispatch a cold reviewer — a reviewer unaware of ADR constraints may approve violations.
+
+For post-plan, pre-push, or explicit full review/audit:
+3. Complete full review pass without interruption — dispatch background agents for investigation; do NOT wait mid-pass
+4. After pass: present findings list; ask "Run recall? [all / select / skip]" — batch into one call
+5. Display all results inline (not collapsed)
+6. Present audit trail table + decision prompt per finding — HALT until user resolves all findings
+--- End Review Audit Protocol ---'
   ROUTING_HARD_BLOCK=""
 
 elif [[ "$SKILL_TYPE" == "finishing" ]]; then

--- a/scripts/pre-skill-rules-inject.sh
+++ b/scripts/pre-skill-rules-inject.sh
@@ -156,7 +156,7 @@ For post-plan, pre-push, or explicit full review/audit:
 3. Complete full review pass without interruption — dispatch background agents for investigation; do NOT wait mid-pass
 4. After pass: present findings list; ask "Run recall? [all / select / skip]" — batch into one call
 5. Display all results inline (not collapsed)
-6. Present audit trail table + decision prompt per finding — HALT until user resolves all findings
+6. Present COMPLETE audit trail table covering ALL findings at once — HALT ONCE. For each finding include: description, severity, recommended action, decision options. Do NOT stop mid-review per finding. Do NOT ask bare "proceed?" questions. Every halt must present finding context + recommendation.
 --- End Review Audit Protocol ---'
   ROUTING_HARD_BLOCK=""
 

--- a/scripts/rules-size-check.sh
+++ b/scripts/rules-size-check.sh
@@ -24,7 +24,8 @@ esac
 LINE_COUNT=$(wc -l < "$FILE_PATH")
 [ "$LINE_COUNT" -gt 120 ] || exit 0
 
-DOMAIN_COUNT=$(grep -c '^## ' "$FILE_PATH" 2>/dev/null || echo 0)
+DOMAIN_COUNT=$(grep -c '^## ' "$FILE_PATH" 2>/dev/null || true)
+DOMAIN_COUNT=${DOMAIN_COUNT:-0}
 [ "$DOMAIN_COUNT" -ge 2 ] || exit 0
 
 # Weekly suppression gate
@@ -36,10 +37,6 @@ MSG="rules.md has grown to ${LINE_COUNT} lines across ${DOMAIN_COUNT} domains.
 Consider splitting into separate files (e.g., rules.md + plan-rules.md).
 To suppress for this week: touch ~/.kmgraph/.split-dismissed-${WEEK_TAG}"
 
-if command -v jq &>/dev/null; then
-    jq -n --arg msg "$MSG" '{"systemMessage": $msg}'
-else
-    echo -e "${YELLOW}⚠️  ${MSG}${NC}"
-fi
+jq -n --arg msg "$MSG" '{"systemMessage": $msg}'
 
 exit 0

--- a/scripts/rules-size-check.sh
+++ b/scripts/rules-size-check.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# rules-size-check.sh — PostToolUse:Write|Edit hook
+#
+# After writing a rules file, check if line count exceeds split threshold.
+# If >120 lines AND 2+ separable ## domains, recommend splitting.
+# Weekly suppression via ~/.kmgraph/.split-dismissed-{YYYY-WW}.
+
+set -euo pipefail
+
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+INPUT=$(cat)
+FILE_PATH=$(printf '%s' "$INPUT" | jq -r '.tool_input.file_path // ""' 2>/dev/null || true)
+
+# Only fire on rules files
+case "$FILE_PATH" in
+    */.kmgraph/rules.md|*/knowledge/rules.md) ;;
+    *) exit 0 ;;
+esac
+
+[ -f "$FILE_PATH" ] || exit 0
+
+LINE_COUNT=$(wc -l < "$FILE_PATH")
+[ "$LINE_COUNT" -gt 120 ] || exit 0
+
+DOMAIN_COUNT=$(grep -c '^## ' "$FILE_PATH" 2>/dev/null || echo 0)
+[ "$DOMAIN_COUNT" -ge 2 ] || exit 0
+
+# Weekly suppression gate
+WEEK_TAG=$(date +%Y-%V)
+DISMISS_FLAG="$HOME/.kmgraph/.split-dismissed-${WEEK_TAG}"
+[ -f "$DISMISS_FLAG" ] && exit 0
+
+MSG="rules.md has grown to ${LINE_COUNT} lines across ${DOMAIN_COUNT} domains.
+Consider splitting into separate files (e.g., rules.md + plan-rules.md).
+To suppress for this week: touch ~/.kmgraph/.split-dismissed-${WEEK_TAG}"
+
+if command -v jq &>/dev/null; then
+    jq -n --arg msg "$MSG" '{"systemMessage": $msg}'
+else
+    echo -e "${YELLOW}⚠️  ${MSG}${NC}"
+fi
+
+exit 0


### PR DESCRIPTION
## Summary

- Adds Review Audit Protocol (post-plan/pre-push governance): 4-step HALT-once pattern with structured decision blocks; prevents per-finding interruptions and bare "proceed?" prompts
- ENH-016: `rules-size-check.sh` PostToolUse hook recommends splitting `rules.md` when >120 lines and 2+ domains; weekly suppression via flag file
- Hook fixes: lesson-check fires on Bash tool; post-plan-validate fires on Write|Edit; idempotency gate added
- `pre-skill-rules-inject.sh`: review-request OVERRIDE_BLOCK rewritten with 6-step HARD BLOCK enforcing HALT-once
- issue-7 tracked: Bash permission prompt UX gap deferred to v0.6.0 (Option B allow-list)
- Opus review fixes: grep-c bug, dead code, git commit anchor, flag day-scoping, trigger warning

## Changes

- `core/rules-registry/review-audit-protocol.md` — canonical rule (new)
- `core/templates/knowledge/templates/user/governance-rules.md` — genericized template (new)
- `scripts/rules-size-check.sh` — ENH-016 PostToolUse hook (new)
- `hooks/hooks.json` — lesson-check Bash matcher, post-plan-validate Edit matcher, rules-size-check hook
- `scripts/post-plan-validate-checklist.sh` — idempotency gate
- `scripts/post-tool-lesson-check.sh` — Bash path added
- `scripts/hooks-master.sh` — `_check_rules_split_threshold()` (ENH-016 SessionStart)
- `scripts/pre-skill-rules-inject.sh` — review-request OVERRIDE_BLOCK rewrite
- `knowledge/enhancements/ENH-020/` — cascade check spec (deferred, stub)
- `knowledge/issues/issue-7/` — Bash permission prompt UX tracking docs
- `package.json` + `.claude-plugin/plugin.json` — 0.5.9.1

## Test plan

- [ ] SessionStart fires hooks-master.sh cleanly; no regression on profile staleness checks
- [ ] Post-Write on a plan file triggers post-plan-validate-checklist once (idempotency gate)
- [ ] Post-Bash on a lesson-worthy command triggers lesson-check prompt
- [ ] Post-Edit on rules.md >120 lines triggers rules-size-check recommendation
- [ ] Review agent dispatched via `superpowers:requesting-code-review` receives HALT-once OVERRIDE_BLOCK; does not interrupt per finding

🤖 Generated with [Claude Code](https://claude.com/claude-code)