### PR TITLE
fix(docs): restore broken /CONCEPTS and /COMMAND-GUIDE nav links (v0.6.13)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "kmgraph",
-  "version": "0.6.12",
+  "version": "0.6.13",
   "description": "Structured knowledge capture, lesson-learned documentation, and cross-session memory for Claude Code projects. Includes KG entries, ADRs, meta-issue tracking, chat extraction, and profile-file rule capture.",
   "author": {
     "name": "technomensch",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ displayed_sidebar: null
 
 All notable changes to the Knowledge Plugin will be documented in this file.
 
+## [0.6.13] — 2026-06-25
+
+### Fixed
+
+- **Broken navbar/footer links** — `/CONCEPTS` and `/COMMAND-GUIDE` have been 404 since `CONCEPTS.md` was deleted (`1897d5a1`) and `COMMAND-GUIDE.md` was moved to `docs/reference/command-guide.md` (`192590c2`). No fix pass updated `docusaurus.config.js`. Repaired by creating `docs/concepts/index.md` (new concepts landing page) and repointing both nav items. Also fixed 7 stale file-level references to the old paths in template docs.
+
 ## [0.6.12] — 2026-06-25
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Structured knowledge capture, lesson-learned documentation, and cross-session memory for Claude Code projects.
 
-**Version:** 0.6.12
+**Version:** 0.6.13
 **Status:** Actively developed and in daily use
 
 Documentation: https://kmgraph.stayinginsync.info

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -416,7 +416,7 @@ Quality > Quantity. 5 valuable lessons > 50 routine entries.
 
   Installation and setup walkthrough
 
-- [Command Reference](COMMAND-GUIDE.md)
+- [Command Reference](reference/command-guide.md)
 
   All commands with detailed examples
 
@@ -426,7 +426,7 @@ Quality > Quantity. 5 valuable lessons > 50 routine entries.
 
 ### **Learning**
 
-- [Concepts Guide](CONCEPTS.md)
+- [Concepts Guide](concepts/index.md)
 
   Plain-English definitions of all terms and patterns
 

--- a/docs/concepts/index.md
+++ b/docs/concepts/index.md
@@ -1,0 +1,15 @@
+---
+title: Concepts
+slug: /concepts/
+---
+
+# Concepts
+
+Core ideas behind KMGraph — what it is, how it's organized, and why it works the way it does.
+
+## In This Section
+
+- **[What Is a Knowledge Graph](what-is-a-knowledge-graph)** — The core idea: a local, searchable repo of everything you've learned.
+- **[Four Content Types](four-content-types)** — Lessons, decisions, patterns, and concepts — what goes where and why.
+- **[How KMGraph Is Organized](how-kmgraph-is-organized)** — Directory structure, naming conventions, and the graph model.
+- **[Why KMGraph](why-kmgraph)** — The problem it solves: AI amnesia across sessions, tools, and team members.

--- a/docs/templates/decisions/README.md
+++ b/docs/templates/decisions/README.md
@@ -112,7 +112,7 @@ ADRs follow a lightweight format:
 ## Learn More
 
 **Concepts & Guides**:
-- [Concepts Guide](../../CONCEPTS.md#adr-architecture-decision-record) - Term explanations
+- [Concepts Guide](../../concepts/index.md) - Term explanations
 - [ADR template](ADR-template.md) - Starting scaffold
 
 **Resources**:

--- a/docs/templates/documentation/doc-template.md
+++ b/docs/templates/documentation/doc-template.md
@@ -78,8 +78,8 @@ Description of what the example demonstrates.
 - [Installation Guide](../../GETTING-STARTED.md) — First-time setup
 
 **Reference**:
-- [Command Reference](../../COMMAND-GUIDE.md) — All commands with examples
-- [Concepts Guide](../../CONCEPTS.md) — Plain-English term explanations
+- [Command Reference](../../reference/command-guide.md) — All commands with examples
+- [Concepts Guide](../../concepts/index.md) — Plain-English term explanations
 
 **Guides**:
 - [Pattern Writing](../../PATTERNS-GUIDE.md) — Writing effective entries

--- a/docs/templates/lessons-learned/README.md
+++ b/docs/templates/lessons-learned/README.md
@@ -124,7 +124,7 @@ See [core/examples/lessons-learned/](../../examples/lessons-learned/) for filled
 ## Learn More
 
 **Understanding fields**:
-- [Concepts Guide](../../CONCEPTS.md#yaml-frontmatter) - YAML field explanations
+- [Concepts Guide](../../concepts/index.md) - YAML field explanations
 - [lesson-template.md](lesson-template.md) - See inline field comments
 
 **See examples**:
@@ -133,4 +133,4 @@ See [core/examples/lessons-learned/](../../examples/lessons-learned/) for filled
 
 **How to capture**:
 - [Manual Workflow](../../WORKFLOWS.md#workflow-1-create-lesson-learned) - Step-by-step
-- [Command Guide](../../COMMAND-GUIDE.md#essential-commands) - Automated (Claude Code)
+- [Command Guide](../../reference/command-guide.md) - Automated (Claude Code)

--- a/docs/templates/meta-issue/README.md
+++ b/docs/templates/meta-issue/README.md
@@ -75,7 +75,7 @@ title: Readme
 ## Learn More
 
 **Concepts & Guides**:
-- [Concepts Guide](../../CONCEPTS.md#meta-issue) - Term explanations
+- [Concepts Guide](../../concepts/index.md) - Term explanations
 - [META-ISSUE-GUIDE.md](../../META-ISSUE-GUIDE.md) - Full meta-issue guide
 
 **Resources**:

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -104,8 +104,8 @@ const config = {
         },
         items: [
           {to: '/quickstart', label: 'Getting Started', position: 'left'},
-          {to: '/CONCEPTS', label: 'Concepts', position: 'left'},
-          {to: '/COMMAND-GUIDE', label: 'Commands', position: 'left'},
+          {to: '/concepts/', label: 'Concepts', position: 'left'},
+          {to: '/reference/command-guide', label: 'Commands', position: 'left'},
           {to: '/CONFIGURATION', label: 'Configuration', position: 'left'},
           {
             href: 'https://github.com/technomensch/knowledge-graph',
@@ -134,7 +134,7 @@ const config = {
             title: 'Docs',
             items: [
               {label: 'Getting Started', to: '/quickstart'},
-              {label: 'Command Guide', to: '/COMMAND-GUIDE'},
+              {label: 'Command Guide', to: '/reference/command-guide'},
               {label: 'Cheat Sheet', to: '/CHEAT-SHEET'},
               {label: 'FAQ', to: '/FAQ'},
             ],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "knowledge-graph-plugin",
-  "version": "0.6.12",
+  "version": "0.6.13",
   "description": "Structured knowledge capture and cross-session memory for Claude Code projects.",
   "files": [
     ".claude-plugin/",


### PR DESCRIPTION
## Summary

- **`/CONCEPTS` 404** — `CONCEPTS.md` was deleted in `1897d5a1` and replaced with `docs/concepts/` directory, but no `index.md` was created and the navbar was never updated. Created `docs/concepts/index.md` as a landing page; repointed navbar from `/CONCEPTS` → `/concepts/`.
- **`/COMMAND-GUIDE` 404** — `COMMAND-GUIDE.md` was moved to `docs/reference/command-guide.md` in `192590c2` but navbar/footer still pointed at the old path. Repointed both to `/reference/command-guide`.
- **7 stale file references** fixed in `docs/CONFIGURATION.md` and `docs/templates/` pointing to the old `COMMAND-GUIDE.md` and `CONCEPTS.md` paths.

Both regressions were pre-existing and survived all prior fix passes because every pass focused on page content, not `docusaurus.config.js`.

## Test plan

- [x] `npm run build` — zero broken links for `/COMMAND-GUIDE` or `/CONCEPTS`
- [x] `/concepts/` resolves to new landing page
- [x] `/reference/command-guide` resolves correctly
- [x] Only expected files changed: `docusaurus.config.js`, `docs/concepts/index.md`, `docs/CONFIGURATION.md`, `docs/templates/*/README.md`, `docs/templates/documentation/doc-template.md`, `CHANGELOG.md`, `README.md`, `package.json`, `plugin.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)