### PR TITLE
v0.5.10.5: Codex CLI chat history extraction (ENH-024)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "kmgraph",
-  "version": "0.5.10.4",
+  "version": "0.5.10.5",
   "description": "Structured knowledge capture, lesson-learned documentation, and cross-session memory for Claude Code projects. Includes KG entries, ADRs, meta-issue tracking, chat extraction, and profile-file rule capture.",
   "author": {
     "name": "technomensch",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Released]
 
+## [0.5.10.5] — 2026-06-12
+
+### Added
+- **extract-chat: Codex CLI chat history extraction** — New `--source codex` option extracts Codex CLI sessions from `~/.codex/sessions/YYYY/MM/DD/rollout-*.jsonl`
+- Filters platform-injected context blocks (AGENTS.md, environment_context, permissions); retains only real user/assistant turns
+- Per-session header includes `cwd` and `git.branch` from `session_meta`
+- `--project` filter matches `session_meta.cwd` substring
+- Not included in `--source all` yet — use `--source codex` explicitly until cross-platform date semantics validated
+- Implements ENH-024
+
+## [0.5.10.4] — 2026-06-12
+
+### Fixed
+- **MCP server: `kg_config_init` template path was one level too shallow** — All knowledge templates silently skipped on init. Path corrected from `core/templates/knowledge/` to `core/templates/knowledge/templates/`.
+- **MCP server: stale `index.md` removed from knowledge template list** — File does not exist; prevented successful scaffold.
+- **MCP server: root scaffold files never copied to KG root** — `me.md`, `rules.md`, `kg-index.md`, `triggers.md` were not copied to KG root; `kg-category-index.md` was not copied to `knowledge/` subdir
+- **MCP server: `tmp/` directory missing from scaffold dirs array** — Directory structure incomplete on init.
+- **Hooks: Stop hook (`session-end-prompt.sh`) now emits valid JSON on stdout** — Previous plain-text output caused `hook returned invalid stop hook JSON` error on every invocation when invoked via Codex CLI. Hook now emits `{"decision": "continue"}` via `trap EXIT` to satisfy Codex CLI Stop hook JSON contract.
+
 ## [0.5.10.3] — 2026-06-11
 
 ### Fixed

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -247,6 +247,7 @@ done
 | **v0.5.10** | No upgrade action required. `start-issue-tracking` Step 1.2 improved UX and `continues_from` handoff field are automatic after plugin reload. |
 | **v0.5.10.1** | No upgrade action required. Session summary operational sections, zone structure, one-file-per-day enforcement, and reduced handoff package are automatic after plugin reload. Run `/reload-plugins` to activate. Note: `--skip-sessions` flag for `/kmgraph:handoff` has been removed (SESSION-COMPILATION no longer generated). |
 | **v0.5.10.2** | Codex CLI marketplace support added — no upgrade action required for existing Claude Code installs. Codex users: run `codex plugin marketplace add technomensch/knowledge-graph` then `codex plugin add kmgraph@knowledge-management-graph`. Security: `shell-quote` dependency pinned to `>=1.8.4` automatically on `npm install`. |
+| **v0.5.10.3–v0.5.10.5** | No upgrade action required. Bug fixes and improvements are automatic after plugin reload. |
 
 After the wizard completes, your existing lessons, ADRs, sessions, and chat history are untouched.
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Structured knowledge capture, lesson-learned documentation, and cross-session memory for Claude Code projects.
 
-**Version:** 0.5.10.3
+**Version:** 0.5.10.5
 **Status:** Actively developed and in daily use
 
 Documentation: https://kmgraph.stayinginsync.info
@@ -74,7 +74,7 @@ Pull the latest version and run `/kmgraph:init` in any project that uses it. The
 - `/kmgraph:switch` — Change active knowledge graph
 - `/kmgraph:check-sensitive` — Scan knowledge graph for potentially sensitive information
 - `/kmgraph:config-sanitization` — Interactive wizard for pre-commit hook setup
-- `/kmgraph:extract-chat` — Extract chat history from Claude and Gemini logs
+- `/kmgraph:extract-chat` — Extract chat history from Claude, Gemini, and Codex CLI logs (`--source codex` for Codex sessions)
 - `/kmgraph:update-doc` — Update plugin/project documentation (`--user-facing`) or KG content
 - `/kmgraph:init-personal-kg` — Initialize a personal knowledge graph at `~/.kmgraph/` shared across all projects
 
@@ -90,6 +90,10 @@ Pull the latest version and run `/kmgraph:init` in any project that uses it. The
 ---
 
 ## v0.5.x Feature Highlights
+
+**v0.5.10.5 — 2026-06-12**
+
+- **`extract-chat` adds Codex CLI source** — `/kmgraph:extract-chat` now accepts `--source codex` to extract chat history from Codex CLI sessions. Pass `--source codex` (or omit `--source` and select Codex from the interactive prompt) to index Codex conversation logs alongside existing Claude and Gemini sources.
 
 **v0.5.10.3 — 2026-06-11**
 
@@ -122,7 +126,7 @@ Pull the latest version and run `/kmgraph:init` in any project that uses it. The
 - **Decision governance protocol enforced at hook level** — `pre-skill-rules-inject.sh` now hard-blocks brainstorming and planning without a prior knowledge-graph recall. Two recall queries are required before any plan is written (topic + architectural domain). Recall misses are logged to `/tmp/kmgraph-recall-miss-*.log` for audit. Remote-session compatibility: embedded-rules block is written directly into plan files so Ultraplan and other non-hook contexts carry the enforcement.
 - **New `brainstorm-recall` skill** — Fires before `adr-guide` and invokes `kmgraph:recall` before any recommendation. Results appear under a "Prior Art" heading so past decisions surface before new ones are made.
 - **`gov-execute-plan` cascade gate** — When a new ADR is captured mid-session, execution is paused before the next plan task so the user can review cascade impact. ADR flag is day-scoped and cleaned at branch finish.
-- **Chat-history now searchable** — `mcp-server/src/tools/fts5.ts` adds `chat-history` to `searchDirs`; exported chat logs are indexed and reachable via `kg_search`.
+- **Chat-history now searchable** — `mcp-server/src/tools/fts5.ts` adds `chat-history` to `searchDirs`; exported chat logs (Claude, Gemini, Codex CLI) are indexed and reachable via `kg_search`.
 - **Session-documenter Relay Contract** — Draft session summaries are now displayed verbatim before save/edit/cancel options. No silent summarization.
 - **Post-plan validation checklist** — A PostToolUse:Write hook fires after any `plans/*.md` write and outputs an advisory validation checklist.
 - **Canonical rules registry** — `core/rules-registry/` stores authoritative rule text; all deployment surfaces (templates, profile files) copy from here.
@@ -244,7 +248,7 @@ knowledge-graph/
 
 ## Development Status
 
-**Current Release:** v0.5.10.3 (2026-06-11)
+**Current Release:** v0.5.10.5 (2026-06-12)
 
 Actively developed and in daily use. Behavior may evolve between minor versions.
 
@@ -346,6 +350,6 @@ MIT License - See [LICENSE](LICENSE)
 ---
 
 **Created:** 2026-02-12
-**Current Version:** v0.5.10.3 (2026-06-11)
+**Current Version:** v0.5.10.5 (2026-06-12)
 
 📚 **Full documentation:** https://kmgraph.stayinginsync.info

--- a/commands/extract-chat.md
+++ b/commands/extract-chat.md
@@ -1,10 +1,12 @@
 ---
-description: Extract chat history from Claude and Gemini local log sources
+description: Extract chat history from Claude, Gemini, and Codex CLI local log sources
 ---
+
+<!-- Updated: 2026-06-12 -->
 
 # Extract Chat History
 
-Automates the extraction of chat history from local Claude (.jsonl) and Gemini (.json/.pb) log files.
+Automates the extraction of chat history from local Claude (.jsonl), Gemini (.json/.pb), and Codex CLI (.jsonl) log files.
 
 ---
 
@@ -24,25 +26,37 @@ This parses chat logs and extracts insights without consuming your main context,
 
 ```bash
 /kmgraph:extract-chat [-claude | -gemini]
+/kmgraph:extract-chat --source codex
+/kmgraph:extract-chat --source all
 /kmgraph:extract-chat --output-dir=<path>
 /kmgraph:extract-chat -claude --output-dir=<custom-path>
 /kmgraph:extract-chat -claude 2026-02-20 through 2026-02-21
 /kmgraph:extract-chat --today
 /kmgraph:extract-chat --project=knowledge-graph
+/kmgraph:extract-chat --source codex --after=2026-01-01
 ```
 
 ---
 
 ## Options
 
-- `-claude`: Extract only Claude Code session history
-- `-gemini`: Extract only Antigravity/Gemini session history
-- (no option): Extract all available history
+**Source selection:**
+- `-claude`: Extract only Claude Code session history (shorthand for `--source claude`)
+- `-gemini`: Extract only Antigravity/Gemini session history (shorthand for `--source gemini`)
+- `--source codex`: Extract only Codex CLI sessions from `~/.codex/sessions/YYYY/MM/DD/rollout-*.jsonl`; outputs `YYYY-MM-DD-codex.md`
+- `--source all`: Extract Claude and Gemini sessions; does **not** include Codex (use `--source codex` explicitly)
+- (no option): Extract all available Claude and Gemini history (same as `--source all`)
+
+**Output:**
 - `--output-dir=<path>`: Override output directory (default: active KG's chat-history/)
+
+**Date filtering:**
 - `--today`: Extract only today's sessions (convenience flag)
 - `--date=YYYY-MM-DD`: Extract only sessions from a specific date
 - `--after=YYYY-MM-DD`: Extract sessions from this date onwards (inclusive)
 - `--before=YYYY-MM-DD`: Extract sessions up to and including this date
+
+**Filtering:**
 - `--project=<fragment>`: Filter to sessions from a specific project (path fragment match against `~/.claude/projects/<name>/`)
 
 ---
@@ -70,6 +84,18 @@ The workflow runs the centralized Python extraction script located at `${CLAUDE_
 **Protobuf support:**
 - Requires `blackboxprotobuf` library (optional)
 - Falls back to JSON-only if protobuf library not installed
+
+### Codex CLI Extraction
+
+1. **Scans:** `~/.codex/sessions/YYYY/MM/DD/` for `rollout-*.jsonl` files
+2. **Parses:** UTC timestamps in each turn, converted to local date and time
+3. **Merges:** By local date into `YYYY-MM-DD-codex.md`
+4. **Output:** `{output_dir}/YYYY-MM-DD-codex.md`
+
+**Notes:**
+- Codex is not included in `--source all` pending date-semantics validation across platforms — use `--source codex` explicitly
+- System injection turns (internal Codex context) are filtered out of the output
+- Large file splitting and incremental append behavior apply the same as Claude/Gemini extraction
 
 ---
 
@@ -103,11 +129,14 @@ mkdir -p "$output_dir"
 ```bash
 # Parse user input
 case "$input" in
-  *-claude*)
+  *-claude* | *--source\ claude*)
     source_flag="claude"
     ;;
-  *-gemini*)
+  *-gemini* | *--source\ gemini*)
     source_flag="gemini"
+    ;;
+  *--source\ codex*)
+    source_flag="codex"
     ;;
   *)
     source_flag="all"
@@ -189,6 +218,26 @@ python3 ${CLAUDE_PLUGIN_ROOT}/core/scripts/run_extraction.py --source $source_fl
 ---
 
 ## Conversation 2: Another Topic (HH:MM - HH:MM)
+
+[...]
+```
+
+### Codex History Files
+
+```markdown
+# Chat History: YYYY-MM-DD (Codex)
+
+## Session 1 (HH:MM - HH:MM)
+
+**User:**
+[Message content]
+
+**Assistant:**
+[Response content]
+
+---
+
+## Session 2 (HH:MM - HH:MM)
 
 [...]
 ```
@@ -279,13 +328,21 @@ When multiple knowledge graphs are configured:
 ### Problem: No chat history found
 
 **Solution:**
-- Verify Claude/Gemini log directories exist:
+- Verify log directories exist:
   ```bash
   ls ~/.claude/projects/
   ls ~/.gemini/tmp/
+  ls ~/.codex/sessions/
   ```
-- Check if you've used Claude Code or Gemini recently
+- Check if the relevant tool has been used recently
 - Logs may be cleared on app updates
+
+### Problem: Codex extraction returns no sessions
+
+**Solution:**
+- Verify the sessions directory structure: `~/.codex/sessions/YYYY/MM/DD/rollout-*.jsonl`
+- Check that `--source codex` was used (Codex is not included in `--source all`)
+- Confirm Codex CLI has been used since the directory was created
 
 ### Problem: Protobuf extraction fails
 
@@ -416,6 +473,34 @@ Extracting Claude history (project filter: knowledge-graph)...
 Saved to: {active_kg_path}/chat-history/2026-02-21-claude.md
 ```
 
+### Example 7: Extract Codex CLI sessions
+
+```bash
+/kmgraph:extract-chat --source codex
+```
+
+**Output:**
+```
+Extracting Codex CLI history...
+✅ Codex: Found 4 sessions (2026-06-12)
+
+Saved to: {active_kg_path}/chat-history/2026-06-12-codex.md
+```
+
+### Example 8: Extract Codex sessions from a date onwards
+
+```bash
+/kmgraph:extract-chat --source codex --after=2026-01-01
+```
+
+**Output:**
+```
+Extracting Codex CLI history (from 2026-01-01)...
+✅ Codex: Found sessions for 12 dates
+
+Saved to: {active_kg_path}/chat-history/2026-01-*.codex.md (12 files)
+```
+
 ---
 
 ## Non-Claude Code Usage
@@ -438,6 +523,7 @@ Saved to: {active_kg_path}/chat-history/2026-02-21-claude.md
 ---
 
 **Created:** 2026-02-12
-**Version:** 1.0 (Plugin version with OUTPUT_DIR fix)
+**Updated:** 2026-06-12
+**Version:** 1.1 (Added Codex CLI extraction — ENH-024)
 **Integration:** Works with active KG, `/kmgraph:recall`, session summaries
 **Related Skills:** /kmgraph:session-summary, /kmgraph:capture-lesson

--- a/core/scripts/extract_codex.py
+++ b/core/scripts/extract_codex.py
@@ -1,0 +1,239 @@
+import os
+import json
+import glob
+from datetime import datetime, timezone
+from typing import List, Optional
+from collections import defaultdict
+from chat_extractor_base import (
+    get_output_path, format_timestamp, write_markdown_header,
+    write_message_block, split_file_if_oversized,
+)
+
+CODEX_SESSIONS_DIR = os.path.expanduser("~/.codex/sessions")
+
+
+def _parse_ts_utc(ts: str) -> Optional[float]:
+    """Parse UTC ISO timestamp to epoch float."""
+    if not ts:
+        return None
+    for fmt in (
+        "%Y-%m-%dT%H:%M:%S.%fZ",
+        "%Y-%m-%dT%H:%M:%SZ",
+        "%Y-%m-%dT%H:%M:%S.%f",
+        "%Y-%m-%dT%H:%M:%S",
+    ):
+        try:
+            return datetime.strptime(ts, fmt).replace(tzinfo=timezone.utc).timestamp()
+        except ValueError:
+            continue
+    return None
+
+
+def _utc_to_local_date(ts: str) -> Optional[str]:
+    epoch = _parse_ts_utc(ts)
+    if epoch is None:
+        return None
+    return datetime.fromtimestamp(epoch).strftime("%Y-%m-%d")
+
+
+def _utc_to_local_hms(ts: str) -> Optional[str]:
+    epoch = _parse_ts_utc(ts)
+    if epoch is None:
+        return None
+    return datetime.fromtimestamp(epoch).strftime("%H%M%S")
+
+
+_INJECTION_PREFIXES = (
+    "# AGENTS.md instructions",
+    "<environment_context>",
+    "<permissions instructions>",
+    "<INSTRUCTIONS>",
+)
+
+
+def _extract_text(content_list) -> str:
+    """Join all input_text/output_text parts from a content array."""
+    if not content_list:
+        return ""
+    return "".join(
+        item.get("text", "")
+        for item in content_list
+        if isinstance(item, dict) and item.get("type") in ("input_text", "output_text")
+    )
+
+
+def _is_system_injection(text: str) -> bool:
+    """True if text is a platform-injected context block (not a real human turn)."""
+    stripped = text.lstrip()
+    return any(stripped.startswith(p) for p in _INJECTION_PREFIXES)
+
+
+def extract_codex_sessions(
+    date_filter: Optional[str] = None,
+    after_date: Optional[str] = None,
+    before_date: Optional[str] = None,
+    project_filter: Optional[str] = None,
+    incremental: bool = False,
+    limit: Optional[int] = None,
+) -> List[str]:
+    """
+    Scans ~/.codex/sessions/YYYY/MM/DD/ for rollout-*.jsonl files and extracts
+    user/assistant turns into per-date markdown files (YYYY-MM-DD-codex.md).
+
+    Date keys are derived from session_meta.timestamp converted to local time,
+    not from the directory path (which is UTC-based and causes midnight skew).
+
+    Not included in --source all until date semantics are validated across platforms.
+    Use --source codex explicitly.
+    """
+    if not os.path.isdir(CODEX_SESSIONS_DIR):
+        return [f"Skipped: {CODEX_SESSIONS_DIR} not found"]
+
+    results = []
+    all_sessions = []
+
+    jsonl_files = glob.glob(
+        os.path.join(CODEX_SESSIONS_DIR, "**", "rollout-*.jsonl"), recursive=True
+    )
+
+    for jsonl_path in jsonl_files:
+        if os.path.getsize(jsonl_path) == 0:
+            continue
+
+        meta = {}
+        messages = []
+        session_ts = None
+
+        try:
+            with open(jsonl_path, "r", encoding="utf-8") as f:
+                for line in f:
+                    line = line.strip()
+                    if not line:
+                        continue
+                    try:
+                        obj = json.loads(line)
+                    except json.JSONDecodeError:
+                        continue
+
+                    event_type = obj.get("type", "")
+
+                    if event_type == "session_meta":
+                        payload = obj.get("payload") or {}
+                        meta = {
+                            "cwd": payload.get("cwd", ""),
+                            "branch": (payload.get("git") or {}).get("branch", ""),
+                            "cli_version": payload.get("cli_version", ""),
+                        }
+                        session_ts = obj.get("timestamp") or payload.get("timestamp")
+
+                    elif event_type == "response_item":
+                        payload = obj.get("payload") or {}
+                        role = payload.get("role")
+                        # Skip developer (system injections) and encrypted tool calls
+                        if role not in ("user", "assistant"):
+                            continue
+                        content_list = payload.get("content") or []
+                        text = _extract_text(content_list)
+                        if not text.strip() or _is_system_injection(text):
+                            continue
+                        ts = obj.get("timestamp") or session_ts
+                        messages.append({
+                            "role": role,
+                            "content": text,
+                            "timestamp": ts,
+                        })
+
+        except Exception as e:
+            print(f"Error reading {jsonl_path}: {e}")
+            continue
+
+        if not messages or not session_ts:
+            continue
+
+        # Derive local date from session_meta UTC timestamp (not directory path)
+        session_date = _utc_to_local_date(session_ts)
+        session_hms = _utc_to_local_hms(session_ts) or "000000"
+        if not session_date:
+            continue
+
+        # --project filter via session_meta.cwd substring (case-insensitive)
+        if project_filter and project_filter.lower() not in meta.get("cwd", "").lower():
+            continue
+
+        messages.sort(key=lambda m: m.get("timestamp") or "")
+
+        all_sessions.append({
+            "date": session_date,
+            "ts_str": session_hms,
+            "messages": messages,
+            "count": len(messages),
+            "meta": meta,
+        })
+
+    if limit:
+        all_sessions = all_sessions[:limit]
+
+    sessions_by_date = defaultdict(list)
+    for session in all_sessions:
+        sessions_by_date[session["date"]].append(session)
+
+    # Date filtering
+    if date_filter:
+        sessions_by_date = {k: v for k, v in sessions_by_date.items() if k == date_filter}
+    else:
+        if after_date:
+            sessions_by_date = {k: v for k, v in sessions_by_date.items() if k >= after_date}
+        if before_date:
+            sessions_by_date = {k: v for k, v in sessions_by_date.items() if k <= before_date}
+
+    for date, sessions in sessions_by_date.items():
+        sessions.sort(key=lambda s: s["ts_str"])
+
+        filename = f"{date}-codex.md"
+        output_path = get_output_path(filename)
+
+        if incremental and os.path.exists(output_path):
+            age = datetime.now().timestamp() - os.path.getmtime(output_path)
+            if age <= 3600:
+                results.append(
+                    f"Skipped {filename} (already current, modified {int(age / 60)} min ago)"
+                )
+                continue
+
+        total_messages = sum(s["count"] for s in sessions)
+
+        with open(output_path, "w", encoding="utf-8") as f:
+            write_markdown_header(f, "Codex CLI", total_messages, date)
+
+            global_idx = 1
+            for sess_idx, session in enumerate(sessions, 1):
+                if len(sessions) > 1:
+                    m = session["meta"]
+                    parts = []
+                    if m.get("cwd"):
+                        parts.append(f"cwd: {m['cwd']}")
+                    if m.get("branch"):
+                        parts.append(f"branch: {m['branch']}")
+                    label = f"({', '.join(parts)})" if parts else ""
+                    f.write(f"## Session {sess_idx} {label}\n\n")
+
+                for msg in session["messages"]:
+                    write_message_block(
+                        f, global_idx, msg["role"],
+                        format_timestamp(msg["timestamp"]),
+                        msg["content"],
+                    )
+                    global_idx += 1
+
+                if sess_idx < len(sessions):
+                    f.write("\n---\n\n")
+
+        split_parts = split_file_if_oversized(output_path)
+        if split_parts:
+            results.append(
+                f"Created {filename}: split into {len(split_parts)} parts in {date}/ subfolder"
+            )
+        else:
+            results.append(f"Created {filename} with {total_messages} messages")
+
+    return results

--- a/core/scripts/run_extraction.py
+++ b/core/scripts/run_extraction.py
@@ -10,7 +10,7 @@ from datetime import datetime
 
 def main():
     parser = argparse.ArgumentParser(description="Extract Chat History from Local Sources")
-    parser.add_argument("--source", choices=['all', 'claude', 'gemini'], default='all', help="Source to extract from")
+    parser.add_argument("--source", choices=['all', 'claude', 'gemini', 'codex'], default='all', help="Source to extract from (codex not included in 'all' until validated)")
     parser.add_argument("--limit", type=int, default=None, help="Limit number of samples for testing")
     parser.add_argument("--output-dir", type=str, default=None, help="Override output directory (default: auto-detect from active KG)")
 
@@ -41,12 +41,18 @@ def main():
     # Import AFTER setting environment variable
     from extract_claude import extract_claude_sessions
     from extract_gemini import extract_all_gemini
+    from extract_codex import extract_codex_sessions
     from chat_extractor_base import get_output_path
 
     # Interactive prompt for --today if file exists (only if running in terminal)
     if args.today and sys.stdin.isatty():
         date_str = args.date
-        filename = f"{date_str}-claude.md" if args.source in ['all', 'claude'] else f"{date_str}-gemini.md"
+        if args.source in ['all', 'claude']:
+            filename = f"{date_str}-claude.md"
+        elif args.source == 'codex':
+            filename = f"{date_str}-codex.md"
+        else:
+            filename = f"{date_str}-gemini.md"
         output_path = get_output_path(filename)
 
         if os.path.exists(output_path):
@@ -63,7 +69,12 @@ def main():
     elif args.today and not sys.stdin.isatty():
         # Non-interactive mode: just show info and proceed
         date_str = args.date
-        filename = f"{date_str}-claude.md" if args.source in ['all', 'claude'] else f"{date_str}-gemini.md"
+        if args.source in ['all', 'claude']:
+            filename = f"{date_str}-claude.md"
+        elif args.source == 'codex':
+            filename = f"{date_str}-codex.md"
+        else:
+            filename = f"{date_str}-gemini.md"
         output_path = get_output_path(filename)
         if os.path.exists(output_path):
             file_size = os.path.getsize(output_path)
@@ -96,7 +107,18 @@ def main():
         )
         results.extend(gemini_res)
 
-        
+    if args.source == 'codex':
+        print("Processing Codex CLI sessions...")
+        codex_res = extract_codex_sessions(
+            date_filter=args.date,
+            after_date=args.after,
+            before_date=args.before,
+            project_filter=args.project,
+            incremental=args.incremental,
+            limit=args.limit,
+        )
+        results.extend(codex_res)
+
     print("-" * 40)
     print("Extraction Complete.")
     print(f"Total sessions processed: {len(results)}")

--- a/docs/CHEAT-SHEET.md
+++ b/docs/CHEAT-SHEET.md
@@ -62,7 +62,7 @@ Active users use these for regular workflows:
 | `/kmgraph:switch` | Change active knowledge graph |
 | `/kmgraph:check-sensitive` | Scan knowledge graph for potentially sensitive information |
 | `/kmgraph:config-sanitization` | Interactive wizard for pre-commit hook setup |
-| `/kmgraph:extract-chat` | Extract chat history from Claude and Gemini logs (`--today`, `--date`, `--after`, `--before`, `--project`); large days auto-split into `YYYY-MM-DD/` subfolder |
+| `/kmgraph:extract-chat` | Extract chat history from Claude, Gemini, and Codex logs (`--today`, `--date`, `--after`, `--before`, `--project`); large days auto-split into `YYYY-MM-DD/` subfolder |
 | `/kmgraph:update-doc` | Update plugin/project docs (`--user-facing`) or KG content |
 
 *→ [Full details in Command Guide](reference/command-guide.md#intermediate-commands)*

--- a/docs/pillars/portability/migrate-claude-gemini.md
+++ b/docs/pillars/portability/migrate-claude-gemini.md
@@ -24,10 +24,11 @@ This writes a summary to `docs/sessions/` and updates MEMORY.md pointers. Commit
 ## Export chat history
 
 ```bash
-/kmgraph:extract-chat
+/kmgraph:extract-chat          # Claude + Gemini history
+/kmgraph:extract-chat --source codex   # Codex CLI history (if applicable)
 ```
 
-Extracts any lessons from the departing session that haven't been formally captured yet.
+Extracts session history from the departing platform into the active KG's `chat-history/` directory, making it available for `/kmgraph:recall` and lesson extraction on the target platform.
 
 ## Point to the same graph
 
@@ -58,6 +59,7 @@ Copy the contents of `core/templates/AGENTS-template.md` into your project's `AG
 - MCP tools (`kg_*`) work the same on any MCP-enabled IDE
 - MEMORY.md is human-readable markdown — the target platform can load it directly
 - Full automation (slash commands, hooks) is Claude Code-exclusive; other platforms use the MCP tools or manual workflow
+- Codex CLI chat history can be extracted with `--source codex`; see [`/kmgraph:extract-chat`](/knowledge-graph/commands/extract-chat) for the full source flag reference
 
 ## Related
 

--- a/docs/pillars/tailoring/automation-layer.md
+++ b/docs/pillars/tailoring/automation-layer.md
@@ -69,12 +69,14 @@ Skills listen for natural-language signals. They never execute commands automati
 | **docs-impact-scan** | "push to origin", "push and merge", "open PR", "create PR", "finishing up", "ready to push" |
 | **sidebar-update** | Doc file moved or renamed, `git mv docs/...`, "move [doc]", "rename [doc]" |
 
+The docs-impact-scan skill runs an eight-step pre-push workflow — diff scan, docs grep, user confirmation, and update-doc dispatch. See [Docs Impact Scan](./docs-impact-scan.md) for the full workflow and pre-push gate details.
+
 ## Hooks and their lifecycle events
 
 | Hook script | Fires on | Default |
 |---|---|---|
 | `hooks-master.sh` (router) | All events | Enabled |
-| `session-end-prompt.sh` | Stop | Prompts for session summary |
+| `session-end-prompt.sh` | Stop | Prompts for session summary; Codex CLI-compatible (emits JSON decision on stdout via `trap EXIT`) |
 | `post-tool-lesson-check.sh` | PostToolUse | Prompts for lesson capture after certain tools |
 | `platform-file-change-check.sh` | PostToolUse | Detects changes to CLAUDE.md / AGENTS.md |
 | `plan-mirror.sh` | PostToolUse | Mirrors plan files from `~/.claude/plans/` to `docs/plans/` |

--- a/docs/pillars/tailoring/customize-hooks.md
+++ b/docs/pillars/tailoring/customize-hooks.md
@@ -74,7 +74,7 @@ mv hooks/hooks.json.disabled hooks/hooks.json
 | `post-tool-lesson-check.sh` | Prompts for lesson capture after solving | Yes |
 | `platform-file-change-check.sh` | Detects changes to CLAUDE.md / AGENTS.md | Yes |
 | `pre-commit-knowledge-gate.sh` | Blocks commits that skip knowledge capture | Yes (reduces automation) |
-| `session-end-prompt.sh` | Prompts for session summary on Stop | Yes |
+| `session-end-prompt.sh` | Prompts for session summary on Stop; Codex CLI-compatible | Yes |
 | `plan-mirror.sh` | Mirrors plan files from `~/.claude/plans/` to `docs/plans/` | Yes |
 | `notification-dispatch.sh` | Sends webhook notifications | Yes (if webhook not configured) |
 

--- a/docs/reference/command-guide.md
+++ b/docs/reference/command-guide.md
@@ -789,12 +789,19 @@ Test the hook:
 **What it does**:
 
 1. Determines output directory (active KG's `chat-history/` by default, or custom path)
-2. Scans Claude logs (`~/.claude/projects/` for `.jsonl` files) and/or Gemini logs (`~/.gemini/tmp/`, `~/.gemini/antigravity/conversations/` for `.json`/`.pb` files)
-3. Merges sessions by date into `YYYY-MM-DD-claude.md` and/or `YYYY-MM-DD-gemini.md`
+2. Scans Claude logs (`~/.claude/projects/` for `.jsonl` files), Gemini logs (`~/.gemini/tmp/`, `~/.gemini/antigravity/conversations/` for `.json`/`.pb` files), and/or Codex CLI sessions (`~/.codex/sessions/YYYY/MM/DD/rollout-*.jsonl`)
+3. Merges sessions by date into `YYYY-MM-DD-claude.md`, `YYYY-MM-DD-gemini.md`, and/or `YYYY-MM-DD-codex.md`
 4. If a daily file exceeds 900 KB or 30,000 lines, automatically splits into numbered parts (`-part1.md`, `-part2.md`, …) inside a `YYYY-MM-DD/` subfolder to prevent Obsidian rendering failures
 5. Supports incremental append — re-running adds new sessions without overwriting; appends target the last part file if the day was previously split
 
 **Time**: Under 30 seconds
+
+**Source flags**:
+
+- `-claude` — Extract only Claude sessions
+- `-gemini` — Extract only Gemini sessions
+- `--source codex` — Extract only Codex CLI sessions from `~/.codex/sessions/YYYY/MM/DD/rollout-*.jsonl`; outputs `YYYY-MM-DD-codex.md`
+- `--source all` — Extract Claude and Gemini sessions; does not include Codex yet, use `--source codex` explicitly
 
 **Date filtering options**:
 
@@ -809,10 +816,12 @@ Test the hook:
 /kmgraph:extract-chat                                          # Extract all (Claude + Gemini)
 /kmgraph:extract-chat -claude                                  # Extract only Claude
 /kmgraph:extract-chat -gemini                                  # Extract only Gemini
+/kmgraph:extract-chat --source codex                          # Extract only Codex CLI sessions
 /kmgraph:extract-chat --output-dir=/custom/path               # Custom output location
 /kmgraph:extract-chat --today                                  # Today only
 /kmgraph:extract-chat -claude 2026-02-20 through 2026-02-21   # Date range
 /kmgraph:extract-chat --project=knowledge-graph               # Specific project only
+/kmgraph:extract-chat --source codex --after 2026-01-01       # Codex sessions from a date onwards
 ```
 
 **Tips**:

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -5,7 +5,7 @@ sidebar_label: Commands
 description: Every KMGraph slash command — category, description, and key flags
 ---
 
-**Version:** 0.5.2 | All commands use the `/kmgraph:` prefix in Claude Code. Other platforms access equivalent functionality through `kg_*` MCP tools — see [INSTALL.md](../INSTALL.md) for details.
+**Version:** 0.5.10.5 | All commands use the `/kmgraph:` prefix in Claude Code. Other platforms access equivalent functionality through `kg_*` MCP tools — see [INSTALL.md](../INSTALL.md) for details.
 
 <img src="/img/demos/session-summary.gif" alt="KMGraph session-summary demo — snapshot of captured lessons and open plans" width="800" />
 
@@ -38,7 +38,7 @@ description: Every KMGraph slash command — category, description, and key flag
 | [`/kmgraph:capture-lesson`](#capture-lesson) | Document lessons learned with git metadata, duplicate detection, and optional KG extraction | `--user`, `--project`, `--named=<kg>` |
 | [`/kmgraph:create-adr`](#create-adr) | Create Architecture Decision Records with auto-numbering, index update, and automatic capture of implementation commit + subject line | `--user`, `--project`, `--named=<kg>` |
 | [`/kmgraph:session-summary`](#session-summary) | Summarize the active session; supports lightweight mid-session snapshot mode | `--auto`, `--snapshot`, `--snapshot --git`, `--user`, `--project`, `--named=<kg>` |
-| [`/kmgraph:extract-chat`](#extract-chat) | Export Claude and Gemini chat logs to dated markdown files | `--today`, `--date=YYYY-MM-DD`, `--after=`, `--before=`, `--project=`, `-claude`, `-gemini`, `--output-dir=` |
+| [`/kmgraph:extract-chat`](#extract-chat) | Export Claude and Gemini chat logs to dated markdown files; extract Codex CLI sessions with `--source codex` (outputs `YYYY-MM-DD-codex.md`; not included in `--source all` yet) | `--today`, `--date=YYYY-MM-DD`, `--after=`, `--before=`, `--project=`, `--source claude\|gemini\|codex\|all`, `--output-dir=` |
 | [`/kmgraph:handoff`](#handoff) | Generate a handoff package (thin START-HERE pointer, DOCUMENTATION-MAP, ARCHITECTURE-SNAPSHOT) | `--output-dir=` |
 | [`/kmgraph:rules-capture`](#rules-capture) | Detect and route a behavioral correction to `rules.md` or `me.md` (project or personal scope) | — |
 

--- a/docs/reference/hooks.md
+++ b/docs/reference/hooks.md
@@ -55,7 +55,7 @@ Hooks with a `matcher` field fire only when the tool name (and optionally the to
 | `plan-mirror.sh` | `PostToolUse` | `Write` | Yes | Detects writes to `~/.claude/plans/`; copies the file to `docs/plans/` in the active KG project root; exits silently if the target directory does not exist |
 | `pre-commit-knowledge-gate.sh` | `PreToolUse` | `Bash.*git commit` | Yes | Intercepts plain `git commit` calls (skips `--amend` and `--no-verify`); checks staged files for lesson-worthy source types (`src/`, `*.ts`, `*.py`, `*.sh`, etc.); advisory prompt only — does not block the commit |
 | `pre-skill-rules-inject.sh` | `PreToolUse` | `Skill` | Yes | Fires before any superpowers skill invocation; injects `~/.kmgraph/rules.md` overrides into skill context; hard-blocks brainstorming and planning without a prior recall query; enforces PR gate for execution and finishing skills |
-| `session-end-prompt.sh` | `Stop` | (all) | Yes | Checks for open plan tasks, draft/proposed ADRs, and recent lesson-worthy commits without a captured lesson; displays a summary prompt; uses a `/tmp` flag to suppress duplicate output within the same session |
+| `session-end-prompt.sh` | `Stop` | (all) | Yes | Checks for open plan tasks, draft/proposed ADRs, and recent lesson-worthy commits without a captured lesson; displays a summary prompt to stderr; emits `{"decision": "continue"}` JSON to stdout via `trap EXIT` for Codex CLI compatibility; uses a `/tmp` flag to suppress duplicate output within the same session |
 | `stop-plan-gate.sh` | `Stop` | (all) | Yes | Re-injects the plan approval gate reminder at session end when a plan was written this session; uses a daily flag file to suppress duplicates |
 | `post-plan-validate-checklist.sh` | `PostToolUse` | `Write` | Yes | After writing any `plans/*.md` file, outputs an advisory post-plan validation checklist; exits silently for non-plan writes |
 | `notification-dispatch.sh` | `Notification` | (all) | No (opt-in) | Forwards the notification text to a configured `webhookUrl` in `kg-config.json`; exits silently if `webhookUrl` is absent; network failures never block the hook |
@@ -82,3 +82,14 @@ All hook scripts reside in `scripts/` relative to the plugin root. Additional sc
 | `1` | Blocking error — used only by `hooks-master.sh` for unrecoverable config failures |
 
 `PreToolUse` hooks that exit `0` allow the tool call to proceed. A non-zero exit from a `PreToolUse` hook blocks the tool call; KMGraph's `pre-commit-knowledge-gate.sh` always exits `0` because it is advisory only.
+
+## Codex CLI Compatibility
+
+The Codex CLI Stop hook parser requires a JSON object on stdout to determine session continuation. KMGraph's `Stop` hook scripts route all human-readable output to stderr and use a `trap EXIT` to guarantee the JSON decision token reaches stdout on every exit path — including early exits and errors:
+
+```bash
+# Emit JSON on every exit — required by Codex CLI Stop hook parser on all exit paths
+trap 'echo "{\"decision\": \"continue\"}"' EXIT
+```
+
+This pattern ensures the hook never silently swallows the required JSON, regardless of how the script exits. Claude Code ignores stdout from `Stop` hooks, so this change is backward-compatible.

--- a/docs/troubleshooting/index.md
+++ b/docs/troubleshooting/index.md
@@ -68,7 +68,7 @@ If the binary is missing, rebuild it:
 cd mcp-server && npm install && npm run build
 ```
 
-> **Note (v0.5.10.3+):** The MCP server is now pre-bundled and committed to `mcp-server/dist/`. Marketplace installs (Claude Code, Codex CLI) should have the binary without running `npm install`. The rebuild command above is only needed for local development or manual git-clone installs that modify the server source.
+> **Note (v0.5.10.5+):** The MCP server is now pre-bundled and committed to `mcp-server/dist/`. Marketplace installs (Claude Code, Codex CLI) should have the binary without running `npm install`. The rebuild command above is only needed for local development or manual git-clone installs that modify the server source.
 
 ---
 

--- a/mcp-server/dist/cli.js
+++ b/mcp-server/dist/cli.js
@@ -31489,7 +31489,8 @@ function registerConfigTools(server) {
         "lessons-learned",
         "decisions",
         "sessions",
-        "chat-history"
+        "chat-history",
+        "tmp"
       ];
       for (const dir of dirs) {
         fs2.mkdirSync(path2.join(expandedPath, dir), { recursive: true });
@@ -31508,11 +31509,10 @@ function registerConfigTools(server) {
           "gotchas.md",
           "concepts.md",
           "architecture.md",
-          "workflows.md",
-          "index.md"
+          "workflows.md"
         ];
         for (const t of knowledgeTemplates) {
-          const src = path2.join(templateSrc, "knowledge", t);
+          const src = path2.join(templateSrc, "knowledge", "templates", t);
           const dest = path2.join(expandedPath, "knowledge", t);
           if (fs2.existsSync(src) && !fs2.existsSync(dest)) {
             fs2.copyFileSync(src, dest);
@@ -31540,6 +31540,19 @@ function registerConfigTools(server) {
         const sessDest = path2.join(expandedPath, "sessions", "session-template.md");
         if (fs2.existsSync(sessSrc) && !fs2.existsSync(sessDest)) {
           fs2.copyFileSync(sessSrc, sessDest);
+        }
+        const rootScaffolds = ["me.md", "rules.md", "kg-index.md", "triggers.md"];
+        for (const f of rootScaffolds) {
+          const src = path2.join(templateSrc, "knowledge", f);
+          const dest = path2.join(expandedPath, f);
+          if (fs2.existsSync(src) && !fs2.existsSync(dest)) {
+            fs2.copyFileSync(src, dest);
+          }
+        }
+        const catIndexSrc = path2.join(templateSrc, "knowledge", "kg-category-index.md");
+        const catIndexDest = path2.join(expandedPath, "knowledge", "kg-category-index.md");
+        if (fs2.existsSync(catIndexSrc) && !fs2.existsSync(catIndexDest)) {
+          fs2.copyFileSync(catIndexSrc, catIndexDest);
         }
       }
       const now = (/* @__PURE__ */ new Date()).toISOString();

--- a/mcp-server/dist/index.js
+++ b/mcp-server/dist/index.js
@@ -30397,7 +30397,8 @@ function registerConfigTools(server2) {
         "lessons-learned",
         "decisions",
         "sessions",
-        "chat-history"
+        "chat-history",
+        "tmp"
       ];
       for (const dir of dirs) {
         fs2.mkdirSync(path2.join(expandedPath, dir), { recursive: true });
@@ -30416,11 +30417,10 @@ function registerConfigTools(server2) {
           "gotchas.md",
           "concepts.md",
           "architecture.md",
-          "workflows.md",
-          "index.md"
+          "workflows.md"
         ];
         for (const t of knowledgeTemplates) {
-          const src = path2.join(templateSrc, "knowledge", t);
+          const src = path2.join(templateSrc, "knowledge", "templates", t);
           const dest = path2.join(expandedPath, "knowledge", t);
           if (fs2.existsSync(src) && !fs2.existsSync(dest)) {
             fs2.copyFileSync(src, dest);
@@ -30448,6 +30448,19 @@ function registerConfigTools(server2) {
         const sessDest = path2.join(expandedPath, "sessions", "session-template.md");
         if (fs2.existsSync(sessSrc) && !fs2.existsSync(sessDest)) {
           fs2.copyFileSync(sessSrc, sessDest);
+        }
+        const rootScaffolds = ["me.md", "rules.md", "kg-index.md", "triggers.md"];
+        for (const f of rootScaffolds) {
+          const src = path2.join(templateSrc, "knowledge", f);
+          const dest = path2.join(expandedPath, f);
+          if (fs2.existsSync(src) && !fs2.existsSync(dest)) {
+            fs2.copyFileSync(src, dest);
+          }
+        }
+        const catIndexSrc = path2.join(templateSrc, "knowledge", "kg-category-index.md");
+        const catIndexDest = path2.join(expandedPath, "knowledge", "kg-category-index.md");
+        if (fs2.existsSync(catIndexSrc) && !fs2.existsSync(catIndexDest)) {
+          fs2.copyFileSync(catIndexSrc, catIndexDest);
         }
       }
       const now = (/* @__PURE__ */ new Date()).toISOString();

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "knowledge-graph-plugin",
-  "version": "0.5.10.4",
+  "version": "0.5.10.5",
   "description": "Structured knowledge capture and cross-session memory for Claude Code projects.",
   "files": [
     ".claude-plugin/",

--- a/skills/knowledge-graph-usage/references/command-workflows.md
+++ b/skills/knowledge-graph-usage/references/command-workflows.md
@@ -627,11 +627,13 @@ Mental checklist:
 
 ```bash
 # Extract chat history from recent sessions
-/kmgraph:extract-chat
+/kmgraph:extract-chat              # Claude + Gemini
+/kmgraph:extract-chat --source codex   # Codex CLI only
 
 # Processes:
 # - Claude chat logs (if available)
 # - Gemini conversation logs
+# - Codex CLI sessions (--source codex required)
 # - Saves to docs/chat-history/
 ```
 


### PR DESCRIPTION
## Summary

- **feat**: Add Codex CLI chat history extraction (`--source codex`) — ENH-024
- **docs**: New user-facing guide `docs/pillars/tailoring/docs-impact-scan.md` + ADR-052
- **docs**: Update 6 affected docs via docs-impact-scan workflow (extract-chat, hooks, migrate guide, automation-layer, customize-hooks, command-workflows)
- **docs**: Rebuild dist for Codex extraction, document `--source` flags in command-guide

## Test plan

- [ ] Run `/kmgraph:extract-chat --source codex` — verify `YYYY-MM-DD-codex.md` output
- [ ] Run `/kmgraph:extract-chat --source all` — verify Codex NOT included
- [ ] Verify Stop hook emits JSON to stdout and display to stderr in both Claude Code and Codex CLI
- [ ] Check new docs-impact-scan guide renders correctly in docs site
- [ ] Confirm Gate 3 flag clears pre-push gate

🤖 Generated with [Claude Code](https://claude.com/claude-code)