### PR TITLE
feat(codex): deliver lifecycle hooks via .codex-plugin/hooks/hooks.json (v0.5.10.6)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "kmgraph",
-  "version": "0.5.10.5",
+  "version": "0.5.10.6",
   "description": "Structured knowledge capture, lesson-learned documentation, and cross-session memory for Claude Code projects. Includes KG entries, ADRs, meta-issue tracking, chat extraction, and profile-file rule capture.",
   "author": {
     "name": "technomensch",

--- a/.codex-plugin/hooks/hooks.json
+++ b/.codex-plugin/hooks/hooks.json
@@ -1,0 +1,64 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/scripts/hooks-master.sh",
+            "timeout": 60
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "local_shell|shell|exec_command|Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/scripts/post-tool-lesson-check.sh",
+            "timeout": 10
+          }
+        ]
+      }
+    ],
+    "PreToolUse": [
+      {
+        "matcher": "local_shell|shell|exec_command|Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/scripts/pre-push-gate.sh",
+            "timeout": 10
+          }
+        ]
+      }
+    ],
+    "UserPromptSubmit": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/scripts/recommendation-gate.sh",
+            "timeout": 5
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/scripts/session-end-prompt.sh",
+            "timeout": 30
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "kmgraph",
-  "version": "0.5.10.3",
+  "version": "0.5.10.6",
   "description": "Structured knowledge capture, lesson-learned documentation, and cross-session memory for Claude Code projects. Includes KG entries, ADRs, meta-issue tracking, chat extraction, and profile-file rule capture.",
   "author": {
     "name": "technomensch",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Released]
 
+## [0.5.10.6] — 2026-06-12
+
+### Added
+- **Codex CLI lifecycle hooks** — Delivers kmgraph hook suite to Codex CLI via `.codex-plugin/hooks/hooks.json` (auto-discovered by Codex plugin runtime). Hooks: `SessionStart` (hooks-master), `PostToolUse` shell (post-tool-lesson-check), `PreToolUse` shell (pre-push-gate), `UserPromptSubmit` (recommendation-gate), `Stop` (session-end-prompt). Requires Codex ≥ post-PR-19705 with `plugin_hooks` flag enabled; user must run `/hooks` to trust after install.
+
+### Docs
+- **INSTALL.md** — Added Node/PATH requirement note and hook trust-gate note under the Codex CLI section.
+
+### Not delivered (pending Codex upstream fix)
+- PostToolUse `Write|Edit`-matched hooks deferred pending [openai/codex#16732](https://github.com/openai/codex/issues/16732) — `apply_patch` does not emit PostToolUse events.
+
 ## [0.5.10.5] — 2026-06-12
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Structured knowledge capture, lesson-learned documentation, and cross-session memory for Claude Code projects.
 
-**Version:** 0.5.10.5
+**Version:** 0.5.10.6
 **Status:** Actively developed and in daily use
 
 Documentation: https://kmgraph.stayinginsync.info
@@ -90,6 +90,11 @@ Pull the latest version and run `/kmgraph:init` in any project that uses it. The
 ---
 
 ## v0.5.x Feature Highlights
+
+**v0.5.10.6 — 2026-06-12**
+
+- **Codex CLI lifecycle hooks** — kmgraph hook suite now delivered to Codex CLI sessions via `.codex-plugin/hooks/hooks.json`. Hooks: SessionStart, PostToolUse (shell), PreToolUse (shell), UserPromptSubmit, Stop. Requires Codex ≥ post-PR-19705 with `plugin_hooks` flag; run `/hooks` in Codex to trust after install.
+- **Pre-push gate: README version check** — Gate 2 now also flags when the current version is missing from `README.md`, matching the existing CHANGELOG advisory.
 
 **v0.5.10.5 — 2026-06-12**
 

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -69,6 +69,22 @@ codex plugin add kmgraph@knowledge-management-graph
 This resolves issues where tools are out of date or skills don't appear after an update.
 
 :::
+
+:::note[Node/PATH requirement]
+
+kmgraph hook scripts require `node` to be on the PATH visible to the Codex process. If hooks silently fail after install, confirm `node` is accessible from the shell that launches Codex — not just your login shell.
+
+- **nvm users:** source `nvm` before launching Codex, or add it to your shell's `rc` file so it loads for non-login shells
+- **fnm / volta users:** these work reliably when their shims are on the system PATH (default install)
+- **Homebrew / system Node:** typically works without changes
+
+:::
+
+:::note[Hook trust required]
+
+Codex skips plugin-bundled hooks until you explicitly trust them. After install, run `/hooks` inside a Codex session to review and trust the kmgraph hook definitions. New or modified hooks must be re-trusted whenever the hook file changes.
+
+:::
 ---
 
 :::note[Not using Claude Code?]

--- a/knowledge/enhancements/ENH-016/ENH-016-specification.md
+++ b/knowledge/enhancements/ENH-016/ENH-016-specification.md
@@ -166,6 +166,17 @@ When `personal-rule` routing is selected, scan `~/.kmgraph/` for `*rules*.md` fi
 - Seeding `~/.kmgraph/plan-rules.md` during `/kmgraph:init`
 - Defining a canonical split structure — user defines their own
 
+## Implementation Status
+
+### Advisory Version Checks in `scripts/pre-push-gate.sh`
+
+| Check | Status | Version | Details |
+|---|---|---|---|
+| CHANGELOG version presence | ✓ Implemented | v0.5.10.0+ | Advisory only; skips silently if CHANGELOG.md absent |
+| README version presence | ✓ Implemented | v0.5.10.6 | Advisory only; skips silently if README.md absent |
+
+Both checks follow the same pattern: append to FINDINGS with advisory message (no execution block). Implemented in `scripts/pre-push-gate.sh` lines 70-86.
+
 ## Related
 
 - issue-8: Docs Update Enforcement Meta-Issue (ENH-016 multi-file fallback pattern required by issue-8 fix)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "knowledge-graph-plugin",
-  "version": "0.5.10.5",
+  "version": "0.5.10.6",
   "description": "Structured knowledge capture and cross-session memory for Claude Code projects.",
   "files": [
     ".claude-plugin/",

--- a/scripts/pre-push-gate.sh
+++ b/scripts/pre-push-gate.sh
@@ -75,6 +75,15 @@ if [ -f "$PKG_JSON" ] && [ -f "$PLUGIN_JSON" ] && command -v jq &>/dev/null; the
 "
     fi
   fi
+
+  # Advisory: README should reference the version being pushed
+  README="${REPO_ROOT}/README.md"
+  if [ -n "$PKG_VER" ] && [ -f "$README" ]; then
+    if ! grep -qF "$PKG_VER" "$README" 2>/dev/null; then
+      FINDINGS="${FINDINGS}README ADVISORY: version ${PKG_VER} not found in README.md. Update the version reference before pushing.
+"
+    fi
+  fi
 fi
 
 # ── Gate 3: docs-impact-scan completion flag ──────────────────────────────────


### PR DESCRIPTION
## Summary

- Creates `.codex-plugin/hooks/hooks.json` with kmgraph shell-compatible hooks for Codex CLI
- Auto-discovered by Codex at `hooks/hooks.json` in plugin root — no manifest `"hooks"` key needed
- Commands use `${CLAUDE_PLUGIN_ROOT}/scripts/` (injected by Codex runtime, PR #19705)
- Bumps all plugin manifests and `package.json` to `0.5.10.6`
- Adds Node/PATH and hook trust-gate notes to `docs/INSTALL.md`
- Gate 2 in `pre-push-gate.sh` now also checks `README.md` for version string (advisory)

## Hooks delivered

| Event | Script | Notes |
|---|---|---|
| SessionStart | hooks-master.sh | |
| PostToolUse (`local_shell\|shell\|exec_command\|Bash`) | post-tool-lesson-check.sh | |
| PreToolUse (`local_shell\|shell\|exec_command\|Bash`) | pre-push-gate.sh | |
| UserPromptSubmit | recommendation-gate.sh | |
| Stop | session-end-prompt.sh | |

## Hooks NOT delivered (pending Codex fix)

`platform-file-change-check`, `plan-mirror`, `post-plan-validate-checklist`, `rules-size-check`, `plan-docs-xref-check` — Codex `apply_patch` does not emit PostToolUse ([openai/codex#16732](https://github.com/openai/codex/issues/16732)).

## Requirements

- Codex built after 2026-04-28 (PR #19705)
- `plugin_hooks` feature flag enabled
- User must run `/hooks` to review and trust hooks after install

## Test plan

- [ ] JSON validates: `python3 -m json.tool .codex-plugin/hooks/hooks.json`
- [ ] All 5 referenced scripts exist in `scripts/`
- [ ] Versions consistent across all plugin manifests (`0.5.10.6`)
- [ ] INSTALL.md Node/PATH and trust-gate notes render correctly in Docusaurus
- [ ] Hooks fire in a live Codex session after `/hooks` trust step

🤖 Generated with [Claude Code](https://claude.com/claude-code)