### PR TITLE
fix(skills,hooks): Codex YAML frontmatter + full POSIX stop hook (v0.6.10)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "kmgraph",
-  "version": "0.6.9",
+  "version": "0.6.10",
   "description": "Structured knowledge capture, lesson-learned documentation, and cross-session memory for Claude Code projects. Includes KG entries, ADRs, meta-issue tracking, chat extraction, and profile-file rule capture.",
   "author": {
     "name": "technomensch",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "kmgraph",
-  "version": "0.6.9",
+  "version": "0.6.10",
   "description": "Structured knowledge capture, lesson-learned documentation, and cross-session memory for Claude Code projects. Includes KG entries, ADRs, meta-issue tracking, chat extraction, and profile-file rule capture.",
   "author": {
     "name": "technomensch",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@
 
 All notable changes to the Knowledge Plugin will be documented in this file.
 
+## [0.6.10] — 2026-06-22
+
+### Fixed
+
+- **Skills broken in Codex (all 15)** — All `SKILL.md` files were missing YAML frontmatter, causing Codex to reject them with `⚠ missing YAML frontmatter delimited by ---`. Added `name` + `description` frontmatter block to all 15 skills. Skills are now fully functional in Codex.
+- **Stop hook POSIX incompatibility** — `session-end-prompt.sh` used two bash-only constructs (`[[` in EXIT trap, `&>` redirection) that fail when invoked under `sh`. Replaced with POSIX equivalents (`[`, `>/dev/null 2>&1`). Hook now passes `sh -n` and runs correctly under `sh`.
+
 ## [0.6.9] — 2026-06-21
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Structured knowledge capture, lesson-learned documentation, and cross-session memory for Claude Code projects.
 
-**Version:** 0.6.9
+**Version:** 0.6.10
 **Status:** Actively developed and in daily use
 
 Documentation: https://kmgraph.stayinginsync.info
@@ -90,6 +90,11 @@ Pull the latest version and run `/kmgraph:kmg-init` in any project that uses it.
 ---
 
 ## v0.6.x Feature Highlights
+
+**v0.6.10 — 2026-06-22**
+
+- **Codex skills fixed** — All 15 `SKILL.md` files now include required YAML frontmatter. Skills were completely non-functional in Codex due to missing `---` delimiters.
+- **Stop hook POSIX fix** — `session-end-prompt.sh` bash-isms (`[[`, `&>`) replaced with POSIX equivalents. Hook now runs correctly when invoked via `sh`.
 
 **v0.6.9 — 2026-06-21**
 
@@ -316,6 +321,6 @@ MIT License - See [LICENSE](LICENSE)
 ---
 
 **Created:** 2026-02-12
-**Current Version:** v0.6.9 (2026-06-21)
+**Current Version:** v0.6.10 (2026-06-22)
 
 📚 **Full documentation:** https://kmgraph.stayinginsync.info

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@knowledge-graph-plugin/mcp-server",
-  "version": "0.6.9",
+  "version": "0.6.10",
   "description": "MCP server for Knowledge Management Graph — cross-platform data layer for knowledge capture, search, and management",
   "main": "dist/index.js",
   "bin": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "knowledge-graph-plugin",
-  "version": "0.6.9",
+  "version": "0.6.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "knowledge-graph-plugin",
-      "version": "0.6.9",
+      "version": "0.6.10",
       "license": "MIT",
       "dependencies": {
         "@docusaurus/plugin-client-redirects": "^3.10.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "knowledge-graph-plugin",
-  "version": "0.6.9",
+  "version": "0.6.10",
   "description": "Structured knowledge capture and cross-session memory for Claude Code projects.",
   "files": [
     ".claude-plugin/",

--- a/scripts/session-end-prompt.sh
+++ b/scripts/session-end-prompt.sh
@@ -6,7 +6,7 @@ CONFIG_PATH="$HOME/.claude/kg-config.json"
 
 # Claude Code Stop hooks require hookSpecificOutput format; Codex requires {"decision":"continue"}.
 # Gemini has no Stop hook. Select output by CLAUDECODE env var (set only by Claude Code).
-trap '[[ -n "${CLAUDECODE:-}" ]] && echo "{\"hookSpecificOutput\": {\"hookEventName\": \"Stop\"}}" || echo "{\"decision\": \"continue\"}"' EXIT
+trap 'if [ -n "${CLAUDECODE:-}" ]; then echo "{\"hookSpecificOutput\": {\"hookEventName\": \"Stop\"}}"; else echo "{\"decision\": \"continue\"}"; fi' EXIT
 
 # Color codes
 RED='\033[0;31m'
@@ -115,7 +115,7 @@ fi
 LESSON_MSG=""
 LESSONS_DIR="$KG_PROJECT_ROOT/knowledge/lessons-learned"
 
-if command -v git &>/dev/null && [ -d "$KG_PROJECT_ROOT/.git" ]; then
+if command -v git >/dev/null 2>&1 && [ -d "$KG_PROJECT_ROOT/.git" ]; then
     RECENT_COMMITS="$(git -C "$KG_PROJECT_ROOT" log -5 --format="%s" 2>/dev/null)"
     LESSON_KEYWORD_FOUND=false
 
@@ -146,11 +146,11 @@ HAS_ITEMS=false
 
 if [ "$HAS_ITEMS" = true ]; then
     echo "" >&2
-    echo -e "${BLUE}Before you go —${NC}" >&2
+    printf '%b\n' "${BLUE}Before you go —${NC}" >&2
     echo "" >&2
-    [ -n "$OPEN_PLAN_MSG" ] && echo -e "${YELLOW}$OPEN_PLAN_MSG${NC}" >&2
-    [ -n "$DRAFT_ADR_MSG" ] && echo -e "${YELLOW}$DRAFT_ADR_MSG${NC}" >&2
-    [ -n "$LESSON_MSG" ] && echo -e "${YELLOW}$LESSON_MSG${NC}" >&2
+    [ -n "$OPEN_PLAN_MSG" ] && printf '%b\n' "${YELLOW}$OPEN_PLAN_MSG${NC}" >&2
+    [ -n "$DRAFT_ADR_MSG" ] && printf '%b\n' "${YELLOW}$DRAFT_ADR_MSG${NC}" >&2
+    [ -n "$LESSON_MSG" ] && printf '%b\n' "${YELLOW}$LESSON_MSG${NC}" >&2
     echo "" >&2
     if [ "$SNAPSHOT_TODAY" = true ]; then
         echo "You have a session snapshot from today — run /kmgraph:kmg-session-summary to complete the wrap-up." >&2
@@ -160,9 +160,9 @@ if [ "$HAS_ITEMS" = true ]; then
     echo "" >&2
 else
     if [ "$SNAPSHOT_TODAY" = true ]; then
-        echo -e "${GREEN}✅ Session snapshot taken. Run /kmgraph:kmg-session-summary to finalize the wrap-up.${NC}" >&2
+        printf '%b\n' "${GREEN}✅ Session snapshot taken. Run /kmgraph:kmg-session-summary to finalize the wrap-up.${NC}" >&2
     else
-        echo -e "${GREEN}✅ Good stopping point. /kmgraph:kmg-session-summary if you'd like a summary.${NC}" >&2
+        printf '%b\n' "${GREEN}✅ Good stopping point. /kmgraph:kmg-session-summary if you'd like a summary.${NC}" >&2
     fi
 fi
 

--- a/skills/kmg-adr-guide/SKILL.md
+++ b/skills/kmg-adr-guide/SKILL.md
@@ -1,3 +1,7 @@
+---
+name: kmg-adr-guide
+description: Auto-surface ADR creation when user makes architectural decisions or chooses between technical approaches
+---
 
 # Skill: kmg-adr-guide
 

--- a/skills/kmg-auto-recall/SKILL.md
+++ b/skills/kmg-auto-recall/SKILL.md
@@ -1,3 +1,7 @@
+---
+name: kmg-auto-recall
+description: Auto-invoke knowledge graph search when user asks about project history, past decisions, or previously solved problems
+---
 
 # Skill: kmg-auto-recall
 

--- a/skills/kmg-brainstorm-recall/SKILL.md
+++ b/skills/kmg-brainstorm-recall/SKILL.md
@@ -1,3 +1,7 @@
+---
+name: kmg-brainstorm-recall
+description: Ensure the knowledge graph is consulted before any recommendation is made
+---
 
 # Skill: kmg-brainstorm-recall
 

--- a/skills/kmg-capture-router/SKILL.md
+++ b/skills/kmg-capture-router/SKILL.md
@@ -1,3 +1,7 @@
+---
+name: kmg-capture-router
+description: Route capture-that / remember-that requests to the correct destination via auto-detection
+---
 
 # Skill: kmg-capture-router
 

--- a/skills/kmg-doc-update-router/SKILL.md
+++ b/skills/kmg-doc-update-router/SKILL.md
@@ -1,3 +1,7 @@
+---
+name: kmg-doc-update-router
+description: Intercept explicit doc-update requests and route to the correct command
+---
 
 # Skill: kmg-doc-update-router
 

--- a/skills/kmg-docs-impact-scan/SKILL.md
+++ b/skills/kmg-docs-impact-scan/SKILL.md
@@ -1,3 +1,7 @@
+---
+name: kmg-docs-impact-scan
+description: Fires on pre-ship signals to scan for docs affected by code changes
+---
 
 ## When This Applies
 

--- a/skills/kmg-execute-plan/SKILL.md
+++ b/skills/kmg-execute-plan/SKILL.md
@@ -1,3 +1,7 @@
+---
+name: kmg-execute-plan
+description: Enforce zero-deviation plan execution when user invokes plan implementation
+---
 
 # Skill: kmg-execute-plan
 

--- a/skills/kmg-knowledge-graph-usage/SKILL.md
+++ b/skills/kmg-knowledge-graph-usage/SKILL.md
@@ -1,3 +1,7 @@
+---
+name: kmg-knowledge-graph-usage
+description: Provide orientation to the Knowledge Graph system architecture and guidance for knowledge capture
+---
 
 # Knowledge Graph Usage Guidance
 

--- a/skills/kmg-lesson-capture/SKILL.md
+++ b/skills/kmg-lesson-capture/SKILL.md
@@ -1,3 +1,7 @@
+---
+name: kmg-lesson-capture
+description: Auto-capture lessons when user solves complex bugs, makes breakthroughs, or completes debugging sessions
+---
 
 # Skill: kmg-lesson-capture
 

--- a/skills/kmg-plan-gate/SKILL.md
+++ b/skills/kmg-plan-gate/SKILL.md
@@ -1,3 +1,7 @@
+---
+name: kmg-plan-gate
+description: Enforce user approval gates after superpowers planning and execution skills complete
+---
 
 # Skill: kmg-plan-gate
 

--- a/skills/kmg-rules-capture/SKILL.md
+++ b/skills/kmg-rules-capture/SKILL.md
@@ -1,3 +1,7 @@
+---
+name: kmg-rules-capture
+description: Detect implicit mid-session behavioral corrections and route to the correct rules file
+---
 
 # Skill: kmg-rules-capture
 

--- a/skills/kmg-session-wrap/SKILL.md
+++ b/skills/kmg-session-wrap/SKILL.md
@@ -1,3 +1,7 @@
+---
+name: kmg-session-wrap
+description: Prompt for session summary when user indicates they are stopping work or approaching context limits
+---
 
 # Skill: kmg-session-wrap
 

--- a/skills/kmg-sidebar-update/SKILL.md
+++ b/skills/kmg-sidebar-update/SKILL.md
@@ -1,3 +1,7 @@
+---
+name: kmg-sidebar-update
+description: Fires when a docs file is moved or renamed to keep sidebar navigation in sync
+---
 
 ## When This Applies
 

--- a/skills/kmg-stuck-work-escalation/SKILL.md
+++ b/skills/kmg-stuck-work-escalation/SKILL.md
@@ -1,3 +1,7 @@
+---
+name: kmg-stuck-work-escalation
+description: Escalate stuck work using the Plan Protocol thresholds before switching tactics
+---
 
 Before starting, read `~/.kmgraph/rules.md` — Plan Protocol § Stuck-Work Escalation for thresholds, scope rules, and exit paths.
 

--- a/skills/kmg-update-profile/SKILL.md
+++ b/skills/kmg-update-profile/SKILL.md
@@ -1,3 +1,7 @@
+---
+name: kmg-update-profile
+description: Detect when the user asks to update their profile and route changes to all three profile files
+---
 
 # Skill: kmg-update-profile
 


### PR DESCRIPTION
## Summary

- **Codex skills fixed** — All 15 `SKILL.md` files were missing YAML frontmatter (`---name/description---`), causing Codex to reject every skill with `⚠ missing YAML frontmatter delimited by ---`. Skills were completely non-functional in Codex.
- **Stop hook full POSIX fix** — `session-end-prompt.sh` had four bash-only constructs that fail under `sh` (Codex invocation path): `[[` in EXIT trap, `&>` redirection, 6× `echo -e`, and the `&&/||` trap idiom. All replaced with POSIX equivalents (`if/else`+`[`, `>/dev/null 2>&1`, `printf '%b\n'`). Script now passes `sh -n` and runs correctly under `sh`.
- **Version bump** — 0.6.9 → 0.6.10 across all four manifests + package-lock.

## Test plan

- [ ] `sh -n scripts/session-end-prompt.sh` exits 0
- [ ] `CLAUDECODE=1 sh scripts/session-end-prompt.sh` outputs `{"hookSpecificOutput": {"hookEventName": "Stop"}}`, exits 0
- [ ] `sh scripts/session-end-prompt.sh` (no CLAUDECODE) outputs `{"decision": "continue"}`, exits 0
- [ ] No stray `dev` file created after above runs
- [ ] Install in Codex — skills load without frontmatter warning
- [ ] All 4 manifests report `0.6.10`

🤖 Generated with [Claude Code](https://claude.com/claude-code)