### PR TITLE
feat(extract-chat): add Step 0 KG alignment guard (v0.5.10.8)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "kmgraph",
-  "version": "0.5.10.7",
+  "version": "0.5.10.8",
   "description": "Structured knowledge capture, lesson-learned documentation, and cross-session memory for Claude Code projects. Includes KG entries, ADRs, meta-issue tracking, chat extraction, and profile-file rule capture.",
   "author": {
     "name": "technomensch",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Released]
 
+## [0.5.10.8] — 2026-06-14
+
+### Fixed
+- **`extract-chat` KG write guard (Step 0)** — Adds a pre-extraction alignment check that compares the active knowledge graph's project root against the current working directory. On mismatch, surfaces a stop-and-ask prompt (switch / proceed / cancel) before any `mkdir` or Python extraction runs. Guard is skipped when `--output-dir` or `--project` is present (explicit destination = unambiguous intent). Cross-platform: works on Claude, Gemini, and Codex. Closes the non-agent write path gap documented in ADR-019. Deferred to ENH-026: same guard for `sync-all`/`update-graph`, and bypass-proof enforcement in `run_extraction.py`.
+
+---
+
 ## [0.5.10.7] — 2026-06-13
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Structured knowledge capture, lesson-learned documentation, and cross-session memory for Claude Code projects.
 
-**Version:** 0.5.10.6
+**Version:** 0.5.10.8
 **Status:** Actively developed and in daily use
 
 Documentation: https://kmgraph.stayinginsync.info
@@ -90,6 +90,14 @@ Pull the latest version and run `/kmgraph:init` in any project that uses it. The
 ---
 
 ## v0.5.x Feature Highlights
+
+**v0.5.10.8 — 2026-06-14**
+
+- **`extract-chat` KG write guard** — New Step 0 alignment check compares the active KG's project root against the current working directory before extraction. On mismatch: stop-and-ask prompt (switch / proceed / cancel). Skipped when `--output-dir` or `--project` is explicit. Cross-platform (Claude, Gemini, Codex).
+
+**v0.5.10.7 — 2026-06-13**
+
+- **`core/templates/` renamed to `core/default-templates/`** — Disambiguates frozen distribution scaffolds from live `knowledge/` directories. All internal consumers updated. Closes ENH-022.
 
 **v0.5.10.6 — 2026-06-12**
 
@@ -254,7 +262,7 @@ knowledge-graph/
 
 ## Development Status
 
-**Current Release:** v0.5.10.5 (2026-06-12)
+**Current Release:** v0.5.10.8 (2026-06-14)
 
 Actively developed and in daily use. Behavior may evolve between minor versions.
 
@@ -356,6 +364,6 @@ MIT License - See [LICENSE](LICENSE)
 ---
 
 **Created:** 2026-02-12
-**Current Version:** v0.5.10.5 (2026-06-12)
+**Current Version:** v0.5.10.8 (2026-06-14)
 
 📚 **Full documentation:** https://kmgraph.stayinginsync.info

--- a/commands/extract-chat.md
+++ b/commands/extract-chat.md
@@ -101,6 +101,60 @@ The workflow runs the centralized Python extraction script located at `${CLAUDE_
 
 ## Execution Steps
 
+### Step 0: Active KG / Working Directory Guard
+
+**Skip this step entirely** if an explicit destination flag is present in the user's invocation:
+`--output-dir` or `--project`. When the user has named a target, intent is unambiguous —
+proceed directly to Step 1.
+
+Otherwise, run the following check **before** creating any directories or running extraction:
+
+1. Read the active KG name and path:
+   ```bash
+   active_kg=$(jq -r '.active' ~/.claude/kg-config.json)
+   kg_path=$(jq -r ".graphs[\"$active_kg\"].path" ~/.claude/kg-config.json)
+   ```
+
+2. Derive the project root from `kg_path`. If `kg_path` ends in `/docs`, the project root is
+   its parent directory; otherwise the project root IS `kg_path`. (Mirrors `getProjectRoot`
+   in `mcp-server/src/utils.ts`.)
+   ```bash
+   if [[ "$kg_path" == */docs ]]; then
+     project_root="${kg_path%/docs}"
+   else
+     project_root="$kg_path"
+   fi
+   ```
+
+3. Compare the project root against the current working directory. A **match** is when `pwd`
+   equals `project_root` OR `pwd` starts with `project_root/` (allows subdirectories).
+   ```bash
+   cwd=$(pwd)
+   # Match if cwd == project_root OR cwd starts with project_root/
+   ```
+
+4. **If mismatch — STOP. Do not run `mkdir` or the extraction script. Ask the user:**
+
+   > Hold on — the active knowledge graph is **{active_kg}** (project root: `{project_root}`),
+   > but you are working in `{cwd}`. Chat history would be written to `{kg_path}/chat-history/`.
+   >
+   > Choose:
+   > 1. Switch the active KG to this project's graph, then extract here
+   > 2. Extract to **{active_kg}** (`{kg_path}/chat-history/`) anyway
+   > 3. Cancel
+   >
+   > Reply 1, 2, or 3.
+
+   - Option 1: Run `/kmgraph:switch` for the current project's KG (if configured), then re-resolve output dir in Step 1 using the newly active KG.
+   - Option 2: Continue to Step 1 using the current active KG unchanged.
+   - Option 3: Abort. Do not run extraction.
+
+   **Do not proceed until the user explicitly responds.**
+
+5. **If match:** Continue to Step 1.
+
+---
+
 ### Step 1: Determine Output Directory
 
 **Default behavior (no --output-dir):**

--- a/commands/extract-chat.md
+++ b/commands/extract-chat.md
@@ -113,7 +113,11 @@ Otherwise, run the following check **before** creating any directories or runnin
    ```bash
    active_kg=$(jq -r '.active' ~/.claude/kg-config.json)
    kg_path=$(jq -r ".graphs[\"$active_kg\"].path" ~/.claude/kg-config.json)
+   kg_path="${kg_path/#\~/$HOME}"
    ```
+   The tilde expansion is required: `jq` returns the raw JSON string (e.g. `~/GitHub/foo`),
+   but `pwd` returns an absolute path. Without expansion the comparison always fails for
+   tilde-stored KG paths.
 
 2. Derive the project root from `kg_path`. If `kg_path` ends in `/docs`, the project root is
    its parent directory; otherwise the project root IS `kg_path`. (Mirrors `getProjectRoot`
@@ -145,7 +149,7 @@ Otherwise, run the following check **before** creating any directories or runnin
    >
    > Reply 1, 2, or 3.
 
-   - Option 1: Run `/kmgraph:switch` for the current project's KG (if configured), then re-resolve output dir in Step 1 using the newly active KG.
+   - Option 1: Run `/kmgraph:switch` for the current project's KG (if configured), then re-resolve output dir in Step 1 using the newly active KG. **If the current project has no KG registered in `~/.claude/kg-config.json`**, tell the user and offer `/kmgraph:init` to create one — or fall back to option 2 or 3.
    - Option 2: Continue to Step 1 using the current active KG unchanged.
    - Option 3: Abort. Do not run extraction.
 

--- a/docs/reference/command-guide.md
+++ b/docs/reference/command-guide.md
@@ -788,7 +788,8 @@ Test the hook:
 
 **What it does**:
 
-1. Determines output directory (active KG's `chat-history/` by default, or custom path)
+1. **(Step 0) Checks active KG alignment** — Compares the active KG's project root against the current working directory. On mismatch, stops and asks: switch active KG / proceed to active KG anyway / cancel. Skipped when `--output-dir` or `--project` is present.
+2. Determines output directory (active KG's `chat-history/` by default, or custom path)
 2. Scans Claude logs (`~/.claude/projects/` for `.jsonl` files), Gemini logs (`~/.gemini/tmp/`, `~/.gemini/antigravity/conversations/` for `.json`/`.pb` files), and/or Codex CLI sessions (`~/.codex/sessions/YYYY/MM/DD/rollout-*.jsonl`)
 3. Merges sessions by date into `YYYY-MM-DD-claude.md`, `YYYY-MM-DD-gemini.md`, and/or `YYYY-MM-DD-codex.md`
 4. If a daily file exceeds 900 KB or 30,000 lines, automatically splits into numbered parts (`-part1.md`, `-part2.md`, …) inside a `YYYY-MM-DD/` subfolder to prevent Obsidian rendering failures

--- a/knowledge/decisions/ADR-019-write-guard-agent-instructions-vs-data-layer.md
+++ b/knowledge/decisions/ADR-019-write-guard-agent-instructions-vs-data-layer.md
@@ -1,7 +1,7 @@
 # ADR-019: Write Guard via Agent Instructions (v0.2.0) vs Data Layer (v0.2.1)
 
 **Date:** 2026-03-27
-**Status:** Accepted
+**Status:** Accepted (amended v0.5.10.8 — see § Amendment)
 **Implements:** v0.2.0-beta — Active KG / Project Directory Alignment
 **Related:** [ADR-017](ADR-017-four-layer-architecture-thin-commands.md), [ADR-001](ADR-001-centralized-multi-kg-configuration.md)
 
@@ -176,5 +176,27 @@ Before writing any file:
 ---
 
 **Decision Made:** 2026-03-27
-**Last Updated:** 2026-03-27
-**Status:** Accepted
+**Last Updated:** 2026-06-14
+**Status:** Accepted (amended v0.5.10.8 — see § Amendment)
+
+---
+
+## Amendment — v0.5.10.8 (2026-06-14)
+
+**Phase 2 status confirmed shipped:** `mcp-server/src/tools/capture.ts` implements the
+data-layer CWD guard at lines 252-266. `lesson-capture-agent.md` and
+`session-summary-agent.md` delegate all writes to `kg_capture`. The model-dependent
+agent-instruction guard has been superseded for these paths.
+
+**Remaining gap:** `commands/extract-chat.md`, `commands/sync-all.md`,
+`commands/update-graph.md` do not call `kg_capture` — they write via Python or direct
+filesystem tools. The "non-agent write paths" gap remains open for these commands.
+
+**v0.5.10.8 partial fix:** Added model-layer Step 0 guard to `extract-chat.md` (mirrors
+`capture.ts:252-266` semantics; skip on explicit `--output-dir`/`--project`).
+Cross-platform (Claude, Gemini, Codex). Model-dependent.
+
+**ENH-026** tracks: sync-all/update-graph Step 0 guards, `run_extraction.py` bypass-proof
+CWD check, full unguarded-path audit, and ADR supersession.
+
+**Review date updated:** Reassess when ENH-026 ships; mark this ADR Superseded at that point.

--- a/knowledge/enhancements/ENH-026/ENH-026-specification.md
+++ b/knowledge/enhancements/ENH-026/ENH-026-specification.md
@@ -1,0 +1,42 @@
+# ENH-026: KG Write Guard — Unguarded Command Class
+
+**Status:** Proposed
+**Version:** TBD (post-v0.5.10.8)
+**Parent:** ADR-019 (write guard design), v0.5.10.8 (extract-chat patch)
+
+---
+
+## Problem
+
+v0.5.10.8 added a model-layer Step 0 guard to `extract-chat`. Two other commands share
+the same root cause (they resolve the active KG path from `kg-config.json` and write
+directly without a CWD alignment check):
+
+- `commands/sync-all.md`
+- `commands/update-graph.md`
+
+Additionally, the extract-chat Step 0 guard is model-dependent — a confused LLM could
+skip it. The durable fix is to move the CWD check into `core/scripts/run_extraction.py`
+(Python, bypass-proof, model-independent).
+
+## Scope
+
+1. **Add Step 0 guard to `sync-all` and `update-graph`** — same pattern as extract-chat v0.5.10.8.
+2. **Move CWD check into `run_extraction.py`** — read `kg-config.json`, compare `projectRoot`
+   vs `os.getcwd()`, raise `SystemExit` with a clear message if mismatch and no explicit
+   `--output-dir` override. Model-independent, cross-platform, bypass-proof.
+3. **Audit remaining unguarded write paths** — grep `kg-config.json` reads in commands/ and
+   skills/ to find any other paths that write to KG directories without calling `kg_capture`.
+4. **Supersede ADR-019** — write a new ADR documenting the full enforcement picture after this
+   ENH ships: `kg_capture` for lessons/sessions, Python-layer for extraction, Step 0 guards
+   for remaining commands.
+
+## Success Criteria
+
+- `sync-all` and `update-graph` block on active-KG/CWD mismatch with the same three-option prompt
+- `run_extraction.py` refuses to write on mismatch unless an explicit `--output-dir` override is passed
+- ADR-019 is marked Superseded with a link to the new ADR
+
+## Deferred From
+
+v0.5.10.8 (this release): extract-chat Step 0 guard only.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "knowledge-graph-plugin",
-  "version": "0.5.10.7",
+  "version": "0.5.10.8",
   "description": "Structured knowledge capture and cross-session memory for Claude Code projects.",
   "files": [
     ".claude-plugin/",


### PR DESCRIPTION
## Summary

- Adds Step 0 pre-extraction guard to `commands/extract-chat.md` that compares the active KG's project root against the current working directory
- On mismatch: surfaces stop-and-ask prompt (switch / proceed / cancel) before any `mkdir` or Python extraction runs
- On explicit `--output-dir` or `--project`: guard is skipped (user named the destination)
- Tilde expansion applied to `kg_path` after jq read (mirrors `switch.md` / `getActiveGraphPath` behavior — prevents false mismatches on `~/`-stored paths)
- Option 1 documents `/kmgraph:init` fallback when current project has no registered KG
- Mirrors semantics of `kg_capture` CWD guard (`capture.ts:252-266`) and `lesson-capture-agent` Phase 0 wording
- Cross-platform: works on Claude, Gemini, and Codex (model-layer instruction, no hooks)

## Files Changed

- `commands/extract-chat.md` — Step 0 guard inserted before Step 1
- `knowledge/enhancements/ENH-026/ENH-026-specification.md` — follow-on scope (sync-all, update-graph, Python-layer enforcement)
- `knowledge/decisions/ADR-019-write-guard-agent-instructions-vs-data-layer.md` — amendment confirming Phase 2 shipped, remaining gaps
- `CHANGELOG.md` / `README.md` / `docs/reference/command-guide.md` — release docs

## Deferred (ENH-026)

- sync-all and update-graph Step 0 guards
- run_extraction.py bypass-proof CWD check
- Full unguarded-path audit
- ADR-019 supersession

## Test Plan

- [ ] With active KG ≠ CWD: `/kmgraph:extract-chat -claude --today` → guard fires, three-option prompt shown
- [ ] With active KG = CWD: same command → guard passes silently, extraction proceeds
- [ ] With `--output-dir`: guard skipped entirely
- [ ] With `--project=<fragment>`: guard skipped entirely
- [ ] Tilde-stored KG path (`~/GitHub/foo`): no false mismatch when in correct dir
- [ ] Current project has no KG: Option 1 surfaces `/kmgraph:init` suggestion
- [ ] Gemini/Codex: confirm Step 0 text is read and respected by model

Closes gap documented in ADR-019 (non-agent write paths).
Refs: ADR-019, ADR-043, ENH-026

🤖 Generated with [Claude Code](https://claude.com/claude-code)