### PR TITLE
fix(docs): strip readme.com frontmatter + restore Docusaurus JSX/Tabs (v0.6.11)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+---
+hide_table_of_contents: true
+displayed_sidebar: null
+---
 
 # Changelog
 

--- a/docs/CHEAT-SHEET.md
+++ b/docs/CHEAT-SHEET.md
@@ -1,9 +1,5 @@
 ---
 title: Cheat Sheet
-category:
-  uri: overview
-position: 4
-slug: cheat-sheet
 ---
 
 **Version:** 0.5.2 | **Updated:** 2026-04-22

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -1,9 +1,5 @@
 ---
 title: Configuration
-category:
-  uri: overview
-position: 8
-slug: configuration
 ---
 
 This guide covers configuring and customizing the Knowledge Management Graph after installation.

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -1,9 +1,5 @@
 ---
 title: FAQ
-category:
-  uri: overview
-position: 5
-slug: faq
 ---
 
 This guide provides answers to common questions about using and maintaining the Knowledge Management Graph.

--- a/docs/GLOSSARY.md
+++ b/docs/GLOSSARY.md
@@ -1,9 +1,5 @@
 ---
 title: Glossary
-category:
-  uri: overview
-position: 6
-slug: glossary
 ---
 
 This glossary provides plain-English definitions for key terms and concepts used throughout the Knowledge Management Graph documentation.

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -1,9 +1,5 @@
 ---
 title: Installation
-category:
-  uri: overview
-position: 3
-slug: install
 ---
 
 Users can install the Knowledge Management Graph using a **universal installer** — a single markdown file that any AI assistant can execute for automated setup.

--- a/docs/STYLE-GUIDE.md
+++ b/docs/STYLE-GUIDE.md
@@ -1,9 +1,5 @@
 ---
 title: Style Guide
-category:
-  uri: overview
-position: 9
-slug: style-guide
 ---
 
 Authoring standards for contributors writing or reviewing documentation for the Knowledge Management Graph.

--- a/docs/TRACK-ISSUES.md
+++ b/docs/TRACK-ISSUES.md
@@ -1,9 +1,5 @@
 ---
 title: Track Issues
-category:
-  uri: overview
-position: 7
-slug: track-issues
 ---
 
 The issue tracking process documents a problem or enhancement from identification through resolution. The `/kmgraph:kmg-start-issue-tracking` command drives this process. Beginning with v0.2.3.4-beta, the command gates all git-dependent steps on repository presence — when no git repository is detected, branch strategy and git integration steps are omitted automatically.

--- a/docs/concepts/four-content-types.md
+++ b/docs/concepts/four-content-types.md
@@ -1,9 +1,5 @@
 ---
 title: Four Content Types
-category:
-  uri: concepts
-position: 3
-slug: concepts-four-content-types
 ---
 
 The knowledge graph system organizes information into four distinct types, each optimized for a different purpose. Together, these pillars form a comprehensive institutional memory.

--- a/docs/concepts/how-kmgraph-is-organized.md
+++ b/docs/concepts/how-kmgraph-is-organized.md
@@ -1,9 +1,5 @@
 ---
 title: How KMGraph Is Organized
-category:
-  uri: concepts
-position: 4
-slug: concepts-how-kmgraph-is-organized
 ---
 
 # How KMGraph Is Organized

--- a/docs/concepts/what-is-a-knowledge-graph.md
+++ b/docs/concepts/what-is-a-knowledge-graph.md
@@ -1,9 +1,5 @@
 ---
 title: What Is a Knowledge Graph
-category:
-  uri: concepts
-position: 2
-slug: concepts-what-is-a-knowledge-graph
 ---
 
 # What Is a Knowledge Graph

--- a/docs/concepts/why-kmgraph.md
+++ b/docs/concepts/why-kmgraph.md
@@ -1,9 +1,5 @@
 ---
 title: Why KMGraph?
-category:
-  uri: concepts
-position: 1
-slug: concepts-why-kmgraph
 ---
 
 # Why KMGraph?

--- a/docs/contributing/docs-updates-workflow.md
+++ b/docs/contributing/docs-updates-workflow.md
@@ -1,9 +1,5 @@
 ---
 title: Documentation Updates Workflow
-category:
-  uri: contributing
-position: 1
-slug: contributing-docs-updates-workflow
 ---
 
 # Documentation Updates Workflow

--- a/docs/design/platform-detection.md
+++ b/docs/design/platform-detection.md
@@ -1,9 +1,5 @@
 ---
 title: Platform Detection
-category:
-  uri: design
-position: 1
-slug: design-platform-detection
 ---
 
 # Design: Platform Detection for `rules-capture`

--- a/docs/examples/decisions/ADR-001-example.md
+++ b/docs/examples/decisions/ADR-001-example.md
@@ -1,8 +1,5 @@
 ---
 title: Adr 001 Example
-category:
-  uri: examples
-slug: examples-decisions-adr-001-example
 ---
 
 <!-- THIS IS AN EXAMPLE — Replace with your project's ADRs -->

--- a/docs/examples/decisions/ADR-002-example.md
+++ b/docs/examples/decisions/ADR-002-example.md
@@ -1,8 +1,5 @@
 ---
 title: Adr 002 Example
-category:
-  uri: examples
-slug: examples-decisions-adr-002-example
 ---
 
 <!-- THIS IS AN EXAMPLE — Replace with your project's ADRs -->

--- a/docs/examples/knowledge/sample-concepts.md
+++ b/docs/examples/knowledge/sample-concepts.md
@@ -1,8 +1,5 @@
 ---
 title: Sample Concepts
-category:
-  uri: examples
-slug: examples-knowledge-sample-concepts
 ---
 
 # Core Concepts

--- a/docs/examples/knowledge/sample-gotchas.md
+++ b/docs/examples/knowledge/sample-gotchas.md
@@ -1,8 +1,5 @@
 ---
 title: Sample Gotchas
-category:
-  uri: examples
-slug: examples-knowledge-sample-gotchas
 ---
 
 # Common Gotchas & Solutions

--- a/docs/examples/knowledge/sample-patterns.md
+++ b/docs/examples/knowledge/sample-patterns.md
@@ -1,8 +1,5 @@
 ---
 title: Sample Patterns
-category:
-  uri: examples
-slug: examples-knowledge-sample-patterns
 ---
 
 # Design Patterns Catalog

--- a/docs/examples/lessons-learned/architecture/Example_Claude_Code_Skills_Arch.md
+++ b/docs/examples/lessons-learned/architecture/Example_Claude_Code_Skills_Arch.md
@@ -1,8 +1,5 @@
 ---
 title: 'Lesson: Platform Skill Discovery Architecture'
-category:
-  uri: examples
-slug: examples-lessons-learned-architecture-example-claude-code-skills-arch
 ---
 
 # Lesson Learned: Platform Skill Discovery Architecture

--- a/docs/examples/lessons-learned/architecture/Example_Three_Tier_Sync.md
+++ b/docs/examples/lessons-learned/architecture/Example_Three_Tier_Sync.md
@@ -1,8 +1,5 @@
 ---
 title: 'Lesson: Three-Tier Configuration Synchronization'
-category:
-  uri: examples
-slug: examples-lessons-learned-architecture-example-three-tier-sync
 ---
 
 # Lesson Learned: Three-Tier Configuration Synchronization

--- a/docs/examples/lessons-learned/patterns/Example_Complete_Memory_System.md
+++ b/docs/examples/lessons-learned/patterns/Example_Complete_Memory_System.md
@@ -1,8 +1,5 @@
 ---
 title: 'Lesson: Complete Knowledge System Implementation'
-category:
-  uri: examples
-slug: examples-lessons-learned-patterns-example-complete-memory-system
 ---
 
 # Lesson Learned: Complete Knowledge System Implementation

--- a/docs/examples/lessons-learned/process/Example_Agentic_Momentum.md
+++ b/docs/examples/lessons-learned/process/Example_Agentic_Momentum.md
@@ -1,8 +1,5 @@
 ---
 title: 'Lesson: Agentic Momentum & Failure of Subjective Validation'
-category:
-  uri: examples
-slug: examples-lessons-learned-process-example-agentic-momentum
 ---
 
 # Lesson Learned: Agentic Momentum & The Failure of Subjective Validation

--- a/docs/examples/lessons-learned/process/Example_Chat_History_Workflow.md
+++ b/docs/examples/lessons-learned/process/Example_Chat_History_Workflow.md
@@ -1,8 +1,5 @@
 ---
 title: 'Lesson: Knowledge Extraction Workflow'
-category:
-  uri: examples
-slug: examples-lessons-learned-process-example-chat-history-workflow
 ---
 
 # Lesson Learned: Knowledge Extraction Workflow

--- a/docs/examples/lessons-learned/process/Example_Effective_LLM_Constraints.md
+++ b/docs/examples/lessons-learned/process/Example_Effective_LLM_Constraints.md
@@ -1,8 +1,5 @@
 ---
 title: 'Lesson: AI Constraint Enforcement Strategies'
-category:
-  uri: examples
-slug: examples-lessons-learned-process-example-effective-llm-constraints
 ---
 
 # Lesson Learned: AI Constraint Enforcement Strategies

--- a/docs/examples/lessons-learned/process/Example_Git_Branch_Preservation.md
+++ b/docs/examples/lessons-learned/process/Example_Git_Branch_Preservation.md
@@ -1,8 +1,5 @@
 ---
 title: 'Lesson: Git Branch Governance Without Deletion'
-category:
-  uri: examples
-slug: examples-lessons-learned-process-example-git-branch-preservation
 ---
 
 # Lesson Learned: Git Branch Governance Without Deletion

--- a/docs/examples/lessons-learned/process/Example_Identifier_Decoupling.md
+++ b/docs/examples/lessons-learned/process/Example_Identifier_Decoupling.md
@@ -1,8 +1,5 @@
 ---
 title: 'Lesson: Identifier Decoupling (The Serial ID Drift)'
-category:
-  uri: examples
-slug: examples-lessons-learned-process-example-identifier-decoupling
 ---
 
 # Lesson Learned: Identifier Decoupling (The Serial ID Drift)

--- a/docs/examples/lessons-learned/process/Example_Relative_File_Paths.md
+++ b/docs/examples/lessons-learned/process/Example_Relative_File_Paths.md
@@ -1,8 +1,5 @@
 ---
 title: 'Lesson: Relative File Path Hygiene'
-category:
-  uri: examples
-slug: examples-lessons-learned-process-example-relative-file-paths
 ---
 
 # Lesson Learned: Relative File Path Hygiene

--- a/docs/examples/lessons-learned/process/Example_SessionStart_Automation.md
+++ b/docs/examples/lessons-learned/process/Example_SessionStart_Automation.md
@@ -1,8 +1,5 @@
 ---
 title: 'Lesson: Hook-Based Session Automation'
-category:
-  uri: examples
-slug: examples-lessons-learned-process-example-sessionstart-automation
 ---
 
 # Lesson Learned: Hook-Based Session Automation

--- a/docs/examples/meta-issue/example-performance-saga/README.md
+++ b/docs/examples/meta-issue/example-performance-saga/README.md
@@ -1,8 +1,5 @@
 ---
 title: Readme
-category:
-  uri: examples
-slug: examples-meta-issue-example-performance-saga-readme
 ---
 
 <!-- THIS IS AN EXAMPLE — Replace with your project's meta-issues -->

--- a/docs/examples/meta-issue/example-performance-saga/attempts/001-baseline/attempt-results.md
+++ b/docs/examples/meta-issue/example-performance-saga/attempts/001-baseline/attempt-results.md
@@ -1,8 +1,5 @@
 ---
 title: Attempt Results
-category:
-  uri: examples
-slug: examples-meta-issue-example-performance-saga-attempts-001-baseline-attempt-results
 ---
 
 <!-- THIS IS AN EXAMPLE — Replace with your project's meta-issues -->

--- a/docs/examples/meta-issue/example-performance-saga/attempts/001-baseline/solution-approach.md
+++ b/docs/examples/meta-issue/example-performance-saga/attempts/001-baseline/solution-approach.md
@@ -1,8 +1,5 @@
 ---
 title: Solution Approach
-category:
-  uri: examples
-slug: examples-meta-issue-example-performance-saga-attempts-001-baseline-solution-approach
 ---
 
 <!-- THIS IS AN EXAMPLE — Replace with your project's meta-issues -->

--- a/docs/examples/meta-issue/example-performance-saga/attempts/002-caching/attempt-results.md
+++ b/docs/examples/meta-issue/example-performance-saga/attempts/002-caching/attempt-results.md
@@ -1,8 +1,5 @@
 ---
 title: Attempt Results
-category:
-  uri: examples
-slug: examples-meta-issue-example-performance-saga-attempts-002-caching-attempt-results
 ---
 
 <!-- THIS IS AN EXAMPLE — Replace with your project's meta-issues -->

--- a/docs/examples/meta-issue/example-performance-saga/attempts/002-caching/solution-approach.md
+++ b/docs/examples/meta-issue/example-performance-saga/attempts/002-caching/solution-approach.md
@@ -1,8 +1,5 @@
 ---
 title: Solution Approach
-category:
-  uri: examples
-slug: examples-meta-issue-example-performance-saga-attempts-002-caching-solution-approach
 ---
 
 <!-- THIS IS AN EXAMPLE — Replace with your project's meta-issues -->

--- a/docs/examples/meta-issue/example-performance-saga/description.md
+++ b/docs/examples/meta-issue/example-performance-saga/description.md
@@ -1,8 +1,5 @@
 ---
 title: Description
-category:
-  uri: examples
-slug: examples-meta-issue-example-performance-saga-description
 ---
 
 <!-- THIS IS AN EXAMPLE — Replace with your project's meta-issues -->

--- a/docs/examples/meta-issue/example-performance-saga/implementation-log.md
+++ b/docs/examples/meta-issue/example-performance-saga/implementation-log.md
@@ -1,8 +1,5 @@
 ---
 title: Implementation Log
-category:
-  uri: examples
-slug: examples-meta-issue-example-performance-saga-implementation-log
 ---
 
 <!-- THIS IS AN EXAMPLE — Replace with your project's meta-issues -->

--- a/docs/examples/meta-issue/example-performance-saga/test-cases.md
+++ b/docs/examples/meta-issue/example-performance-saga/test-cases.md
@@ -1,8 +1,5 @@
 ---
 title: Test Cases
-category:
-  uri: examples
-slug: examples-meta-issue-example-performance-saga-test-cases
 ---
 
 <!-- THIS IS AN EXAMPLE — Replace with your project's meta-issues -->

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -1,11 +1,6 @@
 ---
 title: Knowledge Management Graph
-category:
-  uri: overview
-position: 1
 slug: /
-content:
-  excerpt: KMGraph gives your AI coding assistant a persistent memory — capturing lessons, decisions, and patterns across every session.
 ---
 
 # Knowledge Management Graph

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -15,11 +15,11 @@ Capture lessons, decisions, and patterns across every session — searchable, po
 
 | Pillar | When to use it |
 |---|---|
-| 📥 **[Capturing](pillars-capturing-index)** | "I solved something. How do I save it?" |
-| 🔍 **[Recalling](pillars-recalling-index)** | "I think I've solved this before." |
-| 🗂️ **[Organizing](pillars-organizing-index)** | "How do I keep this from becoming a junk drawer?" |
-| 🌐 **[Portability](pillars-portability-index)** | "I use multiple AI tools. Make them share knowledge." |
-| ⚙️ **[Tailoring](pillars-tailoring-index)** | "I want this to fit my workflow." |
+| 📥 **[Capturing](pillars/capturing)** | "I solved something. How do I save it?" |
+| 🔍 **[Recalling](pillars/recalling)** | "I think I've solved this before." |
+| 🗂️ **[Organizing](pillars/organizing)** | "How do I keep this from becoming a junk drawer?" |
+| 🌐 **[Portability](pillars/portability)** | "I use multiple AI tools. Make them share knowledge." |
+| ⚙️ **[Tailoring](pillars/tailoring)** | "I want this to fit my workflow." |
 
 Not sure where to start? Try the **[5-minute Quickstart](quickstart)**.
 

--- a/docs/pillars/capturing/architecture-decisions.md
+++ b/docs/pillars/capturing/architecture-decisions.md
@@ -1,11 +1,5 @@
 ---
 title: Architecture Decisions
-category:
-  uri: capturing
-position: 2
-slug: pillars-capturing-architecture-decisions
-parent:
-  uri: pillars-capturing-index
 ---
 
 # Architecture Decisions

--- a/docs/pillars/capturing/capture-lessons-learned.md
+++ b/docs/pillars/capturing/capture-lessons-learned.md
@@ -1,11 +1,5 @@
 ---
 title: Capture Lessons Learned
-category:
-  uri: capturing
-position: 1
-slug: pillars-capturing-capture-lessons-learned
-parent:
-  uri: pillars-capturing-index
 ---
 
 # Capture Lessons Learned

--- a/docs/pillars/capturing/capture-patterns.md
+++ b/docs/pillars/capturing/capture-patterns.md
@@ -1,11 +1,5 @@
 ---
 title: Capture Patterns
-category:
-  uri: capturing
-position: 3
-slug: pillars-capturing-capture-patterns
-parent:
-  uri: pillars-capturing-index
 ---
 
 # Capture Patterns

--- a/docs/pillars/capturing/document-meta-issues.md
+++ b/docs/pillars/capturing/document-meta-issues.md
@@ -1,11 +1,5 @@
 ---
 title: Document Meta-Issues
-category:
-  uri: capturing
-position: 4
-slug: pillars-capturing-document-meta-issues
-parent:
-  uri: pillars-capturing-index
 ---
 
 # Document Meta-Issues

--- a/docs/pillars/capturing/index.md
+++ b/docs/pillars/capturing/index.md
@@ -1,9 +1,5 @@
 ---
 title: Capturing
-category:
-  uri: capturing
-position: 1
-slug: pillars-capturing-index
 ---
 
 # Capturing

--- a/docs/pillars/capturing/what-to-capture.md
+++ b/docs/pillars/capturing/what-to-capture.md
@@ -1,11 +1,5 @@
 ---
 title: What to Capture
-category:
-  uri: capturing
-position: 5
-slug: pillars-capturing-what-to-capture
-parent:
-  uri: pillars-capturing-index
 ---
 
 # What to Capture

--- a/docs/pillars/organizing/backfill.md
+++ b/docs/pillars/organizing/backfill.md
@@ -1,11 +1,5 @@
 ---
 title: Backfill
-category:
-  uri: organizing
-position: 4
-slug: pillars-organizing-backfill
-parent:
-  uri: pillars-organizing-index
 ---
 
 # Backfill

--- a/docs/pillars/organizing/graph-configuration.md
+++ b/docs/pillars/organizing/graph-configuration.md
@@ -1,11 +1,5 @@
 ---
 title: Graph Configuration
-category:
-  uri: organizing
-position: 3
-slug: pillars-organizing-graph-configuration
-parent:
-  uri: pillars-organizing-index
 ---
 
 # Graph Configuration

--- a/docs/pillars/organizing/index.md
+++ b/docs/pillars/organizing/index.md
@@ -1,9 +1,5 @@
 ---
 title: Organizing
-category:
-  uri: organizing
-position: 1
-slug: pillars-organizing-index
 ---
 
 # Organizing

--- a/docs/pillars/organizing/multi-kg-workflows.md
+++ b/docs/pillars/organizing/multi-kg-workflows.md
@@ -1,11 +1,5 @@
 ---
 title: Multi-KG Workflows
-category:
-  uri: organizing
-position: 2
-slug: pillars-organizing-multi-kg-workflows
-parent:
-  uri: pillars-organizing-index
 ---
 
 # Multi-KG Workflows

--- a/docs/pillars/organizing/personal-vs-project.md
+++ b/docs/pillars/organizing/personal-vs-project.md
@@ -1,11 +1,5 @@
 ---
 title: Personal vs. Project
-category:
-  uri: organizing
-position: 1
-slug: pillars-organizing-personal-vs-project
-parent:
-  uri: pillars-organizing-index
 ---
 
 # Personal vs. Project

--- a/docs/pillars/organizing/sanitize-before-sharing.md
+++ b/docs/pillars/organizing/sanitize-before-sharing.md
@@ -1,11 +1,5 @@
 ---
 title: Sanitize Before Sharing
-category:
-  uri: organizing
-position: 5
-slug: pillars-organizing-sanitize-before-sharing
-parent:
-  uri: pillars-organizing-index
 ---
 
 # Sanitize Before Sharing

--- a/docs/pillars/portability/index.md
+++ b/docs/pillars/portability/index.md
@@ -1,9 +1,5 @@
 ---
 title: Portability
-category:
-  uri: portability
-position: 1
-slug: pillars-portability-index
 ---
 
 # Portability

--- a/docs/pillars/portability/integrate-notebooklm.md
+++ b/docs/pillars/portability/integrate-notebooklm.md
@@ -1,11 +1,5 @@
 ---
 title: Integrate with NotebookLM
-category:
-  uri: portability
-position: 5
-slug: pillars-portability-integrate-notebooklm
-parent:
-  uri: pillars-portability-index
 ---
 
 # Integrate with NotebookLM

--- a/docs/pillars/portability/integrate-notion.md
+++ b/docs/pillars/portability/integrate-notion.md
@@ -1,11 +1,5 @@
 ---
 title: Integrate with Notion
-category:
-  uri: portability
-position: 6
-slug: pillars-portability-integrate-notion
-parent:
-  uri: pillars-portability-index
 ---
 
 # Integrate with Notion

--- a/docs/pillars/portability/integrate-obsidian.md
+++ b/docs/pillars/portability/integrate-obsidian.md
@@ -1,11 +1,5 @@
 ---
 title: Integrate with Obsidian
-category:
-  uri: portability
-position: 7
-slug: pillars-portability-integrate-obsidian
-parent:
-  uri: pillars-portability-index
 ---
 
 # Integrate with Obsidian

--- a/docs/pillars/portability/migrate-claude-gemini.md
+++ b/docs/pillars/portability/migrate-claude-gemini.md
@@ -1,11 +1,5 @@
 ---
 title: Migrate Claude ↔ Gemini
-category:
-  uri: portability
-position: 4
-slug: pillars-portability-migrate-claude-gemini
-parent:
-  uri: pillars-portability-index
 ---
 
 # Migrate Claude ↔ Gemini

--- a/docs/pillars/portability/sync-across-machines.md
+++ b/docs/pillars/portability/sync-across-machines.md
@@ -1,11 +1,5 @@
 ---
 title: Sync a Knowledge Graph Across Machines
-category:
-  uri: portability
-position: 2
-slug: pillars-portability-sync-across-machines
-parent:
-  uri: pillars-portability-index
 ---
 
 # Sync a Knowledge Graph Across Machines

--- a/docs/pillars/portability/use-in-cursor.mdx
+++ b/docs/pillars/portability/use-in-cursor.mdx
@@ -1,11 +1,5 @@
 ---
 title: 'Use KMGraph in Cursor, Windsurf, VS Code, and JetBrains'
-category:
-  uri: portability
-position: 3
-slug: pillars-portability-use-in-cursor
-parent:
-  uri: pillars-portability-index
 ---
 
 

--- a/docs/pillars/portability/use-in-cursor.mdx
+++ b/docs/pillars/portability/use-in-cursor.mdx
@@ -1,8 +1,12 @@
 ---
-title: 'Use KMGraph in Cursor, Windsurf, VS Code, and JetBrains'
+id: use-in-cursor
+title: Use KMGraph in Cursor, Windsurf, VS Code, and JetBrains
+sidebar_label: Use in Cursor/Windsurf/VS Code
+description: How to install and use KMGraph with MCP-compatible IDEs beyond Claude Code
 ---
 
-
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
 
 # Use KMGraph in Cursor, Windsurf, VS Code, and JetBrains
 
@@ -22,7 +26,8 @@ The server binary is at `mcp-server/dist/index.js`.
 
 ## Step 2 — Register the MCP server in your IDE
 
-#### Cursor
+<Tabs groupId="ide">
+  <TabItem value="cursor" label="Cursor" default>
 
 Open `.cursor/mcp.json` (create if absent):
 
@@ -42,7 +47,8 @@ Open `.cursor/mcp.json` (create if absent):
 
 Restart Cursor. The `kg_*` tools appear in the MCP tools panel.
 
-#### Windsurf
+  </TabItem>
+  <TabItem value="windsurf" label="Windsurf">
 
 Open `.windsurf/mcp.json`:
 
@@ -57,7 +63,8 @@ Open `.windsurf/mcp.json`:
 }
 ```
 
-#### VS Code
+  </TabItem>
+  <TabItem value="vscode" label="VS Code">
 
 Run the VS Code installer script:
 
@@ -80,11 +87,13 @@ Alternatively, add to `.vscode/settings.json`:
 }
 ```
 
-#### JetBrains
+  </TabItem>
+  <TabItem value="jetbrains" label="JetBrains">
 
 In JetBrains settings → Tools → AI Assistant → MCP Servers, add a new server with name `kmgraph`, command `node`, and args `/path/to/knowledge-graph/mcp-server/dist/index.js`.
 
-#### Continue.dev
+  </TabItem>
+  <TabItem value="continue" label="Continue.dev">
 
 In `.continue/config.json`:
 
@@ -99,6 +108,9 @@ In `.continue/config.json`:
   ]
 }
 ```
+
+  </TabItem>
+</Tabs>
 
 ## Step 3 — Initialize the knowledge graph
 

--- a/docs/pillars/portability/your-ai-profile.mdx
+++ b/docs/pillars/portability/your-ai-profile.mdx
@@ -1,8 +1,12 @@
 ---
+id: your-ai-profile
 title: Your AI Profile
+sidebar_label: Your AI Profile
+description: How to set up and maintain your identity file so AI assistants know who you are across every tool.
 ---
 
-
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
 
 # Your AI Profile
 
@@ -46,7 +50,7 @@ Behavioral rules ("always run tests before pushing") belong in `rules.md`, not `
 
 Your profile lives at `~/.kmgraph/me.md` (personal, cross-project) or `knowledge/me.md` (project-specific override, gitignored).
 
-Run `/kmgraph:kmg-init` to create the initial profile interactively, or edit the file directly.
+Run `/kmgraph:init` to create the initial profile interactively, or edit the file directly.
 
 For cross-project personal identity (rules and style that apply across all projects), run `/kmgraph:kmg-init-personal-kg`. It creates `~/.kmgraph/me.md`, `~/.kmgraph/rules.md`, and `~/.kmgraph/triggers.md`.
 
@@ -54,7 +58,8 @@ For cross-project personal identity (rules and style that apply across all proje
 
 When both files exist, the project file takes precedence. This lets you have global defaults and per-project overrides.
 
-#### Project (knowledge/me.md)
+<Tabs groupId="kg-scope">
+<TabItem value="project" label="Project (knowledge/me.md)">
 
 Each contributor keeps their own copy — it's gitignored. It covers your role on this project, your areas of strength, and what's new to you in this codebase.
 
@@ -76,7 +81,8 @@ Correctness over speed. If a change might break something, say so first.
 
 Two contributors on the same project will have different files. Committing one person's file would give every other contributor the wrong context.
 
-#### Personal (~/.kmgraph/me.md)
+</TabItem>
+<TabItem value="personal" label="Personal (~/.kmgraph/me.md)">
 
 Cross-project identity: the communication style, expertise, and preferences that stay consistent regardless of which project is active. Created once with `/kmgraph:kmg-init-personal-kg`.
 
@@ -99,6 +105,9 @@ Primary languages: TypeScript, Python, Go.
 
 Preferences that never change between projects belong here; codebase-specific context belongs in `knowledge/me.md`.
 
+</TabItem>
+</Tabs>
+
 ## Cross-platform portability
 
 Because `me.md` is plain Markdown, it works on any platform that reads KMGraph. Claude Code, Gemini CLI, Cursor — they all load the same profile. You configure it once and every AI tool benefits.
@@ -117,6 +126,7 @@ CLAUDE.md               ← shim: "read knowledge/rules.md and me.md"
 One profile update. Every platform served.
 
 ```mermaid
+%%{init: { 'flowchart': { 'useMaxWidth': true }, 'theme': 'neutral' }}%%
 flowchart TB
     subgraph platforms ["Platform Config — thin shims"]
         direction LR
@@ -143,6 +153,8 @@ flowchart TB
     R -. project overrides .-> PR
     M -. project overrides .-> PM
 
+    accTitle: Platform shim pattern
+    accDescr: All platform config files point to two foundation files in knowledge/ — rules.md and me.md. Project scope overrides personal scope defaults in ~/.kmgraph/.
 ```
 
 ## Model tier configuration

--- a/docs/pillars/portability/your-ai-profile.mdx
+++ b/docs/pillars/portability/your-ai-profile.mdx
@@ -50,7 +50,7 @@ Behavioral rules ("always run tests before pushing") belong in `rules.md`, not `
 
 Your profile lives at `~/.kmgraph/me.md` (personal, cross-project) or `knowledge/me.md` (project-specific override, gitignored).
 
-Run `/kmgraph:init` to create the initial profile interactively, or edit the file directly.
+Run `/kmgraph:kmg-init` to create the initial profile interactively, or edit the file directly.
 
 For cross-project personal identity (rules and style that apply across all projects), run `/kmgraph:kmg-init-personal-kg`. It creates `~/.kmgraph/me.md`, `~/.kmgraph/rules.md`, and `~/.kmgraph/triggers.md`.
 

--- a/docs/pillars/portability/your-ai-profile.mdx
+++ b/docs/pillars/portability/your-ai-profile.mdx
@@ -1,11 +1,5 @@
 ---
 title: Your AI Profile
-category:
-  uri: portability
-position: 1
-slug: pillars-portability-your-ai-profile
-parent:
-  uri: pillars-portability-index
 ---
 
 

--- a/docs/pillars/recalling/index.md
+++ b/docs/pillars/recalling/index.md
@@ -1,9 +1,5 @@
 ---
 title: Recalling
-category:
-  uri: recalling
-position: 1
-slug: pillars-recalling-index
 ---
 
 # Recalling

--- a/docs/pillars/recalling/linking-entries.md
+++ b/docs/pillars/recalling/linking-entries.md
@@ -1,11 +1,5 @@
 ---
 title: Linking Entries
-category:
-  uri: recalling
-position: 3
-slug: pillars-recalling-linking-entries
-parent:
-  uri: pillars-recalling-index
 ---
 
 # Linking Entries

--- a/docs/pillars/recalling/search-the-graph.md
+++ b/docs/pillars/recalling/search-the-graph.md
@@ -1,11 +1,5 @@
 ---
 title: Search the Graph
-category:
-  uri: recalling
-position: 1
-slug: pillars-recalling-search-the-graph
-parent:
-  uri: pillars-recalling-index
 ---
 
 # Search the Graph

--- a/docs/pillars/recalling/session-memory.md
+++ b/docs/pillars/recalling/session-memory.md
@@ -1,11 +1,5 @@
 ---
 title: Session Memory
-category:
-  uri: recalling
-position: 2
-slug: pillars-recalling-session-memory
-parent:
-  uri: pillars-recalling-index
 ---
 
 # Session Memory

--- a/docs/pillars/tailoring/automation-layer.md
+++ b/docs/pillars/tailoring/automation-layer.md
@@ -1,11 +1,5 @@
 ---
 title: The Automation Layer
-category:
-  uri: tailoring
-position: 4
-slug: pillars-tailoring-automation-layer
-parent:
-  uri: pillars-tailoring-index
 ---
 
 # The Automation Layer

--- a/docs/pillars/tailoring/custom-rules.md
+++ b/docs/pillars/tailoring/custom-rules.md
@@ -1,11 +1,5 @@
 ---
 title: Custom Rules
-category:
-  uri: tailoring
-position: 3
-slug: pillars-tailoring-custom-rules
-parent:
-  uri: pillars-tailoring-index
 ---
 
 # Custom Rules

--- a/docs/pillars/tailoring/customize-hooks.md
+++ b/docs/pillars/tailoring/customize-hooks.md
@@ -1,11 +1,5 @@
 ---
 title: Customize Hooks
-category:
-  uri: tailoring
-position: 1
-slug: pillars-tailoring-customize-hooks
-parent:
-  uri: pillars-tailoring-index
 ---
 
 # Customize Hooks

--- a/docs/pillars/tailoring/customize-templates.md
+++ b/docs/pillars/tailoring/customize-templates.md
@@ -1,11 +1,5 @@
 ---
 title: Customize Templates
-category:
-  uri: tailoring
-position: 2
-slug: pillars-tailoring-customize-templates
-parent:
-  uri: pillars-tailoring-index
 ---
 
 # Customize Templates

--- a/docs/pillars/tailoring/docs-impact-scan.md
+++ b/docs/pillars/tailoring/docs-impact-scan.md
@@ -1,11 +1,5 @@
 ---
 title: Docs Impact Scan
-category:
-  uri: tailoring
-position: 5
-slug: pillars-tailoring-docs-impact-scan
-parent:
-  uri: pillars-tailoring-index
 ---
 
 # Docs Impact Scan

--- a/docs/pillars/tailoring/index.md
+++ b/docs/pillars/tailoring/index.md
@@ -1,9 +1,5 @@
 ---
 title: Tailoring
-category:
-  uri: tailoring
-position: 1
-slug: pillars-tailoring-index
 ---
 
 # Tailoring

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -1,11 +1,5 @@
 ---
 title: Quickstart
-category:
-  uri: overview
-position: 2
-slug: quickstart
-content:
-  excerpt: Install KMGraph, initialize a knowledge graph, and capture your first lesson — in under 5 minutes.
 ---
 
 # Quickstart

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -33,7 +33,7 @@ codex plugin marketplace add technomensch/knowledge-graph
 codex plugin add kmgraph@knowledge-management-graph
 ```
 
-Skills and MCP tools activate immediately. Run `/kmgraph:init` in a Codex session to initialize a knowledge graph.
+Skills and MCP tools activate immediately. Run `/kmgraph:kmg-init` in a Codex session to initialize a knowledge graph.
 
   </TabItem>
   <TabItem value="cursor" label="Cursor / Windsurf / VS Code">
@@ -77,7 +77,7 @@ plugin system.
 <img src={require('@site/static/img/demos/init.gif').default} alt="KMGraph init demo — wizard creates knowledge graph structure" />
 
 ```bash
-/kmgraph:init
+/kmgraph:kmg-init
 ```
 
 The wizard asks for:

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -1,6 +1,12 @@
 ---
+id: quickstart
 title: Quickstart
+sidebar_label: Quickstart (5 min)
+description: Install KMGraph and capture your first lesson in under 5 minutes
 ---
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
 
 # Quickstart
 
@@ -10,52 +16,68 @@ Install KMGraph, initialize a knowledge graph, and capture your first lesson —
 
 ## Step 1 — Install
 
-**Claude Code**
+<Tabs groupId="platform">
+  <TabItem value="claude-code" label="Claude Code" default>
 
 ```bash
 claude --plugin-dir /path/to/knowledge-graph
 ```
 
-Verify: type `/km` — autocomplete should show `kmgraph` commands.
+Verify the plugin loaded: type `/km` and the autocomplete menu should show `kmgraph` commands.
 
-**Codex CLI**
+  </TabItem>
+  <TabItem value="codex" label="Codex CLI">
 
 ```bash
 codex plugin marketplace add technomensch/knowledge-graph
 codex plugin add kmgraph@knowledge-management-graph
 ```
 
-Skills and MCP tools activate immediately. Run `/kmgraph:kmg-init` to initialize.
+Skills and MCP tools activate immediately. Run `/kmgraph:init` in a Codex session to initialize a knowledge graph.
 
-**Cursor / Windsurf / VS Code**
+  </TabItem>
+  <TabItem value="cursor" label="Cursor / Windsurf / VS Code">
 
-Paste the contents of [INSTALL.md](install) into your AI assistant. The installer detects the platform, configures the MCP server, and initializes the knowledge graph automatically.
+Paste the contents of [INSTALL.md](INSTALL.md) into your AI assistant. The installer detects the platform, configures the MCP server, and initializes the knowledge graph automatically.
 
 Requires an assistant with terminal and file system access.
 
-**Generic MCP**
+  </TabItem>
+  <TabItem value="mcp" label="Generic MCP">
 
 ```bash
+# Build the MCP server
 cd mcp-server && npm install && npm run build
-# Register in your IDE's MCP config — point to: mcp-server/dist/index.js
+
+# Register in your IDE's MCP config
+# Point to: mcp-server/dist/index.js
 ```
 
-See [Platform Adaptation](reference-platform-adaptation) for IDE-specific registration steps.
+See [Platform Adaptation](/reference/PLATFORM-ADAPTATION) for IDE-specific registration steps.
 
-**Any platform (manual)**
+  </TabItem>
+  <TabItem value="manual" label="Any platform (manual)">
 
-Copy `core/default-templates/` into your project. Follow the template READMEs to manually create lessons, ADRs, and session summaries without automation.
+Copy `core/default-templates/` into your project. Follow the template READMEs to manually create lessons, ADRs, and session summaries without any automation.
 
-> 🚧 **Do not copy `commands/`, `skills/`, or `agents/`**
->
-> These directories are Claude Code plugin-specific and will not function outside the Claude Code plugin system.
+:::warning[Do not copy `commands/`, `skills/`, or `agents/`]
+
+These directories are Claude Code plugin-specific and will not function outside the Claude Code
+plugin system.
+
+:::
+
+  </TabItem>
+</Tabs>
 
 ---
 
 ## Step 2 — Initialize
 
+<img src={require('@site/static/img/demos/init.gif').default} alt="KMGraph init demo — wizard creates knowledge graph structure" />
+
 ```bash
-/kmgraph:kmg-init
+/kmgraph:init
 ```
 
 The wizard asks for:
@@ -63,11 +85,13 @@ The wizard asks for:
 - **Git tracking** — enable for automatic branch/commit metadata on every capture
 - **KG type** — `project-local` (default) stores in the project; `personal` stores at `~/.kmgraph/` and is shared across all projects
 
-Init also scaffolds `knowledge/me.md` (your identity and working style, gitignored) and `knowledge/rules.md` (project conventions, committed). These give any AI platform consistent context without platform-specific rewrites.
+Init also scaffolds `knowledge/me.md` (your identity and working style, gitignored) and `knowledge/rules.md` (project conventions, committed). These give any AI platform consistent context without platform-specific rewrites. See [Your AI Profile](pillars/portability/your-ai-profile.mdx).
 
 ---
 
-## Step 3 — Capture Your First Lesson
+## Step 3 — Capture your first lesson
+
+<img src={require('@site/static/img/demos/capture-lesson.gif').default} alt="KMGraph capture-lesson demo — structured lesson saved with git metadata" />
 
 ```bash
 /kmgraph:kmg-capture-lesson
@@ -77,7 +101,9 @@ Describe what you just learned or solved. The command structures it into a markd
 
 ---
 
-## Step 4 — Recall It
+## Step 4 — Recall it
+
+<img src={require('@site/static/img/demos/recall.gif').default} alt="KMGraph recall demo — full-text search returns matching lessons" />
 
 ```bash
 /kmgraph:kmg-recall "what you captured"
@@ -87,23 +113,29 @@ Full-text search across all captured lessons, decisions, and patterns.
 
 ---
 
-## Step 5 — Check Status
+## Step 5 — Check status
+
+<img src={require('@site/static/img/demos/status.gif').default} alt="KMGraph status demo — shows entry counts and last capture time" />
 
 ```bash
-/kmgraph:kmg-status
+/kmgraph:status
 ```
 
 Shows the active knowledge graph, entry count, and recent captures.
 
 ---
 
-## The Capture Pipeline
+## The capture pipeline
 
 ```mermaid
+%%{init: { 'flowchart': { 'useMaxWidth': true }, 'theme': 'neutral' }}%%
 graph LR
-    A["Capture\n/kmgraph:kmg-capture-lesson"] --> B["Extract\n/kmgraph:kmg-update-graph"]
-    B --> C["Sync\n/kmgraph:kmg-sync-all"]
-    C --> D["Summarize\n/kmgraph:kmg-session-summary"]
+    A["📝 Capture<br/>/kmgraph:kmg-capture-lesson"] --> B["📊 Extract<br/>/kmgraph:kmg-update-graph"]
+    B --> C["🔄 Sync<br/>/kmgraph:kmg-sync-all"]
+    C --> D["💾 Summarize<br/>/kmgraph:kmg-session-summary"]
+
+    accTitle: Knowledge Capture Pipeline
+    accDescr: Four-step workflow: Capture lessons feeds into Extract patterns, which feeds into Sync across graphs, which feeds into Summarize session.
 ```
 
 Use `/kmgraph:kmg-sync-all` at the end of a session to run all four steps in one command.
@@ -114,14 +146,18 @@ Use `/kmgraph:kmg-sync-all` at the end of a session to run all four steps in one
 
 ### Stale Plugin Cache
 
-**Claude Code**
+If you see outdated commands or features, the plugin cache may be stale. Clear it and reinstall:
+
+<Tabs groupId="platform">
+  <TabItem value="claude-code" label="Claude Code">
 
 ```bash
 rm -rf ~/.claude/plugins/cache/stayinginsync-knowledge-graph/kmgraph/
 /reload-plugins
 ```
 
-**Codex CLI**
+  </TabItem>
+  <TabItem value="codex" label="Codex CLI">
 
 ```bash
 rm -rf ~/.codex/plugins/cache/knowledge-management-graph/kmgraph/
@@ -130,11 +166,14 @@ codex plugin marketplace add technomensch/knowledge-graph
 codex plugin add kmgraph@knowledge-management-graph
 ```
 
+  </TabItem>
+</Tabs>
+
 ---
 
 ## Related
 
-- **[Capturing](pillars-capturing-capture-lessons-learned)** — Save a lesson, ADR, or pattern from your current session
-- **[Command Guide](reference-command-guide)** — Complete command reference with examples and learning path
-- **[Concepts](concepts-why-kmgraph)** — How the knowledge graph is structured and why
-- **[Cheat Sheet](cheat-sheet)** — All commands at a glance
+- **[Capturing](pillars/capturing/capture-lessons-learned)** — Save a lesson, ADR, or pattern from your current session
+- **[Command Guide](reference/command-guide)** — Complete command reference with examples and learning path
+- **[Concepts](concepts/why-kmgraph)** — How the knowledge graph is structured and why
+- **[Cheat Sheet](CHEAT-SHEET)** — All commands at a glance

--- a/docs/reference/ARCHITECTURE.md
+++ b/docs/reference/ARCHITECTURE.md
@@ -1,9 +1,5 @@
 ---
 title: Architecture
-category:
-  uri: reference
-position: 7
-slug: reference-architecture
 ---
 
 # Knowledge Graph Architecture

--- a/docs/reference/PLATFORM-ADAPTATION.md
+++ b/docs/reference/PLATFORM-ADAPTATION.md
@@ -1,9 +1,5 @@
 ---
 title: Platform Adaptation
-category:
-  uri: reference
-position: 8
-slug: reference-platform-adaptation
 ---
 
 # Platform Adaptation Guide

--- a/docs/reference/SANITIZATION-CHECKLIST.md
+++ b/docs/reference/SANITIZATION-CHECKLIST.md
@@ -1,9 +1,5 @@
 ---
 title: Sanitization Checklist
-category:
-  uri: reference
-position: 10
-slug: reference-sanitization-checklist
 ---
 
 # Sanitization Checklist

--- a/docs/reference/agents.md
+++ b/docs/reference/agents.md
@@ -1,9 +1,5 @@
 ---
 title: Agents Catalog
-category:
-  uri: reference
-position: 4
-slug: reference-agents
 ---
 
 # Agents Catalog

--- a/docs/reference/command-guide.md
+++ b/docs/reference/command-guide.md
@@ -1,9 +1,5 @@
 ---
 title: Command Guide
-category:
-  uri: reference
-position: 1
-slug: reference-command-guide
 ---
 
 **Version:** 0.5.2 | **Updated:** 2026-04-22

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -1,9 +1,5 @@
 ---
 title: Commands Reference
-category:
-  uri: reference
-position: 2
-slug: reference-commands
 ---
 
 **Version:** 0.5.10.5 | All commands use the `/kmgraph:` prefix in Claude Code. Other platforms access equivalent functionality through `kg_*` MCP tools — see [INSTALL.md](../INSTALL.md) for details.

--- a/docs/reference/hooks.md
+++ b/docs/reference/hooks.md
@@ -1,9 +1,5 @@
 ---
 title: Hooks Reference
-category:
-  uri: reference
-position: 3
-slug: reference-hooks
 ---
 
 # Hooks Reference

--- a/docs/reference/skills.md
+++ b/docs/reference/skills.md
@@ -1,9 +1,5 @@
 ---
 title: Skills Catalog
-category:
-  uri: reference
-position: 5
-slug: reference-skills
 ---
 
 # Skills Catalog

--- a/docs/reference/templates.md
+++ b/docs/reference/templates.md
@@ -1,9 +1,5 @@
 ---
 title: Templates Reference
-category:
-  uri: reference
-position: 6
-slug: reference-templates
 ---
 
 # Templates Reference

--- a/docs/reference/tier-resolver.md
+++ b/docs/reference/tier-resolver.md
@@ -1,9 +1,5 @@
 ---
 title: Model Tier Resolver
-category:
-  uri: reference
-position: 9
-slug: reference-tier-resolver
 ---
 
 # Model Tier Resolver

--- a/docs/templates/AGENTS-template.md
+++ b/docs/templates/AGENTS-template.md
@@ -1,8 +1,5 @@
 ---
 title: Agents Template
-category:
-  uri: templates
-slug: templates-agents-template
 ---
 
 # Agent Template

--- a/docs/templates/MEMORY-template.md
+++ b/docs/templates/MEMORY-template.md
@@ -1,8 +1,5 @@
 ---
 title: Memory Template
-category:
-  uri: templates
-slug: templates-memory-template
 ---
 
 # Project Memory - [Project Name]

--- a/docs/templates/README.md
+++ b/docs/templates/README.md
@@ -1,8 +1,5 @@
 ---
 title: Readme
-category:
-  uri: templates
-slug: templates-readme
 ---
 
 # Templates — Source Directory

--- a/docs/templates/decisions/ADR-template.md
+++ b/docs/templates/decisions/ADR-template.md
@@ -1,8 +1,5 @@
 ---
 title: 'ADR-XXX: [Title of Decision]'
-category:
-  uri: templates
-slug: templates-decisions-adr-template
 ---
 
 # ADR-XXX: [Title of Decision]

--- a/docs/templates/decisions/README.md
+++ b/docs/templates/decisions/README.md
@@ -1,8 +1,5 @@
 ---
 title: Readme
-category:
-  uri: templates
-slug: templates-decisions-readme
 ---
 
 # Architecture Decision Records (ADRs)

--- a/docs/templates/documentation/doc-template.md
+++ b/docs/templates/documentation/doc-template.md
@@ -1,9 +1,6 @@
 ---
 title: '[Document Title]'
 type: '[guide | concept | tutorial | explanation | reference | faq | custom]'
-category:
-  uri: templates
-slug: templates-documentation-doc-template
 ---
 
 # [Document Title]

--- a/docs/templates/knowledge/architecture.md
+++ b/docs/templates/knowledge/architecture.md
@@ -1,8 +1,5 @@
 ---
 title: Architecture
-category:
-  uri: templates
-slug: templates-knowledge-architecture
 ---
 
 # Knowledge Graph - Architecture

--- a/docs/templates/knowledge/concepts.md
+++ b/docs/templates/knowledge/concepts.md
@@ -1,8 +1,5 @@
 ---
 title: Concepts
-category:
-  uri: templates
-slug: templates-knowledge-concepts
 ---
 
 # Knowledge Graph - Concepts

--- a/docs/templates/knowledge/entry-template.md
+++ b/docs/templates/knowledge/entry-template.md
@@ -1,8 +1,5 @@
 ---
 title: Entry Template
-category:
-  uri: templates
-slug: templates-knowledge-entry-template
 ---
 
 <!--

--- a/docs/templates/knowledge/gotchas.md
+++ b/docs/templates/knowledge/gotchas.md
@@ -1,8 +1,5 @@
 ---
 title: Gotchas
-category:
-  uri: templates
-slug: templates-knowledge-gotchas
 ---
 
 # Knowledge Graph - Gotchas

--- a/docs/templates/knowledge/index.md
+++ b/docs/templates/knowledge/index.md
@@ -1,8 +1,5 @@
 ---
 title: Index
-category:
-  uri: templates
-slug: templates-knowledge-index
 ---
 
 # Knowledge Graph - Master Index

--- a/docs/templates/knowledge/patterns.md
+++ b/docs/templates/knowledge/patterns.md
@@ -1,8 +1,5 @@
 ---
 title: Patterns
-category:
-  uri: templates
-slug: templates-knowledge-patterns
 ---
 
 # Knowledge Graph - Patterns

--- a/docs/templates/knowledge/workflows.md
+++ b/docs/templates/knowledge/workflows.md
@@ -1,8 +1,5 @@
 ---
 title: Workflows
-category:
-  uri: templates
-slug: templates-knowledge-workflows
 ---
 
 # Knowledge Graph - Workflows

--- a/docs/templates/lessons-learned/README.md
+++ b/docs/templates/lessons-learned/README.md
@@ -1,8 +1,5 @@
 ---
 title: Readme
-category:
-  uri: templates
-slug: templates-lessons-learned-readme
 ---
 
 # Lessons Learned - Master Index

--- a/docs/templates/lessons-learned/lesson-template.md
+++ b/docs/templates/lessons-learned/lesson-template.md
@@ -1,8 +1,5 @@
 ---
 title: 'Lesson: [Title]'
-category:
-  uri: templates
-slug: templates-lessons-learned-lesson-template
 ---
 
 # Lesson Learned: [Title]

--- a/docs/templates/meta-issue/README.md
+++ b/docs/templates/meta-issue/README.md
@@ -1,8 +1,5 @@
 ---
 title: Readme
-category:
-  uri: templates
-slug: templates-meta-issue-readme
 ---
 
 # Meta-Issue: [Problem Title]

--- a/docs/templates/meta-issue/analysis/lessons-learned.md
+++ b/docs/templates/meta-issue/analysis/lessons-learned.md
@@ -1,8 +1,5 @@
 ---
 title: Lessons Learned
-category:
-  uri: templates
-slug: templates-meta-issue-analysis-lessons-learned
 ---
 
 # Lessons Learned (Meta-Issue)

--- a/docs/templates/meta-issue/analysis/root-cause-evolution.md
+++ b/docs/templates/meta-issue/analysis/root-cause-evolution.md
@@ -1,8 +1,5 @@
 ---
 title: Root Cause Evolution
-category:
-  uri: templates
-slug: templates-meta-issue-analysis-root-cause-evolution
 ---
 
 # Root Cause Evolution

--- a/docs/templates/meta-issue/analysis/timeline.md
+++ b/docs/templates/meta-issue/analysis/timeline.md
@@ -1,8 +1,5 @@
 ---
 title: Timeline
-category:
-  uri: templates
-slug: templates-meta-issue-analysis-timeline
 ---
 
 # Timeline

--- a/docs/templates/meta-issue/attempt-template/attempt-results.md
+++ b/docs/templates/meta-issue/attempt-template/attempt-results.md
@@ -1,8 +1,5 @@
 ---
 title: Attempt Results
-category:
-  uri: templates
-slug: templates-meta-issue-attempt-template-attempt-results
 ---
 
 # Attempt NNN: Results

--- a/docs/templates/meta-issue/attempt-template/plan-reference.md
+++ b/docs/templates/meta-issue/attempt-template/plan-reference.md
@@ -1,8 +1,5 @@
 ---
 title: Plan Reference
-category:
-  uri: templates
-slug: templates-meta-issue-attempt-template-plan-reference
 ---
 
 # Attempt NNN: Plan Reference

--- a/docs/templates/meta-issue/attempt-template/solution-approach.md
+++ b/docs/templates/meta-issue/attempt-template/solution-approach.md
@@ -1,8 +1,5 @@
 ---
 title: Solution Approach
-category:
-  uri: templates
-slug: templates-meta-issue-attempt-template-solution-approach
 ---
 
 # Attempt NNN: [Approach Name]

--- a/docs/templates/meta-issue/description.md
+++ b/docs/templates/meta-issue/description.md
@@ -1,8 +1,5 @@
 ---
 title: Description
-category:
-  uri: templates
-slug: templates-meta-issue-description
 ---
 
 # Problem Description (Living Document)

--- a/docs/templates/meta-issue/implementation-log.md
+++ b/docs/templates/meta-issue/implementation-log.md
@@ -1,8 +1,5 @@
 ---
 title: Implementation Log
-category:
-  uri: templates
-slug: templates-meta-issue-implementation-log
 ---
 
 # Implementation Log

--- a/docs/templates/meta-issue/related-issues/github-links.md
+++ b/docs/templates/meta-issue/related-issues/github-links.md
@@ -1,8 +1,5 @@
 ---
 title: Github Links
-category:
-  uri: templates
-slug: templates-meta-issue-related-issues-github-links
 ---
 
 # Related GitHub Issues

--- a/docs/templates/meta-issue/test-cases.md
+++ b/docs/templates/meta-issue/test-cases.md
@@ -1,8 +1,5 @@
 ---
 title: Test Cases
-category:
-  uri: templates
-slug: templates-meta-issue-test-cases
 ---
 
 # Test Cases & Validation

--- a/docs/templates/sessions/session-template.md
+++ b/docs/templates/sessions/session-template.md
@@ -1,8 +1,5 @@
 ---
 title: Session Template
-category:
-  uri: templates
-slug: templates-sessions-session-template
 ---
 
 <!--

--- a/docs/troubleshooting/index.md
+++ b/docs/troubleshooting/index.md
@@ -1,9 +1,5 @@
 ---
 title: Troubleshooting
-category:
-  uri: troubleshooting
-position: 1
-slug: troubleshooting-index
 ---
 
 # Troubleshooting


### PR DESCRIPTION
## Summary

- Strips readme.com-specific frontmatter (`category/uri`, `parent/uri`, `position:`, `content/excerpt:`, path-based `slug:`) from all 106 docs files injected by commits `170a9657` and `20ab1503`
- Preserves `slug: /` on `docs/index.mdx` (homepage)
- Surgically restores Tabs/TabItem JSX in `use-in-cursor.mdx`, `your-ai-profile.mdx`, and `quickstart.mdx`; restores `init.gif` demo image and `:::warning` admonition in quickstart
- Fixes pillar links in `index.mdx` from readme.com flat slugs to correct Docusaurus paths
- Restores `hide_table_of_contents`/`displayed_sidebar` frontmatter in `CHANGELOG.md`
- Fixes 3 occurrences of `/kmgraph:init` → `/kmgraph:kmg-init` (caught by Opus review)

## Root cause

Two commits bulk-modified the entire docs tree for a readme.com upload never applicable to this Docusaurus repo. Every page was served at wrong flat URLs (e.g. `/pillars-capturing-index` instead of `/pillars/capturing/`) and the homepage returned 404.

## Test plan

- [x] `npm run build` passes — no new errors
- [x] Homepage `slug: /` preserved
- [x] Opus review clean
- [x] 106 files stripped, 5 files surgically restored

🤖 Generated with [Claude Code](https://claude.ai/code)