### PR TITLE
docs: add docs-impact-scan guide, ADR-052, ENH-024 spec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Not included in `--source all` yet — use `--source codex` explicitly until cross-platform date semantics validated
 - Implements ENH-024
 
+### Docs
+- **Docs-Impact-Scan Guide** — New `docs/pillars/tailoring/docs-impact-scan.md` documents the 8-step pre-push workflow that scans git diffs, discovers affected documentation, and dispatches updates. Previously undocumented except in internal ADRs; now has dedicated user-facing guide. See ADR-052.
+
 ## [0.5.10.4] — 2026-06-12
 
 ### Fixed
@@ -106,7 +109,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - **issue-5 (#124):** `start-issue-tracking` Step 5 now calls `gh issue create` (Step 5.0) before branch creation. Returned issue URL is parsed for the issue number, which is written back to spec frontmatter (`github-issue` field). Draft PR is updated to include `Closes #N`. Previously, `github-issue` was always `null` or `"TBD"` — every ENH and issue since `v0.0.5-alpha` was unsynced to GitHub.
-- **issue-6 (#125):** `plan-rules.md` false "blocking gate" claim corrected — post-plan validation checklist hook is advisory only (PostToolUse cannot block in Claude Code). `scripts/post-plan-validate-checklist.sh` header updated to clarify advisory intent. Blocking enforcement deferred to v0.6.0 per ENH-015 Gap 2. (User-local `~/.kmgraph/plan-rules.md` fix only — no behavior change for marketplace users.)
+- **issue-6 (#125):** `plan-rules.md` false "blocking gate" claim corrected — post-plan validation checklist hook is advisory only (PostToolUse cannot block in Claude Code). `scripts/post-plan-validate-checklist.sh` header updated to clarify advisory intent. Blocking enforcement deferred to v0.7.0 per ENH-015 Gap 2. (User-local `~/.kmgraph/plan-rules.md` fix only — no behavior change for marketplace users.)
 
 ### Related
 - ADR-024, ADR-043, ADR-049, ENH-015, ENH-017
@@ -132,7 +135,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `core/rules-registry/review-audit-protocol.md`, `core/templates/.../governance-rules.md`, `~/.kmgraph/governance-rules.md`, `scripts/pre-skill-rules-inject.sh`: HALT ambiguity — Step 4 was interpreted as stop-per-finding with bare "proceed?"; clarified to ONE halt after complete audit trail; decision blocks now require finding description, severity, recommended action, and decision options
 
 ### Knowledge Graph
-- issue-7: Bash permission prompt UX bug tracked — solution designed for v0.6.0 (`knowledge/issues/issue-7/`)
+- issue-7: Bash permission prompt UX bug tracked — solution designed for v0.7.0 (`knowledge/issues/issue-7/`)
 - ADR-049: Review Audit Protocol — Post-Plan/Pre-Push Review Governance (Accepted; branch updated to `v0.5.9.1-review-audit-protocol`)
 - ENH-019 spec committed (deferred, no implementation in this release)
 
@@ -265,7 +268,7 @@ Closes #38, #39, #40, #41, #42, #43, #44, #45, #46, #47, #48, #49, #50, #51, #52
 ### Added
 
 - **Shared `ai-model-tier-resolver` module** — `commands/init-shared/ai-model-tier-resolver.md` is the single source of truth for all tier resolution logic (Steps R-1 through R-4). Eliminates 4-way duplication across dispatchers.
-- **Backwards-compat alias map (S4)** — Legacy model names (Haiku, Sonnet, Opus, Gemini Flash/Pro/Ultra) resolve to tier labels with a once-per-session deprecation warning. Aliases sunset in v0.6.0.
+- **Backwards-compat alias map (S4)** — Legacy model names (Haiku, Sonnet, Opus, Gemini Flash/Pro/Ultra) resolve to tier labels with a once-per-session deprecation warning. Aliases sunset in v0.7.0.
 - **Validation gate (S5)** — Step R-4 warns on suspicious model ID values at dispatcher resolution time only; never fires from file scanning. Continues rather than halts.
 - **Project-level model overrides in `me.md`** — A `platforms[]` block can now be added to `knowledge/me.md` to override which AI models are used for this project, independent of personal defaults in `~/.kmgraph/me.md`.
 - **`create-adr` now records where and when decisions were implemented** — The wizard automatically captures the commit and subject line at the time the ADR is created, giving every accepted decision a traceable link back to the implementation. For design-first ADRs (not yet implemented), the wizard adds a back-fill reminder to the ADR.

--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ Pull the latest version and run `/kmgraph:init` in any project that uses it. The
 **v0.5.10.5 — 2026-06-12**
 
 - **`extract-chat` adds Codex CLI source** — `/kmgraph:extract-chat` now accepts `--source codex` to extract chat history from Codex CLI sessions. Pass `--source codex` (or omit `--source` and select Codex from the interactive prompt) to index Codex conversation logs alongside existing Claude and Gemini sources.
+- **Docs-impact-scan guide page published** — New [Docs-Impact-Scan Guide](docs/pillars/tailoring/docs-impact-scan.md) documents the 8-step pre-push workflow that automatically discovers and updates affected documentation. This feature (previously undocumented except in ADRs) now has a dedicated user-facing guide.
 
 **v0.5.10.3 — 2026-06-11**
 
@@ -119,7 +120,7 @@ Pull the latest version and run `/kmgraph:init` in any project that uses it. The
 **v0.5.9.2 — 2026-05-30**
 
 - **`start-issue-tracking` now auto-creates GitHub Issue** — Step 5.0 calls `gh issue create --body-file` before branch creation; returned issue number is written back to spec frontmatter (`github-issue` field). Draft PR is updated to include `Closes #N`.
-- **Post-plan validation checklist advisory clarification** — `plan-rules.md` false "blocking gate" claim corrected; checklist hook is advisory only (PostToolUse cannot block in Claude Code). Hard-gate enforcement deferred to v0.6.0 (ENH-015 Gap 2).
+- **Post-plan validation checklist advisory clarification** — `plan-rules.md` false "blocking gate" claim corrected; checklist hook is advisory only (PostToolUse cannot block in Claude Code). Hard-gate enforcement deferred to v0.7.0 (ENH-015 Gap 2).
 
 **v0.5.9 — 2026-05-27**
 

--- a/docs/pillars/tailoring/docs-impact-scan.md
+++ b/docs/pillars/tailoring/docs-impact-scan.md
@@ -1,0 +1,119 @@
+---
+id: docs-impact-scan
+title: Docs Impact Scan
+sidebar_label: Docs Impact Scan
+description: How KMGraph automatically discovers and updates affected documentation before every push using the docs-impact-scan pre-push workflow
+---
+
+# Docs Impact Scan
+
+> "How does KMGraph know which docs need updating when code changes?"
+
+When code changes ship, documentation often lags behind. The docs-impact-scan skill closes this gap automatically: it fires on pre-push phrases, scans the current git diff for changed identifiers, discovers every doc file that references them, validates the list with the developer, and dispatches targeted updates — all before `git push` completes.
+
+## How it works
+
+The scan runs in eight steps:
+
+| Step | Action |
+|---|---|
+| 1 | Read `git diff main...HEAD` — extract changed command names, feature names, flag names, skill names |
+| 2 | Grep all `.md` files in the project root and `docs/` for each extracted identifier |
+| 3 | Always add obvious files: `README.md`, `INSTALL.md`, `CHANGELOG.md`, `COMMAND-GUIDE.md` |
+| 4 | Query the active knowledge graph for learned correction patterns (e.g., "when X changes, also check Y") |
+| 5 | Present the combined list to the developer for confirmation — add, remove, or approve |
+| 6 | Offer to save any manually-added files as learned patterns to the KG for future runs |
+| 7 | Dispatch `/kmgraph:update-doc --user-facing [file]` for each confirmed file, in sequence |
+| 8 | Write a completion flag to `/tmp/` — the pre-push gate checks this flag before allowing push |
+
+```mermaid
+flowchart TD
+    A([Trigger phrase detected\n&quot;push to origin&quot; / &quot;create PR&quot;]) --> B[Step 1: Read git diff main...HEAD]
+    B --> C[Step 2: Extract identifiers\ncommand names · flags · feature names · skill names]
+    C --> D[Step 3: Grep all .md files\nin project root and docs/]
+    D --> E[Step 4: Add obvious files\nREADME · INSTALL · CHANGELOG · COMMAND-GUIDE]
+    E --> F[Step 5: Query KG for\nlearned correction patterns]
+    F --> G[Step 6: Present combined list\nto developer for confirmation]
+    G --> H{Developer reviews list}
+    H -->|All removed| Z([No doc updates — skip])
+    H -->|Confirmed| I{Any manually\nadded files?}
+    I -->|Yes| J[Offer to save as\nlearned KG pattern]
+    I -->|No| K
+    J --> K[Step 7: Dispatch update-doc\nfor each confirmed file in sequence]
+    K --> L[Step 8: Write completion flag\n/tmp/kmgraph-docs-scan-branch-sha.flag]
+    L --> M([Gate 3 passes · git push proceeds])
+
+    accTitle: docs-impact-scan eight-step workflow
+    accDescr: Flowchart showing the eight steps from trigger phrase detection through diff scanning, identifier extraction, docs grep, KG pattern query, user confirmation, update-doc dispatch, and completion flag write.
+```
+
+## The pre-push gate
+
+The completion flag written in Step 8 has the form:
+
+```
+/tmp/kmgraph-docs-scan-<branch>-<sha>.flag
+```
+
+The branch name is sanitized (slashes replaced with `-`). The flag is **commit-specific**: a new commit invalidates it, and a flag from a different branch never satisfies the gate. The scan must complete on the same commit and branch being pushed — there is no way to carry a prior scan forward.
+
+The gate is advisory by default: if the flag is absent at push time, Gate 3 injects a prompt to run the scan rather than hard-blocking the push.
+
+```mermaid
+sequenceDiagram
+    participant Dev as Developer
+    participant Skill as docs-impact-scan skill
+    participant Gate as pre-push-gate.sh (Gate 3)
+    participant Docs as update-doc
+
+    Dev->>Dev: "push to origin" (or similar phrase)
+    Note over Skill: trigger phrase detected
+    Skill->>Dev: Scan diff → present affected docs list
+    Dev->>Skill: Confirm or edit list
+    Skill->>Docs: /kmgraph:update-doc --user-facing for each file
+    Docs->>Dev: Each doc updated
+    Skill->>Gate: Write /tmp/kmgraph-docs-scan-<branch>-<sha>.flag
+    Dev->>Dev: git push proceeds
+    Gate->>Gate: Flag found → Gate 3 passes
+
+    accTitle: docs-impact-scan pre-push flow
+    accDescr: Sequence showing the skill triggering on a push phrase, scanning the diff, presenting docs to the developer, dispatching update-doc for each file, writing the completion flag, and the pre-push gate passing on flag check.
+```
+
+## Trigger phrases
+
+The skill fires automatically when any of these phrases appear in conversation:
+
+| Phrase | Notes |
+|---|---|
+| "push to origin" | Exact or partial match |
+| "push and merge" | Also matches "push and merge with admin" |
+| "open PR" / "create PR" | PR creation signals |
+| "finishing up" / "ready to push" | End-of-session signals |
+
+The skill does not fire on targeted mid-session doc file updates — use `/kmgraph:update-doc` directly for those.
+
+## When docs are already updated
+
+If the diff already includes changes to expected doc files (for example, `README.md` was updated as part of the feature branch), those files still appear in the confirmed list. The `update-doc` dispatch is additive — it appends only what is missing and does not overwrite existing content.
+
+## Learned correction patterns
+
+When a developer manually adds a file to the list that the grep scan did not find, the skill offers to save a learned correction pattern to the active knowledge graph:
+
+```
+When [identifier] changes, also check [file].
+Source: docs-impact-scan correction (YYYY-MM-DD)
+```
+
+These patterns accumulate over time, making the scan progressively more accurate for the specific project's documentation layout.
+
+:::tip[Same branch, before push]
+Docs updates commit to the feature branch — not a separate docs-update branch. The completion flag is keyed to the current branch and commit SHA, so updates must land before the push that triggers Gate 3.
+:::
+
+## Related
+
+- [Automation Layer](./automation-layer.md) — where docs-impact-scan fits in the full skills, hooks, and agents picture — and why it fires without explicit commands
+- [Customize Hooks](./customize-hooks.md) — adjusting pre-push gate behavior or disabling Gate 3
+- [Skills Catalog](/knowledge-graph/reference/skills) — all skills with trigger keywords and descriptions

--- a/docs/pillars/tailoring/index.md
+++ b/docs/pillars/tailoring/index.md
@@ -17,6 +17,7 @@ KMGraph ships with sensible defaults. This pillar covers how to adjust hooks, te
 - [Customize Templates](./customize-templates.md) — overriding default lesson and ADR templates
 - [Customize Hooks](./customize-hooks.md) — adding or modifying SessionStart, PostToolUse, and Stop hooks
 - [Automation Layer](./automation-layer.md) — understanding what runs automatically and why
+- [Docs Impact Scan](./docs-impact-scan.md) — how the pre-push skill discovers and updates affected docs before every push
 
 ## Related
 

--- a/knowledge/decisions/ADR-041-tier-abstraction-label-system.md
+++ b/knowledge/decisions/ADR-041-tier-abstraction-label-system.md
@@ -58,7 +58,7 @@ Collapse is logged once per session. Skills may declare `required_tier: <label>`
 
 ### Backwards Compatibility Alias Map
 
-During Phase 2 rollout, the resolver accepts legacy model names as aliases and emits a once-per-session deprecation warning. Aliases are removed in v0.6.0. A sed pass converts repo-owned references; aliases are the safety net for user-owned content we cannot rewrite.
+During Phase 2 rollout, the resolver accepts legacy model names as aliases and emits a once-per-session deprecation warning. Aliases are removed in v0.7.0. A sed pass converts repo-owned references; aliases are the safety net for user-owned content we cannot rewrite.
 
 | Legacy name | Resolves to |
 |---|---|
@@ -111,7 +111,7 @@ Tier labels are platform-neutral vocabulary that any LLM ecosystem supports. Map
 
 **Negative:**
 - Phase 2 rename pass required across all rules, skills, commands
-- Backwards compat alias map adds resolver complexity (temporary, sunset v0.6.0)
+- Backwards compat alias map adds resolver complexity (temporary, sunset v0.7.0)
 - Users must run init walkthrough to configure tier mappings for local platforms
 
 ---
@@ -147,7 +147,7 @@ Tier labels are platform-neutral vocabulary that any LLM ecosystem supports. Map
 
 **DRY consolidation:** The 4 dispatchers that had inline tier-resolution paragraphs (session-summary, create-adr, capture-lesson, sync-all) now reference ai-model-tier-resolver.md. Single source of truth for all resolution logic.
 
-**Status:** Alias map and validation gate are fully implemented. Sunset scheduled for v0.6.0 (alias removal + resolver cleanup).
+**Status:** Alias map and validation gate are fully implemented. Sunset scheduled for v0.7.0 (alias removal + resolver cleanup). v0.6.0 is reserved for kmg-prefix normalization.
 
 ### 2026-04-21 — Phase 3 Opus Review Remediations Applied
 

--- a/knowledge/decisions/ADR-052-docs-impact-scan-user-facing-guide.md
+++ b/knowledge/decisions/ADR-052-docs-impact-scan-user-facing-guide.md
@@ -1,0 +1,55 @@
+---
+title: "ADR-052: docs-impact-scan User-Facing Guide Page"
+number: 052
+created: 2026-06-12T00:00:00Z
+status: Accepted
+author: mkaplan
+email: mkitact@gmail.com
+git:
+  branch: v0.5.10.5-codex-chat-extraction
+  commit: TBD
+  pr: null
+  issue: null
+implements: v0.5.10.5
+related:
+  adrs: [036, 050]
+  lessons: []
+  kg_entries: []
+tags: [docs, tailoring, docs-impact-scan, pre-push, governance]
+category: documentation
+---
+
+# ADR-052: docs-impact-scan User-Facing Guide Page
+
+**Date:** 2026-06-12
+**Status:** Accepted
+**Implements:** v0.5.10.5
+
+---
+
+## Context
+
+The docs-impact-scan feature (ADR-036) and its pre-push gate (ADR-050) constitute a significant workflow automation: phrase-triggered diff scanning, user validation, targeted doc dispatch, and a commit-specific completion flag that gates pushes. Despite this, the full workflow was only documented in internal ADRs and single-row table entries in three reference pages (`docs/reference/skills.md`, `docs/pillars/tailoring/automation-layer.md`, `docs/CHEAT-SHEET.md`).
+
+During a pre-push docs-impact-scan run on v0.5.10.5, the gap was identified: no dedicated user-facing guide existed. The complete Gate 3 contract — same-branch-before-push, flag anatomy, eight-step workflow, learned pattern accumulation — was invisible to users unless they read ADR-036 and ADR-050 directly.
+
+Placement was evaluated using Opus (claude-opus-4-7) against the existing docs information architecture.
+
+## Decision
+
+Add `docs/pillars/tailoring/docs-impact-scan.md` — a dedicated user-facing guide covering the full eight-step workflow, the pre-push gate contract, trigger phrases, and learned correction pattern behavior.
+
+**Placement:** `docs/pillars/tailoring/` alongside `automation-layer.md` and `customize-hooks.md`.
+
+**Rationale:** The tailoring pillar owns automation that fires without explicit commands. Docs-impact-scan is a phrase-triggered pre-push automation — a direct fit. Alternative placements rejected:
+- `docs/reference/` — reference pages are per-artifact catalogs, not narrative workflow guides
+- New `maintaining/` pillar — premature for a single feature; the tailoring pillar already covers this domain
+- New `guides/` section — duplicates what pillars already are
+
+## Consequences
+
+- The docs-impact-scan workflow is user-discoverable without reading internal ADRs.
+- The Gate 3 pre-push contract (same branch, commit-specific flag) is explicitly documented.
+- `docs/pillars/tailoring/index.md` updated to list the new page.
+- Learned correction pattern behavior is documented, encouraging KG contribution over time.
+- Future docs-impact-scan improvements must update this guide as part of the change.

--- a/knowledge/enhancements/ENH-015/ENH-015-specification.md
+++ b/knowledge/enhancements/ENH-015/ENH-015-specification.md
@@ -159,9 +159,9 @@ Hook fires on Skill tool invocations only. `superpowers:writing-plans` invocatio
 ### Gap 2 — Post-Plan Validation Checklist (partial fix in v0.5.9; hard gate future scope)
 v0.5.9 adds Task M: PostToolUse:Write hook that fires after plan files are written and outputs the Post-Plan Validation Checklist as an advisory reminder. This is model self-enforcement, not a hard gate.
 
-**Tracked bug:** [[issue-6]] — GitHub #125 (v0.5.9.2): plan-rules.md falsely described the hook as a blocking gate; corrected to advisory. Layer 3 (gov-execute-plan pre-flight gate) deferred to v0.6.0.
+**Tracked bug:** [[issue-6]] — GitHub #125 (v0.5.9.2): plan-rules.md falsely described the hook as a blocking gate; corrected to advisory. Layer 3 (kmg-execute-plan pre-flight gate) deferred to v0.7.0.
 
-**Future scope (v0.6.0 candidate):** A PreToolUse:Write hook could provide a true hard gate with the following pattern to avoid blocking mid-draft saves:
+**Future scope (v0.7.0 candidate):** A PreToolUse:Write hook could provide a true hard gate with the following pattern to avoid blocking mid-draft saves:
 - Only block if the plan file **already exists** (not a first write)
 - AND the previous version already had a `## Post-Plan Validation Checklist` section
 - AND the incoming content has any `❌` items in that section
@@ -177,7 +177,7 @@ Pre-v0.5.9: only File Location, Parallelism, Approval Gates, RECALL_HARD_BLOCK, 
 
 | Rule | Claude Code (hook) | plan-rules.md | Gemini | Copilot/Codex |
 |------|--------------------|---------------|--------|---------------|
-| Recall before planning | ✅ HARD BLOCK injected | ✅ documented | ✅ Task C | NOT DELIVERED (v0.6.0) |
+| Recall before planning | ✅ HARD BLOCK injected | ✅ documented | ✅ Task C | NOT DELIVERED (v0.7.0) |
 | Two-query pattern | ✅ HARD BLOCK | ✅ documented | ✅ | NOT DELIVERED |
 | Recall miss instrumentation | ✅ hook log | ✅ documented | ⚠️ advisory only | NOT DELIVERED |
 | Post-Plan Checklist gate | ⚠️ advisory (PostToolUse) | ✅ documented | ⚠️ advisory only | NOT DELIVERED |
@@ -220,5 +220,5 @@ See: `knowledge/enhancements/ENH-020/ENH-020-specification.md`
 
 - Modifying `superpowers:writing-plans` or `superpowers:brainstorming` skill files directly — these are third-party; all enforcement is via the hook layer (`pre-skill-rules-inject.sh`)
 - Replacing `superpowers:brainstorming` — brainstorm-recall works alongside it
-- Multi-platform skill name collision risk: when v0.6.0 implements Gemini/Copilot/Codex skill loading, bare-name discovery (no `kmgraph:` namespace) may collide with user personal skills. Deferred to v0.6.0.
+- Multi-platform skill name collision risk: **addressed in v0.6.0** via `kmg-` prefix normalization (all skill/command names prefixed — bare-name collision eliminated).
 - Pure conversational planning enforcement: when a model answers a planning question WITHOUT invoking any skill at all, no hook fires. This is an architecture-level limitation — hooks only fire on Skill tool invocations.

--- a/knowledge/enhancements/ENH-019/ENH-019-specification.md
+++ b/knowledge/enhancements/ENH-019/ENH-019-specification.md
@@ -5,7 +5,7 @@ status: deferred
 github-issue: "TBD"
 branch: "none"
 created: 2026-05-27
-target-release: "TBD (consider for v0.6.0)"
+target-release: "TBD (consider for v0.7.0)"
 ---
 
 # ENH-019: kmgraph Usage Analytics & Stats Dashboard
@@ -53,7 +53,7 @@ Potential candidates (to be validated against real usage — see Research Guidan
 
 ## Research Guidance for Brainstorm Session
 
-**Before the brainstorm session, run `/kmgraph:kg-recall` to search prior chat history for:**
+**Before the brainstorm session, run `/kmgraph:kmg-auto-recall` to search prior chat history for:**
 - Sessions where users asked "what have I captured", "how much have I used this", or similar introspective questions
 - Any feedback about visibility into kmgraph activity
 - Real examples of what information users wanted but couldn't get
@@ -65,15 +65,15 @@ Search queries to use:
 
 These real-world examples should drive which stats fields are prioritized.
 
-## Relation to v0.6.0
+## Relation to v0.7.0
 
-This ENH was identified during v0.5.9 work. Before committing to include it in v0.6.0:
+This ENH was identified during v0.5.9 work. v0.6.0 is reserved for `kmg-` prefix normalization. Before committing to include it in v0.7.0:
 
-1. Review `docs/plans/v0.6.0-multi-platform-expansion.md` — the primary 0.6.0 plan — to assess fit.
-2. The multi-platform focus of 0.6.0 (8 platforms, npm publish, marketplace submissions) means this feature would need to work cross-platform from day one if shipped in that release.
+1. Review `docs/plans/v0.7.0-multi-platform-expansion.md` — the primary 0.7.0 plan — to assess fit.
+2. The multi-platform focus of 0.7.0 (8 platforms, npm publish, marketplace submissions) means this feature would need to work cross-platform from day one if shipped in that release.
 3. Cross-platform stats require the storage/capture questions above to be answered first.
 
-**Recommendation:** Hold this ENH until after the 0.6.0 brainstorm session. If the brainstorm concludes the implementation is lightweight and platform-agnostic, it can be folded in. If not, target 0.6.1 or later.
+**Recommendation:** Hold this ENH until after the 0.7.0 brainstorm session. If the brainstorm concludes the implementation is lightweight and platform-agnostic, it can be folded in. If not, target 0.7.1 or later.
 
 ## Files
 

--- a/knowledge/enhancements/ENH-022/ENH-022-specification.md
+++ b/knowledge/enhancements/ENH-022/ENH-022-specification.md
@@ -3,7 +3,7 @@ id: ENH-022
 title: "Template Directory Disambiguation — rename core/templates/ to core/default-templates/"
 status: proposed
 priority: medium
-version_target: v0.5.12
+version_target: v0.5.10.6
 created: 2026-05-29
 updated: 2026-06-08
 related:
@@ -16,7 +16,7 @@ tags: [templates, naming, directory-structure, disambiguation, init, upgrade]
 
 **Status:** Proposed — approach selected, awaiting brainstorm sign-off and impl plan
 **Priority:** Medium
-**Version Target:** v0.5.12
+**Version Target:** v0.5.10.6
 **Created:** 2026-05-29
 **Updated:** 2026-06-07 — approach locked in; scope broadened to all four pairs; blast radius detailed
 
@@ -151,7 +151,7 @@ ships inside the plugin distribution, not the user's project. Nothing in their
 **Tier 3 (manual installers, ADR-009):** **Breaking change.** Their copy
 instructions reference `core/templates/<dir>/`. Required actions:
 - Update `INSTALL.md` and `docs/INSTALL.md` copy instructions
-- Document in `CHANGELOG.md` under the v0.5.12 release entry as a breaking change
+- Document in `CHANGELOG.md` under the v0.5.10.6 release entry as a breaking change
 - Note the old path and new path explicitly
 
 ### Version sync required
@@ -214,10 +214,10 @@ Previously: approach is selected; brainstorm must confirm:
    `for f in ...` loop" is actually in `init-shared/template-seed.md` line 63 and
    `init-shared/upgrade-inspector.md` lines 97–109/290. `init-personal-kg.md` line 136
    is a single `cp` command. All cases: path-prefix string replace, loop logic unchanged.
-5. ✅ Tier 3 breaking-change wording confirmed (2026-06-08) — see v0.5.12 plan
+5. ✅ Tier 3 breaking-change wording confirmed (2026-06-08) — see v0.5.10.6 plan
    "Tier 3 Breaking-Change Wording" section. Write into INSTALL.md + docs/INSTALL.md
    + CHANGELOG.md during implementation.
 6. ✅ PROTECTED-code permission granted (2026-06-08) — explicit user permission granted
-   to modify `commands/` and rename `core/templates/` for v0.5.12 implementation.
+   to modify `commands/` and rename `core/templates/` for v0.5.10.6 implementation.
 
-See `~/.claude/plans/v0.5.12-template-disambiguation.md`.
+See `~/.claude/plans/v0.5.10.6-template-disambiguation.md`.

--- a/knowledge/enhancements/ENH-024/ENH-024-specification.md
+++ b/knowledge/enhancements/ENH-024/ENH-024-specification.md
@@ -1,0 +1,101 @@
+---
+title: "ENH-024: Add Codex CLI Chat History Extraction Support"
+number: 024
+status: proposed
+version_target: null
+github_issue: null
+created: 2026-06-12
+related_adrs: ["ADR-044"]
+related_enhs: []
+---
+
+# ENH-024: Add Codex CLI Chat History Extraction Support
+
+## Problem
+
+`/kmgraph:extract-chat` currently supports only Claude Code (`-claude`) and Gemini CLI (`-gemini`) as log sources. OpenAI Codex CLI stores chat sessions in a structured JSONL format under `~/.codex/sessions/`, but there is no `extract_codex.py` module and the `run_extraction.py` `--source` argument does not accept `codex`. Codex sessions are therefore excluded from the unified chat history archive.
+
+## Discovery (Dry-Run Investigation — 2026-06-12)
+
+A dry-run investigation of the Codex CLI log format was completed on 2026-06-12 without touching any implementation files. Findings:
+
+### Log File Location and Naming
+
+- Base path: `~/.codex/sessions/YYYY/MM/DD/`
+- Filename pattern: `rollout-YYYY-MM-DDTHH-MM-SS-{uuid}.jsonl`
+- Date is encoded in both the directory path and the filename timestamp
+- One `.jsonl` file = one Codex session
+
+### Event Types per File
+
+| Event type | Count per file | Action |
+|---|---|---|
+| `session_meta` | 1 (always first) | Extract metadata |
+| `response_item` | Many | Extract `user` and `assistant` turns |
+| `event_msg` | Variable | Skip (tool events) |
+| `turn_context` | Variable | Skip (context injections) |
+
+### `session_meta` Payload Fields
+
+- `cwd` — working directory at session start
+- `originator` — who launched the session
+- `cli_version` — Codex CLI version string
+- `model_provider` — e.g., `openai`
+- `git.branch` — git branch at session start
+- `git.commit_hash` — HEAD commit hash at session start
+
+### `response_item` Extraction Rules
+
+Extract these roles:
+- `user` with `content_type: input_text` — human turn
+- `assistant` with `content_type: output_text` — model reply
+
+Skip these roles:
+- `developer` — system/permissions injections (tool definitions, capability grants)
+- anonymous role with `encrypted_content` — tool call payloads (encrypted, not readable)
+
+### Output File Convention
+
+Extracted output follows the existing per-date naming pattern: `YYYY-MM-DD-codex.md`
+
+## Scope
+
+### In Scope
+
+1. New `core/scripts/extract_codex.py` module implementing `extract_codex_sessions()` with the same signature convention as `extract_claude_sessions()` and `extract_all_gemini()`
+2. Patch `core/scripts/run_extraction.py`:
+   - Add `codex` to `--source` choices: `['all', 'claude', 'gemini', 'codex']`
+   - Add `if args.source in ['all', 'codex']:` dispatch block
+   - Import `extract_codex_sessions` alongside existing imports
+3. Update `commands/extract-chat.md` (requires explicit user permission per PROTECTED-file rule):
+   - Add `-codex` flag to Usage section
+   - Add `Codex History Files` subsection to Output Format
+   - Add Example for `-codex` extraction
+   - Update `--source` description in How it works
+
+### Out of Scope
+
+- Encrypted tool call payloads (`encrypted_content`) — skip without attempting decryption
+- Codex project filtering (analogous to Claude's `--project` flag) — defer to a follow-on
+- `split_file_if_oversized` integration — reuse the existing base class call site pattern (same as Claude/Gemini extractors)
+
+## Implementation Notes
+
+- The `extract_codex.py` module should subclass or import from `chat_extractor_base.py` for `get_output_path` and `split_file_if_oversized` — same pattern as `extract_claude.py` and `extract_gemini.py`
+- Date filtering (`--date`, `--after`, `--before`, `--today`) should work via directory path scanning (`~/.codex/sessions/YYYY/MM/DD/`) — efficient because the date is encoded in the path
+- Session ID for deduplication: use the `{uuid}` portion of the filename
+- `session_meta` fields (`cwd`, `git.branch`) provide useful header metadata for each extracted session block
+
+## Open Questions
+
+1. Should `-codex` be included in `all` by default immediately, or gated behind an explicit flag until the extractor is validated?
+2. Should `session_meta.cwd` and `session_meta.git.branch` appear in the markdown output header per session?
+3. Does `--project` filtering apply to Codex via `session_meta.cwd` path matching?
+
+## Related
+
+- `core/scripts/run_extraction.py` — add `codex` to `--source` choices and dispatch block
+- `core/scripts/extract_claude.py` — reference implementation for new module
+- `core/scripts/extract_gemini.py` — reference implementation for new module
+- `commands/extract-chat.md` — PROTECTED: requires explicit user permission for edits
+- ADR-044 — Split Oversized Daily Chat History Files (applies to Codex output too)

--- a/knowledge/issues/issue-7/issue-7-description.md
+++ b/knowledge/issues/issue-7/issue-7-description.md
@@ -7,7 +7,7 @@ branch: v0.5.9.1-review-audit-protocol
 created: 2026-05-28
 related-adrs: [ADR-049]
 related-enhs: [ENH-020]
-target-release: v0.6.0
+target-release: v0.7.0
 ---
 
 # Issue-7: Bash Permission Prompt Provides No Context — Indistinguishable from Review Audit HALT


### PR DESCRIPTION
## Summary

- New `docs/pillars/tailoring/docs-impact-scan.md` — user-facing guide missed in v0.5.10.5 merge
- New `knowledge/decisions/ADR-052` — placement decision record
- New `knowledge/enhancements/ENH-024` — Codex extraction spec
- Updated `docs/pillars/tailoring/index.md`, `CHANGELOG.md`, `README.md`
- Knowledge files updated by session agents

## Notes

Files were created/modified after the last commit on v0.5.10.5 and were not included in PR #137. This branch catches them up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)