### PR TITLE
v0.5.10.4: Codex installation fixes

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "kmgraph",
-  "version": "0.5.10.3",
+  "version": "0.5.10.4",
   "description": "Structured knowledge capture, lesson-learned documentation, and cross-session memory for Claude Code projects. Includes KG entries, ADRs, meta-issue tracking, chat extraction, and profile-file rule capture.",
   "author": {
     "name": "technomensch",

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@knowledge-graph-plugin/mcp-server",
-  "version": "0.3.10",
+  "version": "0.3.11",
   "description": "MCP server for Knowledge Management Graph — cross-platform data layer for knowledge capture, search, and management",
   "main": "dist/index.js",
   "bin": {

--- a/mcp-server/src/tools/config.ts
+++ b/mcp-server/src/tools/config.ts
@@ -65,6 +65,7 @@ export function registerConfigTools(server: McpServer): void {
         "decisions",
         "sessions",
         "chat-history",
+        "tmp",
       ];
       for (const dir of dirs) {
         fs.mkdirSync(path.join(expandedPath, dir), { recursive: true });
@@ -90,10 +91,9 @@ export function registerConfigTools(server: McpServer): void {
           "concepts.md",
           "architecture.md",
           "workflows.md",
-          "index.md",
         ];
         for (const t of knowledgeTemplates) {
-          const src = path.join(templateSrc, "knowledge", t);
+          const src = path.join(templateSrc, "knowledge", "templates", t);
           const dest = path.join(expandedPath, "knowledge", t);
           if (fs.existsSync(src) && !fs.existsSync(dest)) {
             fs.copyFileSync(src, dest);
@@ -127,6 +127,23 @@ export function registerConfigTools(server: McpServer): void {
         const sessDest = path.join(expandedPath, "sessions", "session-template.md");
         if (fs.existsSync(sessSrc) && !fs.existsSync(sessDest)) {
           fs.copyFileSync(sessSrc, sessDest);
+        }
+
+        // Copy root scaffold files (me.md, rules.md, kg-index.md, triggers.md)
+        const rootScaffolds = ["me.md", "rules.md", "kg-index.md", "triggers.md"];
+        for (const f of rootScaffolds) {
+          const src = path.join(templateSrc, "knowledge", f);
+          const dest = path.join(expandedPath, f);
+          if (fs.existsSync(src) && !fs.existsSync(dest)) {
+            fs.copyFileSync(src, dest);
+          }
+        }
+
+        // Copy kg-category-index.md to knowledge/ subdir
+        const catIndexSrc = path.join(templateSrc, "knowledge", "kg-category-index.md");
+        const catIndexDest = path.join(expandedPath, "knowledge", "kg-category-index.md");
+        if (fs.existsSync(catIndexSrc) && !fs.existsSync(catIndexDest)) {
+          fs.copyFileSync(catIndexSrc, catIndexDest);
         }
       }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "knowledge-graph-plugin",
-  "version": "0.5.10.3",
+  "version": "0.5.10.4",
   "description": "Structured knowledge capture and cross-session memory for Claude Code projects.",
   "files": [
     ".claude-plugin/",

--- a/scripts/session-end-prompt.sh
+++ b/scripts/session-end-prompt.sh
@@ -4,6 +4,9 @@
 
 CONFIG_PATH="$HOME/.claude/kg-config.json"
 
+# Emit JSON on every exit — required by Codex CLI Stop hook parser on all exit paths
+trap 'echo "{\"decision\": \"continue\"}"' EXIT
+
 # Color codes
 RED='\033[0;31m'
 YELLOW='\033[1;33m'
@@ -164,9 +167,5 @@ fi
 
 # Create session flag to avoid double-prompting
 touch "$FLAG_PATH"
-
-# Output JSON to stdout — required by Codex CLI Stop hook parser
-# Claude Code reads this as context; human output above is visible via stderr
-echo '{"decision": "continue"}'
 
 exit 0

--- a/scripts/session-end-prompt.sh
+++ b/scripts/session-end-prompt.sh
@@ -141,28 +141,32 @@ HAS_ITEMS=false
 [ -n "$LESSON_MSG" ] && HAS_ITEMS=true
 
 if [ "$HAS_ITEMS" = true ]; then
-    echo ""
-    echo -e "${BLUE}Before you go —${NC}"
-    echo ""
-    [ -n "$OPEN_PLAN_MSG" ] && echo -e "${YELLOW}$OPEN_PLAN_MSG${NC}"
-    [ -n "$DRAFT_ADR_MSG" ] && echo -e "${YELLOW}$DRAFT_ADR_MSG${NC}"
-    [ -n "$LESSON_MSG" ] && echo -e "${YELLOW}$LESSON_MSG${NC}"
-    echo ""
+    echo "" >&2
+    echo -e "${BLUE}Before you go —${NC}" >&2
+    echo "" >&2
+    [ -n "$OPEN_PLAN_MSG" ] && echo -e "${YELLOW}$OPEN_PLAN_MSG${NC}" >&2
+    [ -n "$DRAFT_ADR_MSG" ] && echo -e "${YELLOW}$DRAFT_ADR_MSG${NC}" >&2
+    [ -n "$LESSON_MSG" ] && echo -e "${YELLOW}$LESSON_MSG${NC}" >&2
+    echo "" >&2
     if [ "$SNAPSHOT_TODAY" = true ]; then
-        echo "You have a session snapshot from today — run /kmgraph:session-summary to complete the wrap-up."
+        echo "You have a session snapshot from today — run /kmgraph:session-summary to complete the wrap-up." >&2
     else
-        echo "Run /kmgraph:session-summary to document this session."
+        echo "Run /kmgraph:session-summary to document this session." >&2
     fi
-    echo ""
+    echo "" >&2
 else
     if [ "$SNAPSHOT_TODAY" = true ]; then
-        echo -e "${GREEN}✅ Session snapshot taken. Run /kmgraph:session-summary to finalize the wrap-up.${NC}"
+        echo -e "${GREEN}✅ Session snapshot taken. Run /kmgraph:session-summary to finalize the wrap-up.${NC}" >&2
     else
-        echo -e "${GREEN}✅ Good stopping point. /kmgraph:session-summary if you'd like a summary.${NC}"
+        echo -e "${GREEN}✅ Good stopping point. /kmgraph:session-summary if you'd like a summary.${NC}" >&2
     fi
 fi
 
 # Create session flag to avoid double-prompting
 touch "$FLAG_PATH"
+
+# Output JSON to stdout — required by Codex CLI Stop hook parser
+# Claude Code reads this as context; human output above is visible via stderr
+echo '{"decision": "continue"}'
 
 exit 0


### PR DESCRIPTION
## Summary

- Fix hooks: use `trap` to emit JSON on all exit paths for Codex CLI Stop hook compatibility
- Fix hooks: route stop hook display output to stderr, emit JSON to stdout
- Fix MCP: `kg_config_init` scaffold wrong template path, missing root files, missing tmp dir
- Bump version to 0.5.10.4

## Test plan

- [ ] Verify Stop hook emits `{"decision": "continue"}` on stdout in Codex CLI
- [ ] Verify `kg_config_init` scaffolds correctly with all expected files
- [ ] Confirm session-end-prompt displays correctly in Claude Code (stderr output unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)