### PR TITLE
fix(search): add concepts/ to FTS5 and grep search dirs (v0.6.14)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "kmgraph",
-  "version": "0.6.13",
+  "version": "0.6.14",
   "description": "Structured knowledge capture, lesson-learned documentation, and cross-session memory for Claude Code projects. Includes KG entries, ADRs, meta-issue tracking, chat extraction, and profile-file rule capture.",
   "author": {
     "name": "technomensch",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "kmgraph",
-  "version": "0.6.10",
+  "version": "0.6.14",
   "description": "Structured knowledge capture, lesson-learned documentation, and cross-session memory for Claude Code projects. Includes KG entries, ADRs, meta-issue tracking, chat extraction, and profile-file rule capture.",
   "author": {
     "name": "technomensch",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ displayed_sidebar: null
 
 All notable changes to the Knowledge Plugin will be documented in this file.
 
+## [0.6.14] — 2026-06-28
+
+### Fixed
+
+- **FTS5 and grep search miss `concepts/` directory** — `searchDirs` in `fts5.ts` and `search.ts` hardcoded a fixed list of subdirectories that did not include `concepts/`, added to the scaffold in v0.6.13. All files under `concepts/` were invisible to `kg_fts5_rebuild` and `/kmgraph:kmg-recall`. Fixed by indexing `concepts/` from `kgPath` directly (not `contentRoot`) so it works correctly on both flat and v0.2+ docs-layout KGs. Also aligned the grep fallback list in `search.ts` to mirror the FTS5 scanner (added `chat-history`).
+
 ## [0.6.13] — 2026-06-25
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Structured knowledge capture, lesson-learned documentation, and cross-session memory for Claude Code projects.
 
-**Version:** 0.6.13
+**Version:** 0.6.14
 **Status:** Actively developed and in daily use
 
 Documentation: https://kmgraph.stayinginsync.info

--- a/mcp-server/dist/cli.js
+++ b/mcp-server/dist/cli.js
@@ -31840,7 +31840,7 @@ function searchKg(kgPath, kgName, kgType, query) {
   }
   if (!usingFts5) {
     results = [];
-    const searchDirs = ["knowledge", "lessons-learned", "decisions", "sessions"];
+    const searchDirs = ["knowledge", "concepts", "lessons-learned", "decisions", "sessions"];
     for (const dir of searchDirs) {
       const dirPath = path4.join(kgPath, dir);
       const files = walkDir(dirPath, ".md");

--- a/mcp-server/dist/index.js
+++ b/mcp-server/dist/index.js
@@ -30776,7 +30776,7 @@ function rebuildIndex(kgPath, kgName, kgType = "project-local") {
   try {
     initDb(db);
     const contentRoot = resolveContentRoot(kgPath);
-    const searchDirs = ["knowledge", "lessons-learned", "decisions", "sessions", "chat-history"];
+    const searchDirs = ["knowledge", "concepts", "lessons-learned", "decisions", "sessions", "chat-history"];
     const allFiles = [];
     for (const dir of searchDirs) {
       const dirPath = path3.join(contentRoot, dir);
@@ -31026,7 +31026,7 @@ function searchKg(kgPath, kgName, kgType, query) {
   }
   if (!usingFts5) {
     results = [];
-    const searchDirs = ["knowledge", "lessons-learned", "decisions", "sessions"];
+    const searchDirs = ["knowledge", "concepts", "lessons-learned", "decisions", "sessions"];
     for (const dir of searchDirs) {
       const dirPath = path4.join(kgPath, dir);
       const files = walkDir(dirPath, ".md");

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@knowledge-graph-plugin/mcp-server",
-  "version": "0.6.10",
+  "version": "0.6.14",
   "description": "MCP server for Knowledge Management Graph — cross-platform data layer for knowledge capture, search, and management",
   "main": "dist/index.js",
   "bin": {

--- a/mcp-server/src/tools/fts5.ts
+++ b/mcp-server/src/tools/fts5.ts
@@ -319,13 +319,15 @@ export function rebuildIndex(kgPath: string, kgName: string, kgType = "project-l
     const contentRoot = resolveContentRoot(kgPath);
 
     // Collect all .md files from target subdirectories
-    const searchDirs = ["knowledge", "lessons-learned", "decisions", "sessions", "chat-history"];
+    // concepts/ is always top-level (kgPath), even on v0.2+ docs-layout KGs
+    const contentDirs = ["knowledge", "lessons-learned", "decisions", "sessions", "chat-history"];
     const allFiles: string[] = [];
 
-    for (const dir of searchDirs) {
+    for (const dir of contentDirs) {
       const dirPath = path.join(contentRoot, dir);
       allFiles.push(...walkDir(dirPath, ".md"));
     }
+    allFiles.push(...walkDir(path.join(kgPath, "concepts"), ".md"));
 
     let indexed = 0;
     let skipped = 0;

--- a/mcp-server/src/tools/search.ts
+++ b/mcp-server/src/tools/search.ts
@@ -83,7 +83,7 @@ function searchKg(
 
   if (!usingFts5) {
     results = [];
-    const searchDirs = ["knowledge", "lessons-learned", "decisions", "sessions"];
+    const searchDirs = ["knowledge", "concepts", "lessons-learned", "decisions", "sessions", "chat-history"];
 
     for (const dir of searchDirs) {
       const dirPath = path.join(kgPath, dir);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "knowledge-graph-plugin",
-  "version": "0.6.13",
+  "version": "0.6.14",
   "description": "Structured knowledge capture and cross-session memory for Claude Code projects.",
   "files": [
     ".claude-plugin/",


### PR DESCRIPTION
## Summary

- `concepts/` was added to the KG scaffold in v0.6.13 but omitted from the hardcoded `searchDirs` in both `fts5.ts` and `search.ts`, making all concept files invisible to `kg_fts5_rebuild` and `/kmgraph:kmg-recall`
- Fixed `fts5.ts` to index `concepts/` from `kgPath` directly (not `contentRoot`) — required because `concepts/` is always top-level even on v0.2+ docs-layout KGs where `contentRoot` resolves to `kgPath/docs/`
- Fixed `search.ts` grep fallback to also include `concepts/` and `chat-history/` (the latter was missing vs the FTS5 list — pre-existing drift)

## Test plan

- [ ] Run `kg_fts5_rebuild` on a KG with files in `concepts/` — confirm indexed count > 0
- [ ] Run `/kmgraph:kmg-recall` with a term that exists only in `concepts/` — confirm result returned
- [ ] Run on a v0.2+ docs-layout KG — confirm `concepts/` indexed correctly (not looking in `docs/concepts/`)
- [ ] Verify `chat-history/` still indexed via FTS5 path

Closes #156

🤖 Generated with [Claude Code](https://claude.com/claude-code)