### PR TITLE
fix(start-issue-tracking): v0.5.9.2 — gh issue create bug fix + post-plan advisory

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "kmgraph",
-  "version": "0.5.9.1",
+  "version": "0.5.9.2",
   "description": "Structured knowledge capture, lesson-learned documentation, and cross-session memory for Claude Code projects. Includes KG entries, ADRs, meta-issue tracking, chat extraction, and profile-file rule capture.",
   "author": {
     "name": "technomensch",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Released]
 
+## [0.5.9.2] — 2026-05-30
+
+### Fixed
+- **issue-5 (#124):** `start-issue-tracking` Step 5 now calls `gh issue create` (Step 5.0) before branch creation. Returned issue URL is parsed for the issue number, which is written back to spec frontmatter (`github-issue` field). Draft PR is updated to include `Closes #N`. Previously, `github-issue` was always `null` or `"TBD"` — every ENH and issue since `v0.0.5-alpha` was unsynced to GitHub.
+- **issue-6 (#125):** `plan-rules.md` false "blocking gate" claim corrected — post-plan validation checklist hook is advisory only (PostToolUse cannot block in Claude Code). `scripts/post-plan-validate-checklist.sh` header updated to clarify advisory intent. Blocking enforcement deferred to v0.6.0 per ENH-015 Gap 2. (User-local `~/.kmgraph/plan-rules.md` fix only — no behavior change for marketplace users.)
+
+### Related
+- ADR-024, ADR-043, ADR-049, ENH-015, ENH-017
+
 ## [0.5.9.1] — 2026-05-28 (rev 2)
 
 ### Added

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -242,6 +242,7 @@ done
 | **v0.5.7.1** | Security patch — no upgrade action required. Dependabot dependency overrides applied automatically on install. |
 | **v0.5.8** | No upgrade action required. Project-specific plan-routing rules, dispatcher relay, and MEMORY.md cascade fix are automatic after plugin reload. |
 | **v0.5.9** | No upgrade action required. Decision governance recall enforcement, `brainstorm-recall` skill, and post-plan validation checklist are automatic after plugin reload. Optionally run `/kmgraph:upgrade` to add the "Recall in Plan Mode" rule to your `~/.kmgraph/plan-rules.md` if you have a split rules file. |
+| **v0.5.9.2** | No upgrade action required. `start-issue-tracking` Step 5.0 (`gh issue create`) is automatic after plugin reload. `github-issue` frontmatter is now auto-populated in new issue/ENH specs. Existing specs with `github-issue: null` are not retroactively updated — create GitHub issues manually for those if needed. |
 
 After the wizard completes, your existing lessons, ADRs, sessions, and chat history are untouched.
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Structured knowledge capture, lesson-learned documentation, and cross-session memory for Claude Code projects.
 
-**Version:** 0.5.9
+**Version:** 0.5.9.2
 **Status:** Actively developed and in daily use
 
 Documentation: https://kmgraph.stayinginsync.info
@@ -88,6 +88,11 @@ Pull the latest version and run `/kmgraph:init` in any project that uses it. The
 ---
 
 ## v0.5.x Feature Highlights
+
+**v0.5.9.2 — 2026-05-30**
+
+- **`start-issue-tracking` now auto-creates GitHub Issue** — Step 5.0 calls `gh issue create --body-file` before branch creation; returned issue number is written back to spec frontmatter (`github-issue` field). Draft PR is updated to include `Closes #N`.
+- **Post-plan validation checklist advisory clarification** — `plan-rules.md` false "blocking gate" claim corrected; checklist hook is advisory only (PostToolUse cannot block in Claude Code). Hard-gate enforcement deferred to v0.6.0 (ENH-015 Gap 2).
 
 **v0.5.9 — 2026-05-27**
 
@@ -216,7 +221,7 @@ knowledge-graph/
 
 ## Development Status
 
-**Current Release:** v0.5.9 (2026-05-27)
+**Current Release:** v0.5.9.2 (2026-05-30)
 
 Actively developed and in daily use. Behavior may evolve between minor versions.
 
@@ -309,6 +314,6 @@ MIT License - See [LICENSE](LICENSE)
 ---
 
 **Created:** 2026-02-12
-**Current Version:** v0.5.9 (2026-05-27)
+**Current Version:** v0.5.9.2 (2026-05-30)
 
 📚 **Full documentation:** https://kmgraph.stayinginsync.info

--- a/commands/start-issue-tracking.md
+++ b/commands/start-issue-tracking.md
@@ -366,6 +366,40 @@ Every generated plan MUST include this **Safety Header** and **Atomic Approval P
 
 **CONDITIONAL:** Only execute this step if `{git_available} = true`. If the project has no Git repository, skip this step entirely — no branch is needed and no Git commands should run.
 
+### 5.0: Create GitHub Issue
+
+After documentation is generated (Step 4), create the GitHub issue immediately so the
+issue number can be captured and written to the spec frontmatter before branch creation.
+
+Determine label based on `{issue_type}`:
+- Bug → `--label bug`
+- Enhancement → `--label enhancement`
+- Refactor / Hardening → `--label enhancement`
+- All other types → `--label enhancement` (default fallback)
+
+```bash
+ISSUE_URL=$(gh issue create \
+  --title "[{issue_type}] {issue_title}" \
+  --body-file {active_kg_path}/issues/issue-N/issue-N-description.md \
+  --label {label})
+GITHUB_ISSUE_NUM=$(basename "${ISSUE_URL}")
+echo "GitHub Issue created: #${GITHUB_ISSUE_NUM} — ${ISSUE_URL}"
+```
+
+Write issue number back to spec frontmatter immediately:
+
+```bash
+sed -i.bak -E "s/github-issue: (null|\"TBD\")/github-issue: \"#${GITHUB_ISSUE_NUM}\"/" \
+  {active_kg_path}/issues/issue-N/issue-N-description.md && \
+  rm {active_kg_path}/issues/issue-N/issue-N-description.md.bak
+grep "github-issue: \"#" {active_kg_path}/issues/issue-N/issue-N-description.md || \
+  { echo "ERROR: write-back failed — issue #${GITHUB_ISSUE_NUM} created on GitHub. Update frontmatter manually."; exit 1; }
+```
+
+For enhancements: spec path is `{active_kg_path}/enhancements/ENH-NNN/ENH-NNN-specification.md`
+
+Store `{github_issue_num}` for use in Step 5.2.
+
 ### 5.1: Create Feature Branch
 
 Create the branch with a descriptive name derived from the issue number and slug:
@@ -390,8 +424,11 @@ git branch --show-current
 
 Optionally create a draft PR on GitHub:
 ```bash
-gh pr create --draft --title "[Bug] Brief descriptive title" \
-  --body-file {active_kg_path}/issues/issue-N/solution-approach.md
+gh pr create --draft \
+  --title "[{issue_type}] {issue_title}" \
+  --body "$(cat {active_kg_path}/issues/issue-N/solution-approach.md)
+
+Closes #{github_issue_num}"
 ```
 
 ---
@@ -444,7 +481,7 @@ The `solution-approach.md` MUST link to the resulting lesson or updated entry in
 **Local Issue #N: [Type] Descriptive Title**
 - Status: 🔴 ACTIVE (LOCKED)
 - Branch: v[Major.Minor.Patch]-[issue N]-brief-slug   ← omit if {git_available} = false
-- GitHub Issue: #[N] (Reopened/Created)               ← omit if {git_available} = false
+- GitHub Issue: #[N] — created at Step 5.0 (gh issue create)   ← omit if {git_available} = false
 
 **Files Created:**
 - {active_kg_path}/issues/issue-N/issue-N-description.md

--- a/commands/start-issue-tracking.md
+++ b/commands/start-issue-tracking.md
@@ -382,21 +382,30 @@ ISSUE_URL=$(gh issue create \
   --title "[{issue_type}] {issue_title}" \
   --body-file {active_kg_path}/issues/issue-N/issue-N-description.md \
   --label {label})
+[ -n "$ISSUE_URL" ] || { echo "ERROR: gh issue create failed — check gh auth and remote"; exit 1; }
 GITHUB_ISSUE_NUM=$(basename "${ISSUE_URL}")
 echo "GitHub Issue created: #${GITHUB_ISSUE_NUM} — ${ISSUE_URL}"
 ```
 
 Write issue number back to spec frontmatter immediately:
 
+For bugs/issues (`{active_kg_path}/issues/issue-N/issue-N-description.md`):
 ```bash
-sed -i.bak -E "s/github-issue: (null|\"TBD\")/github-issue: \"#${GITHUB_ISSUE_NUM}\"/" \
-  {active_kg_path}/issues/issue-N/issue-N-description.md && \
-  rm {active_kg_path}/issues/issue-N/issue-N-description.md.bak
-grep "github-issue: \"#" {active_kg_path}/issues/issue-N/issue-N-description.md || \
+SPEC={active_kg_path}/issues/issue-N/issue-N-description.md
+sed -i.bak -E "s/github-issue: (null|\"TBD\"|\"#N\")/github-issue: \"#${GITHUB_ISSUE_NUM}\"/" \
+  "${SPEC}" && rm "${SPEC}.bak"
+grep -E "github-issue: \"#[0-9]+\"" "${SPEC}" || \
   { echo "ERROR: write-back failed — issue #${GITHUB_ISSUE_NUM} created on GitHub. Update frontmatter manually."; exit 1; }
 ```
 
-For enhancements: spec path is `{active_kg_path}/enhancements/ENH-NNN/ENH-NNN-specification.md`
+For enhancements (`{active_kg_path}/enhancements/ENH-NNN/ENH-NNN-specification.md`):
+```bash
+SPEC={active_kg_path}/enhancements/ENH-NNN/ENH-NNN-specification.md
+sed -i.bak -E "s/github-issue: (null|\"TBD\"|\"#N\")/github-issue: \"#${GITHUB_ISSUE_NUM}\"/" \
+  "${SPEC}" && rm "${SPEC}.bak"
+grep -E "github-issue: \"#[0-9]+\"" "${SPEC}" || \
+  { echo "ERROR: write-back failed — issue #${GITHUB_ISSUE_NUM} created on GitHub. Update frontmatter manually."; exit 1; }
+```
 
 Store `{github_issue_num}` for use in Step 5.2.
 

--- a/docs/CHEAT-SHEET.md
+++ b/docs/CHEAT-SHEET.md
@@ -74,7 +74,7 @@ Power users leverage these for complex workflows:
 | Command | Purpose |
 |---------|---------|
 | `/kmgraph:meta-issue` | Initialize meta-issue tracking for complex multi-attempt problems |
-| `/kmgraph:start-issue-tracking` | Initialize issue tracking with structured docs and Git branch |
+| `/kmgraph:start-issue-tracking` | Initialize issue tracking with structured docs, auto-creates GitHub Issue (Step 5.0), and Git branch |
 | `/kmgraph:update-issue-plan` | Sync knowledge graph → plan → issue → GitHub |
 | `/kmgraph:link-issue` | Manually link existing lesson or ADR to GitHub issue |
 | `/kmgraph:sync-all` | Automated full sync pipeline (4 steps → 1 command). Uses background file scanning when context-mode is installed. Refreshes search index automatically if built |

--- a/docs/reference/command-guide.md
+++ b/docs/reference/command-guide.md
@@ -943,8 +943,9 @@ With `--user-facing`:
 6. Auto-detects issue type from keywords (bug vs. enhancement)
 7. Creates directory structure with documentation templates (description, solution approach, test cases, implementation log)
 8. Generates an implementation plan with safety headers and atomic approval protocol
-9. Creates a Git feature branch (`issue/{N}-{slug}`)
-10. Optionally creates a draft PR on GitHub with `--body-file` populated from solution approach
+9. **Step 5.0: Creates a GitHub Issue** via `gh issue create --body-file` from the issue description; writes the returned issue number back to spec frontmatter (`github-issue` field auto-populated)
+10. Creates a Git feature branch (`issue/{N}-{slug}`)
+11. Optionally creates a draft PR on GitHub with `--body-file` populated from solution approach and `Closes #N` referencing the issue created in Step 5.0
 11. **Step 6.2 (lesson capture) is a mandatory gate** — must receive a response before continuing. When working on a non-main branch, this step is strongly recommended.
 12. **Step 6.4 (ROADMAP + CHANGELOG update) is a mandatory gate** — must receive a response confirming ROADMAP and CHANGELOG entries have been considered before the command completes.
 13. Links to knowledge graph and prompts for lesson capture
@@ -962,7 +963,7 @@ With `--user-facing`:
 **Tips**:
 
 - Uses the Dual-ID Policy: local IDs (`issue-N` or `ENH-NNN`) are independent from GitHub issue numbers (`#N`)
-- Always use `--body-file` flag (not manual summary) when creating the GitHub Issue
+- GitHub Issue creation is automatic at Step 5.0 — `gh issue create --body-file` runs before branch creation; `github-issue` frontmatter is written back immediately
 
 **See also**: [Track Issues](TRACK-ISSUES.md) — full lifecycle walkthrough including git integration and the implementation freeze gate.
 

--- a/knowledge/decisions/ADR-024-decouple-issue-tracking-decisions-sequential-prompts.md
+++ b/knowledge/decisions/ADR-024-decouple-issue-tracking-decisions-sequential-prompts.md
@@ -152,6 +152,9 @@ No migration needed. The change is behavioral (prompt structure); existing issue
 **Enhancements:**
 - [ENH-006](../enhancements/ENH-006/) — Issue tracking gap fixes that motivated this decision
 
+**Issues:**
+- [[issue-5]] — GitHub #124 — bug: `start-issue-tracking` Step 5 never called `gh issue create`; any Step 5 changes must stay consistent with sequential prompt design in this ADR; fixed in v0.5.9.2
+
 ---
 
 ## Future Considerations

--- a/knowledge/decisions/ADR-043-pretooluse-hook-injection-superpowers-rule-enforcement.md
+++ b/knowledge/decisions/ADR-043-pretooluse-hook-injection-superpowers-rule-enforcement.md
@@ -180,6 +180,7 @@ All HARD BLOCKs use "invoke the kmgraph:recall skill (via Skill tool)" — NOT `
 - **[[ADR-038-model-selection-rule-for-kg-tasks]]:** Model selection for KG ops; model heuristics addition extends this to cover plan execution task types
 - **[[ENH-015-decision-governance-protocol]]:** The feature this ADR implements; contains full Platform Delivery Matrix, Known Gaps, and Amendment Deliverables
 - **[[ADR-028-me-and-rules-as-platform-agnostic-source-of-truth]]:** rules.md split shipping constraint — the rules-registry in `core/rules-registry/` follows the same principle for canonical rule text
+- **[[issue-6]]:** GitHub #125 — bug: plan-rules.md falsely described PostToolUse checklist hook as a blocking gate; fixed in v0.5.9.2 (advisory intent clarified; Layer 3 hard gate deferred per this ADR's Gap 2 pattern)
 
 ---
 

--- a/knowledge/enhancements/ENH-015/ENH-015-specification.md
+++ b/knowledge/enhancements/ENH-015/ENH-015-specification.md
@@ -159,6 +159,8 @@ Hook fires on Skill tool invocations only. `superpowers:writing-plans` invocatio
 ### Gap 2 — Post-Plan Validation Checklist (partial fix in v0.5.9; hard gate future scope)
 v0.5.9 adds Task M: PostToolUse:Write hook that fires after plan files are written and outputs the Post-Plan Validation Checklist as an advisory reminder. This is model self-enforcement, not a hard gate.
 
+**Tracked bug:** [[issue-6]] — GitHub #125 (v0.5.9.2): plan-rules.md falsely described the hook as a blocking gate; corrected to advisory. Layer 3 (gov-execute-plan pre-flight gate) deferred to v0.6.0.
+
 **Future scope (v0.6.0 candidate):** A PreToolUse:Write hook could provide a true hard gate with the following pattern to avoid blocking mid-draft saves:
 - Only block if the plan file **already exists** (not a first write)
 - AND the previous version already had a `## Post-Plan Validation Checklist` section

--- a/knowledge/enhancements/ENH-017/ENH-017-specification.md
+++ b/knowledge/enhancements/ENH-017/ENH-017-specification.md
@@ -36,3 +36,7 @@ Replace Step 1.2 question with:
 - "WIP update" renamed to "WIP append" for clarity
 - "Patch" now explicitly covers fix or enhancement (not just fix)
 - Identified during v0.5.9 ENH tracking session 2026-05-27
+
+## Related
+
+- [[issue-5]] — GitHub #124 — sibling bug in same command file (`start-issue-tracking`); issue-5 fixes Step 5 (`gh issue create`); ENH-017 improves Step 1.2 UX — implement on separate branch to avoid merge conflict

--- a/knowledge/issues/issue-5/issue-5-description.md
+++ b/knowledge/issues/issue-5/issue-5-description.md
@@ -1,0 +1,52 @@
+---
+id: issue-5
+type: Bug
+status: tracked
+github-issue: "#124"
+branch: v0.5.9.2-fix-gh-issue-create
+created: 2026-05-28
+related-adrs: [ADR-024]
+related-enhs: [ENH-017]
+---
+
+# Issue-5: `start-issue-tracking` Never Calls `gh issue create`
+
+## Problem
+
+The `/kmgraph:start-issue-tracking` skill documents a "CRITICAL RULE" about creating GitHub
+Issues and populates a `github-issue` frontmatter field in every ENH/issue spec — but Step 5
+of the skill only calls `gh pr create --draft`. The `gh issue create` command was never
+implemented in the execution steps.
+
+**Impact:** Every ENH and issue created since `v0.0.5-alpha` (commit `4641faab`) has
+`github-issue: null` or `"TBD"`. ENH-015 through ENH-019 are all unsynced to GitHub.
+
+## Evidence
+
+- `git log --follow commands/start-issue-tracking.md` — 12 commits, `gh issue create`
+  absent from all of them
+- ENH-015, ENH-016, ENH-017, ENH-018, ENH-019: all have `github-issue: null` or `"TBD"`
+- GitHub repo has no open enhancement issues past #47 (ENH-006)
+- `knowledge/issues/issue-1`: `github-issue: NOT SET`
+
+## Root Cause
+
+Original omission in `v0.0.5-alpha`. The prose and frontmatter schema anticipated GitHub
+issue creation, but the actual `gh issue create` call was never written into the execution
+steps. `gh pr create --draft` was added instead — a different operation that requires a
+branch and cannot replace issue creation.
+
+## Fix
+
+In Step 5 of `commands/start-issue-tracking.md`:
+1. Add `gh issue create` call after directory/doc creation (Step 4), before branch creation
+2. Capture the returned issue URL/number and write it back into the spec frontmatter
+3. Update `github-issue` field from `null`/`"TBD"` to the actual issue number
+
+## Related
+
+- **ADR-024** — documents the sequential prompt design for `start-issue-tracking`; any
+  Step 5 changes must remain consistent with the UX decisions there
+- **ENH-017** — proposes UX improvements to Step 1.2; shares the same command file;
+  implementation should be coordinated to avoid merge conflicts
+- **GitHub Issue:** #124

--- a/knowledge/issues/issue-5/solution-approach.md
+++ b/knowledge/issues/issue-5/solution-approach.md
@@ -1,0 +1,55 @@
+# Solution Approach — Issue-5: `gh issue create` Missing from `start-issue-tracking`
+
+## Strategy
+
+Surgical edit to `commands/start-issue-tracking.md`. Add `gh issue create` as a distinct
+sub-step in Step 5, capture the returned issue number, and write it back to the spec
+frontmatter. No restructuring of other steps required.
+
+## Implementation
+
+### Step 5.1 (new): Create GitHub Issue
+
+Insert between Step 4 (doc generation) and Step 5.1 (branch creation):
+
+```bash
+# Create GitHub issue and capture number
+ISSUE_URL=$(gh issue create \
+  --title "[Bug] start-issue-tracking: gh issue create never called" \
+  --body-file {active_kg_path}/issues/issue-N/issue-N-description.md \
+  --label bug \
+  --repo {owner}/{repo})
+
+GITHUB_ISSUE_NUM=$(echo "$ISSUE_URL" | grep -oE '[0-9]+$')
+
+# Write back to spec frontmatter
+sed -i '' "s/github-issue: null/github-issue: \"#${GITHUB_ISSUE_NUM}\"/" \
+  {active_kg_path}/issues/issue-N/issue-N-description.md
+```
+
+For enhancements, use `--label enhancement` instead of `--label bug`.
+
+### Step 5 Ordering (revised)
+
+1. Create GitHub issue → capture `#N`
+2. Update spec frontmatter with `#N`
+3. Create feature branch (existing 5.1)
+4. Verify branch (existing 5.2)
+5. Create draft PR linking to issue (existing `gh pr create --draft`, add `--body "Closes #N"`)
+
+### Frontmatter write-back
+
+The `github-issue` field must be populated immediately after issue creation, before any
+branch or PR steps, so that if the workflow is interrupted the mapping is not lost.
+
+## Files Changed
+
+- `commands/start-issue-tracking.md` — Step 5 rewrite
+
+## Acceptance Criteria
+
+- [ ] `gh issue create` is called in Step 5 before branch creation
+- [ ] Returned issue number is written to spec frontmatter `github-issue` field
+- [ ] Draft PR (if created) includes `Closes #N` reference
+- [ ] ENH path uses `--label enhancement`; Bug path uses `--label bug`
+- [ ] Existing ENH-015 through ENH-019 have GitHub issues opened retroactively (out of scope for this fix — separate backlog item)

--- a/knowledge/issues/issue-6/issue-6-description.md
+++ b/knowledge/issues/issue-6/issue-6-description.md
@@ -5,7 +5,7 @@ status: tracked
 github-issue: "#125"
 branch: v0.5.9.2-fix-gh-issue-create
 created: 2026-05-28
-related-adrs: [ADR-043, ADR-049, ENH-015]
+related-adrs: [ADR-043, ADR-049]
 related-enhs: [ENH-015]
 ---
 

--- a/knowledge/issues/issue-6/issue-6-description.md
+++ b/knowledge/issues/issue-6/issue-6-description.md
@@ -1,0 +1,77 @@
+---
+id: issue-6
+type: Bug
+status: tracked
+github-issue: "#125"
+branch: v0.5.9.2-fix-gh-issue-create
+created: 2026-05-28
+related-adrs: [ADR-043, ADR-049, ENH-015]
+related-enhs: [ENH-015]
+---
+
+# Issue-6: Post-Plan Validation Checklist Not Enforced — Advisory-Only Hook, Static Stub
+
+## Problem
+
+`plan-rules.md` specifies that the Post-Plan Validation Checklist must:
+1. Run immediately after a plan file is written
+2. Dynamically derive rows from both `~/.kmgraph/rules.md` and project `knowledge/rules.md`
+3. **Block execution on any ❌ row**
+
+The implementation shipped in v0.5.9 (ENH-015) does none of these:
+
+- **Wrong enforcement point:** Runs via `PostToolUse:Write` hook — but PostToolUse hooks
+  are architecturally advisory-only in Claude Code; they cannot block.
+- **Static stub:** `scripts/post-plan-validate-checklist.sh` outputs a hardcoded 8-item
+  checklist. The spec requires 15–20 rules derived dynamically from two rules files.
+- **No blocking gate:** Script always exits 0. Rule says "Any ❌ row blocks execution."
+
+## Evidence
+
+- Script comment line 4: *"Does not block — PostToolUse is advisory only."*
+- 5 consecutive sessions (2026-05-22 through 2026-05-28): validation asked manually every
+  time, same 5 failure categories found each session (version files, docs section,
+  parallelism tier labels, branch placement, plugin cache step).
+- `core/templates/post-plan-validation-checklist.md` does not exist — template lives only
+  at user-level `~/.kmgraph/knowledge/templates/`, not deployed to all users.
+
+## Root Cause
+
+ENH-015 shipped the hook and script as advisory infrastructure, intentionally deferring
+the blocking gate. The `plan-rules.md` rule was written to describe the intended end state,
+not the shipped state. The gap was never tracked as a bug.
+
+## Impact
+
+- **All users:** receive the advisory stub (8 hardcoded items, never blocks)
+- **This user:** `plan-rules.md` creates expectation of blocking dynamic validation
+  that the implementation cannot deliver
+- **Result:** same plan quality failures repeat session after session
+
+## Fix
+
+Move the enforcement gate from PostToolUse hook → `gov-execute-plan` pre-flight:
+
+1. `gov-execute-plan` already runs interactively and CAN block
+2. Add a pre-flight step: read plan file, check against rules files, surface ❌ rows,
+   require user to resolve before execution proceeds
+3. `post-plan-validate-checklist.sh` remains advisory (correct for its hook context)
+4. Promote template from `~/.kmgraph/knowledge/templates/` → `core/templates/` so it
+   ships to all users
+
+## Scope
+
+- `skills/gov-execute-plan.md` — add pre-flight validation step
+- `core/templates/post-plan-validation-checklist.md` — promote from user-level
+- `scripts/post-plan-validate-checklist.sh` — update comment to clarify advisory intent
+- `plan-rules.md` (user-level) — update to reflect actual enforcement point
+
+## Related
+
+- **ENH-015** — shipped the advisory stub; this bug tracks what was deferred
+- **ADR-049** — Review Audit Protocol (post-plan/pre-push governance); enforcement design
+  must stay consistent with decisions there
+- **ADR-043** — PreToolUse hook injection for rule enforcement; the pattern here (hook →
+  skill enforcement) applies to PostToolUse as well
+- **issue-5** — sibling bug in same session; being fixed in same branch `v0.5.9.2`
+- **GitHub Issue:** #125

--- a/knowledge/lessons-learned/Lessons_Learned_gh_issue_create_omission.md
+++ b/knowledge/lessons-learned/Lessons_Learned_gh_issue_create_omission.md
@@ -1,0 +1,50 @@
+---
+title: "gh issue create omission in start-issue-tracking Step 5"
+date: 2026-05-30
+version: 1.0
+tags:
+  - github-cli
+  - issue-tracking
+  - start-issue-tracking
+  - workflow-gap
+  - frontmatter
+---
+
+# Lesson: gh issue create omission in start-issue-tracking Step 5
+
+## Problem
+
+`/kmgraph:start-issue-tracking` Step 5 called `gh pr create --draft` but never called `gh issue create`. The original implementation (commit `4641faab`, `v0.0.5-alpha`) conflated issue creation with PR creation. As a result, every ENH and issue created since that version had `github-issue: null` or `"TBD"` in its spec frontmatter — never backed by a real GitHub issue tracker entry. The omission was silent: no error fired, the field simply stayed null.
+
+## Root Cause
+
+`gh pr create --draft` requires a branch to already exist and creates a pull request, not a tracker issue. The original author wrote that call at Step 5 without adding a preceding `gh issue create` call. Because `github-issue: null` is valid YAML and the workflow never validated the field against GitHub, the gap went undetected across all subsequent ENH and issue specs.
+
+## Solution
+
+In v0.5.9.2 (commit `3fcb4428`), a new **Step 5.0** was inserted before branch creation:
+
+1. Call `gh issue create --body-file {spec}.md --label {label}` and capture the returned URL.
+2. Extract the issue number with `basename` applied to the URL.
+3. Write the issue number and URL back into the spec frontmatter using `sed -i.bak`.
+
+For ENH specs the path convention is `enhancements/ENH-NNN/ENH-NNN-specification.md`; a note in Step 5.0 covers this variant explicitly.
+
+The PR creation call (`gh pr create --draft`) is retained in the original Step 5 position — it now runs after the issue exists, so the PR can reference the issue number in its body.
+
+## Replication Pattern
+
+Any workflow that writes `github-issue: null` as a placeholder and then calls only `gh pr create` will reproduce this gap. The pattern to follow instead:
+
+1. Create the issue first (`gh issue create`) — this produces the canonical tracker URL and number.
+2. Capture and immediately persist the returned number into the spec file.
+3. Create the branch and draft PR referencing that number.
+
+Never rely on a deferred fill-in for `github-issue`; the field should be populated in the same step that creates the spec file.
+
+## Related
+
+- [[issue-5]] — tracks the detection and backfill work for specs with null issue numbers
+- [GitHub #124](https://github.com/technomensch/knowledge-graph/issues/124) — upstream tracker entry for this fix
+- [[ADR-024]] — decision record governing spec frontmatter schema requirements
+- [[ENH-017]] — enhancement that exposed the null field during its own creation workflow

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "knowledge-graph-plugin",
-  "version": "0.5.9.1",
+  "version": "0.5.9.2",
   "description": "Structured knowledge capture and cross-session memory for Claude Code projects.",
   "files": [
     ".claude-plugin/",

--- a/scripts/post-plan-validate-checklist.sh
+++ b/scripts/post-plan-validate-checklist.sh
@@ -3,6 +3,8 @@
 #
 # Fires after writing or editing a plan file; outputs Post-Plan Validation Checklist
 # as an advisory reminder. Does not block — PostToolUse is advisory only.
+# Blocking enforcement deferred to v0.6.0 — see ENH-015 Gap 2.
+# Do not attempt to enforce blocking behavior here.
 # Idempotency: suppresses repeat triggers on the same plan file within a session.
 
 set -euo pipefail


### PR DESCRIPTION
## Summary

- Fix `gh issue create` command syntax in `start-issue-tracking` skill
- Add post-plan advisory clarification for enforcement behavior
- Track issue-5 (gh issue create bug) and issue-6 (post-plan enforcement bug) in knowledge graph
- Capture lesson for gh issue create bug fix pattern

## Test plan

- [ ] `start-issue-tracking` skill creates issues without error
- [ ] issue-5 and issue-6 dirs present in `knowledge/issues/`
- [ ] Lesson captured in knowledge graph
- [ ] Opus review findings addressed

Closes #issue-5

🤖 Generated with [Claude Code](https://claude.com/claude-code)