### PR TITLE
fix(init): init completeness + extractor gate fix (v0.6.15)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "kmgraph",
-  "version": "0.6.14",
+  "version": "0.6.15",
   "description": "Structured knowledge capture, lesson-learned documentation, and cross-session memory for Claude Code projects. Includes KG entries, ADRs, meta-issue tracking, chat extraction, and profile-file rule capture.",
   "author": {
     "name": "technomensch",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "kmgraph",
-  "version": "0.6.14",
+  "version": "0.6.15",
   "description": "Structured knowledge capture, lesson-learned documentation, and cross-session memory for Claude Code projects. Includes KG entries, ADRs, meta-issue tracking, chat extraction, and profile-file rule capture.",
   "author": {
     "name": "technomensch",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ displayed_sidebar: null
 
 All notable changes to the Knowledge Plugin will be documented in this file.
 
+## [0.6.15] — 2026-07-02
+
+### Fixed
+
+- **Init directory scaffold** — Fresh init now creates `concepts/` and `templates/` instead of legacy `knowledge/` subdirectory. `knowledge/knowledge/` no longer created on `knowledge/`-rooted KGs. `kg-category-index.md` deployed to `concepts/`; all content and starter templates deployed to `templates/`. Fixes ENH-031 Bug 2 + 4.
+- **`triggers.md` scaffolded on init** — `kmg-directory-scaffold` now creates `triggers.md` with a `[ ! -f ]` idempotency guard. Fixes ENH-031 Bug 4.
+- **Step 1.10 backfill source detection** — Backfill offer no longer gated on CLAUDE.md presence. Source detection now uses if/elif precedence (`knowledge/chat-history` vs `chat-history`, `knowledge/plans` vs `plans`) and standalone checks for `research/`, `specs/`, `README.md`, `CHANGELOG.md`. Matched paths passed as array to extractor. Fixes ENH-031 Bug 1.
+- **CLAUDE.md creation offer** — When no CLAUDE.md exists at project root, init offers to create one with KMGraph platform preferences. Standalone `if [ ! -f ]` guard; gated on real user input (default Y); existing CLAUDE.md never touched. Fixes ENH-031 Bug 3.
+- **Extractor approval gate scoped to init-backfill mode** — `knowledge-extractor` in init-backfill mode extracts candidates and returns them to coordinator without writing or waiting for approval. Update-graph mode retains full write pipeline. Fixes ENH-032.
+
+### Changed
+
+- **Concepts removed from top navbar** — Concepts is accessible via sidebar only. Top navbar: Getting Started, Commands, Configuration, GitHub, LinkedIn.
+
+### Docs
+
+- **Backfill troubleshooting guide** — New `## Troubleshooting` section in `docs/pillars/organizing/backfill.md` covers manual backfill recovery for all platforms (skipped init, no candidates found, mid-run failure).
+
 ## [0.6.14] — 2026-06-28
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Structured knowledge capture, lesson-learned documentation, and cross-session memory for Claude Code projects.
 
-**Version:** 0.6.14
+**Version:** 0.6.15
 **Status:** Actively developed and in daily use
 
 Documentation: https://kmgraph.stayinginsync.info
@@ -90,6 +90,15 @@ Pull the latest version and run `/kmgraph:kmg-init` in any project that uses it.
 ---
 
 ## v0.6.x Feature Highlights
+
+**v0.6.15 — 2026-07-02**
+
+- **Init completeness fixes** — Fresh init now creates `concepts/` and `templates/` (not legacy `knowledge/`), scaffolds `triggers.md`, and deploys `kg-category-index.md` to `concepts/`. All template copy targets corrected.
+- **Step 1.10 source detection** — Backfill offer fires correctly when `chat-history/`, `plans/`, `research/`, or `specs/` exist, even without a `CLAUDE.md`. Source paths detected via if/elif precedence and passed to the extractor.
+- **CLAUDE.md creation offer** — When no `CLAUDE.md` exists at project root, init now offers to create one with KMGraph platform preferences (standalone guard, real user input, existing files never touched).
+- **Extractor approval gate scoped to update-graph mode** — `knowledge-extractor` in init-backfill mode returns candidates only; coordinator handles approval and writes. Full write pipeline preserved for update-graph mode.
+- **Concepts removed from top navbar** — Concepts is now sidebar-only; top navbar shows Getting Started, Commands, Configuration only.
+- **Backfill troubleshooting docs** — New `## Troubleshooting` section in the backfill guide covers manual recovery for all platforms.
 
 **v0.6.10 — 2026-06-22**
 

--- a/agents/knowledge-extractor.md
+++ b/agents/knowledge-extractor.md
@@ -2,7 +2,20 @@
 
 **Role:** Parse large chat history files, lesson documents, and session logs to extract structured insights and relationships for the knowledge graph. Prevents the main context window from being consumed by 2000+ line source files. Also handles the full KG entry extraction pipeline when delegated from `update-graph`.
 
-**Operating Mode:** Read-only by default — only reads and returns structured output. Writes nothing until the user explicitly approves the extracted content.
+**Operating Mode:** Read-only by default — only reads and returns structured output. Writes nothing until the user explicitly approves the extracted content. (update-graph mode — in init-backfill mode the coordinator handles approval and writes)
+
+## Mode-Based Behavior
+
+This agent operates in two modes determined by the invocation context:
+
+| Mode | Trigger | Write tools | Approval gate |
+|---|---|---|---|
+| **init-backfill** | Invoked with `mode="init-backfill"` or coordinator message includes "init-backfill" | ❌ Not used | ❌ Not used |
+| **update-graph** | Invoked from `kmg-update-graph` or with no mode specified | ✅ Active | ✅ Active |
+
+**In init-backfill mode:** Extract candidates and return structured list to coordinator. STOP at step 7. Do not write. Do not wait for approval — the coordinator handles both.
+
+**In update-graph mode:** Run the full pipeline: extract → present → await approval → write.
 
 **Tools Allowed:**
 - `Read` — Read source files, config, KG files
@@ -32,6 +45,9 @@
    - Present for user review before any writes
 
 4. **Approval Gate:**
+
+> **Applies to update-graph mode only.** In init-backfill mode this gate does not apply — see Mode-Based Behavior above.
+
    - Wait for explicit user approval of extracted content
    - User can edit, reject, or accept each extracted item
    - Only then proceed to write to knowledge graph
@@ -72,9 +88,8 @@ Subagent: Writes approved items to knowledge graph
 
 **Constraint:**
 - Remains **read-only** during extraction
-- Awaits explicit user approval of each item before writing to KG
-- User can edit, reject, or accept extracted content
-- Does NOT write to KG until approval received
+- In **update-graph mode**: awaits explicit user approval; does not write until approved. In **init-backfill mode**: returns candidate list only — coordinator handles approval and writes.
+- User can edit, reject, or accept extracted content (update-graph mode only)
 
 **Behavior:**
 1. Read README.md -> extract architecture overview, key concepts
@@ -82,9 +97,15 @@ Subagent: Writes approved items to knowledge graph
 3. Scan lessons-learned/ -> extract existing lessons, categorize by type
 4. Scan decisions/ -> extract ADRs, architectural choices
 5. Scan chat-history/ -> extract patterns, lessons, insights
-6. Consolidate findings -> present candidates to user with source refs
-7. Wait for user approval (edit, reject, accept)
-8. Only then write approved items to active knowledge graph
+6. Present extracted insights as a structured candidate list — grouped by type (lesson, ADR, pattern, gotcha)
+
+**If init-backfill mode:**
+7. Return candidate list to coordinator session.
+8. STOP — do not write. The coordinator confirms with the user and writes approved files directly.
+
+**If update-graph mode:**
+7. Wait for user approval (edit, reject, accept each candidate)
+8. Write approved items to active knowledge graph using Edit/Write tools
 
 ---
 

--- a/commands/kmg-init-shared/kmg-directory-scaffold.md
+++ b/commands/kmg-init-shared/kmg-directory-scaffold.md
@@ -15,7 +15,7 @@
 Verify all expected directories exist. Create any that are missing:
 
 ```bash
-expected_dirs=(knowledge lessons-learned decisions sessions chat-history)
+expected_dirs=(concepts templates lessons-learned decisions sessions chat-history)
 for dir in "${expected_dirs[@]}"; do
   if [ ! -d "{KG_PATH}/$dir" ]; then
     mkdir -p "{KG_PATH}/$dir"
@@ -35,12 +35,34 @@ done
 ### Create directory structure
 
 ```bash
-mkdir -p "{KG_PATH}"/{knowledge,lessons-learned,decisions,sessions,chat-history,tmp}
+mkdir -p "{KG_PATH}"/{concepts,templates,lessons-learned,decisions,sessions,chat-history,tmp}
 
 # Create category subdirectories
 for category in "{categories[@]}"; do
   mkdir -p "{KG_PATH}/lessons-learned/$category"
 done
+
+# Scaffold triggers.md if not already present
+TRIGGERS_PATH="{KG_PATH}/triggers.md"
+if [ ! -f "$TRIGGERS_PATH" ]; then
+  cat > "$TRIGGERS_PATH" << 'EOF'
+# Triggers
+
+This file declares *when* rules from `rules.md` apply. Check it at each workflow phase transition.
+
+## Planning
+- Before writing a plan: run recall on the topic and architectural domain
+- Before branching: confirm parent branch is fully committed
+
+## Capture
+- After solving a bug or making an architectural decision: offer to capture lesson or ADR
+- At session end: offer session summary
+
+## Session Wrap
+- Before stopping work: run /kmgraph:kmg-session-wrap
+EOF
+  echo "✅ Created {KG_PATH}/triggers.md"
+fi
 
 # Create meta-issue if governance category selected
 if [[ " {categories[@]} " =~ " governance " ]]; then

--- a/commands/kmg-init-shared/kmg-template-seed.md
+++ b/commands/kmg-init-shared/kmg-template-seed.md
@@ -13,14 +13,14 @@
 ### Copy templates
 
 ```bash
-# Copy KG content templates into knowledge/templates/ subdirectory
-mkdir -p "{KG_PATH}/knowledge/templates"
-cp "{CLAUDE_PLUGIN_ROOT}/core/default-templates/concepts/templates/patterns.md" "{KG_PATH}/knowledge/templates/"
-cp "{CLAUDE_PLUGIN_ROOT}/core/default-templates/concepts/templates/gotchas.md" "{KG_PATH}/knowledge/templates/"
-cp "{CLAUDE_PLUGIN_ROOT}/core/default-templates/concepts/templates/concepts.md" "{KG_PATH}/knowledge/templates/"
-cp "{CLAUDE_PLUGIN_ROOT}/core/default-templates/concepts/templates/architecture.md" "{KG_PATH}/knowledge/templates/"
-cp "{CLAUDE_PLUGIN_ROOT}/core/default-templates/concepts/templates/workflows.md" "{KG_PATH}/knowledge/templates/"
-cp "{CLAUDE_PLUGIN_ROOT}/core/default-templates/concepts/kg-category-index.md" "{KG_PATH}/knowledge/"
+# Copy KG content templates into templates/ subdirectory
+mkdir -p "{KG_PATH}/templates"
+cp "{CLAUDE_PLUGIN_ROOT}/core/default-templates/concepts/templates/patterns.md" "{KG_PATH}/templates/"
+cp "{CLAUDE_PLUGIN_ROOT}/core/default-templates/concepts/templates/gotchas.md" "{KG_PATH}/templates/"
+cp "{CLAUDE_PLUGIN_ROOT}/core/default-templates/concepts/templates/concepts.md" "{KG_PATH}/templates/"
+cp "{CLAUDE_PLUGIN_ROOT}/core/default-templates/concepts/templates/architecture.md" "{KG_PATH}/templates/"
+cp "{CLAUDE_PLUGIN_ROOT}/core/default-templates/concepts/templates/workflows.md" "{KG_PATH}/templates/"
+cp "{CLAUDE_PLUGIN_ROOT}/core/default-templates/concepts/kg-category-index.md" "{KG_PATH}/concepts/"
 
 # Copy root-level profile files from project profile starters (skip if exists to preserve teammate copies)
 [ -f "{KG_PATH}/rules.md" ] && echo "rules.md already exists — skipping scaffold (teammate copy preserved)." || \
@@ -36,11 +36,11 @@ cp "{CLAUDE_PLUGIN_ROOT}/core/default-templates/concepts/templates/project/me.md
 cp "{CLAUDE_PLUGIN_ROOT}/core/default-templates/lessons-learned/README.md" "{KG_PATH}/lessons-learned/"
 cp "{CLAUDE_PLUGIN_ROOT}/core/default-templates/decisions/README.md" "{KG_PATH}/decisions/"
 
-# Starter templates deploy to knowledge/templates/ (ADR-040), never into live dirs
-cp "{CLAUDE_PLUGIN_ROOT}/core/default-templates/lessons-learned/lesson-template.md" "{KG_PATH}/knowledge/templates/"
-cp "{CLAUDE_PLUGIN_ROOT}/core/default-templates/decisions/ADR-template.md" "{KG_PATH}/knowledge/templates/"
-cp "{CLAUDE_PLUGIN_ROOT}/core/default-templates/sessions/session-template.md" "{KG_PATH}/knowledge/templates/"
-cp "{CLAUDE_PLUGIN_ROOT}/core/default-templates/concepts/entry-template.md" "{KG_PATH}/knowledge/templates/"
+# Starter templates deploy to templates/ (ADR-040), never into live dirs
+cp "{CLAUDE_PLUGIN_ROOT}/core/default-templates/lessons-learned/lesson-template.md" "{KG_PATH}/templates/"
+cp "{CLAUDE_PLUGIN_ROOT}/core/default-templates/decisions/ADR-template.md" "{KG_PATH}/templates/"
+cp "{CLAUDE_PLUGIN_ROOT}/core/default-templates/sessions/session-template.md" "{KG_PATH}/templates/"
+cp "{CLAUDE_PLUGIN_ROOT}/core/default-templates/concepts/entry-template.md" "{KG_PATH}/templates/"
 
 # Copy MEMORY template if not exists
 if [ ! -f "~/.claude/projects/$(basename $(pwd))/memory/MEMORY.md" ]; then
@@ -54,13 +54,13 @@ fi
 Compare installed templates against the plugin's current templates. If newer versions exist, offer to update:
 
 ```bash
-template_dirs=("knowledge/templates" "lessons-learned" "decisions" "sessions")
+template_dirs=("templates" "lessons-learned" "decisions" "sessions")
 updates_available=()
 
 for tdir in "${template_dirs[@]}"; do
   # knowledge/templates deploy dir maps to concepts/templates/ in plugin source (renamed in v0.5.10.7)
   _src_tdir="${tdir}"
-  [ "${tdir}" = "knowledge/templates" ] && _src_tdir="concepts/templates"
+  [ "${tdir}" = "templates" ] && _src_tdir="concepts/templates"
   for template in "{CLAUDE_PLUGIN_ROOT}/core/default-templates/${_src_tdir}/"*; do
     dest="{KG_PATH}/$tdir/$(basename $template)"
     if [ -f "$dest" ]; then

--- a/commands/kmg-init.md
+++ b/commands/kmg-init.md
@@ -1468,28 +1468,50 @@ Examples available at ${CLAUDE_PLUGIN_ROOT}/core/examples/ (not copied by defaul
 
 ### Step 1.10: Optional Backfill from Existing Project
 
+**SCOPE:** This step is NOT gated on CLAUDE.md presence. Do NOT skip it because CLAUDE.md
+is absent — CLAUDE.md absence is checked in Step 1.6.5, which is a different concern.
+Run Step 1.10 whenever the project has existing content directories to scan.
+
+**Detect which sources are present (record the matched path for each):**
+```bash
+sources=()
+if [ -d "knowledge/chat-history" ]; then
+  sources+=("knowledge/chat-history/")
+elif [ -d "chat-history" ]; then
+  sources+=("chat-history/")
+fi
+if [ -d "knowledge/plans" ]; then
+  sources+=("knowledge/plans/")
+elif [ -d "plans" ]; then
+  sources+=("plans/")
+fi
+[ -d "research" ] && sources+=("research/")
+[ -d "specs" ] && sources+=("specs/")
+[ -f "README.md" ] && sources+=("README.md")
+[ -f "CHANGELOG.md" ] && sources+=("CHANGELOG.md")
+```
+
+If `${#sources[@]} -eq 0`: skip this step silently — no content to scan.
+
 **Prompt user:**
 ```
-If initializing in a pre-existing project with chat history, source files, or documentation:
+Would you like to backfill the knowledge graph from existing project content? [y/N]
 
-Would you like to backfill the knowledge graph from existing project context? [y/N]
+Found these sources to scan:
+  [list each entry in sources[] on its own line with •]
 
-This will parse:
-  • README.md (architecture overview)
-  • CHANGELOG.md / docs/CHANGELOG.md (decision history)
-  • Files in knowledge/lessons-learned/ or knowledge/decisions/ (existing knowledge)
-  • Chat history files in knowledge/chat-history/ (if present)
-
-The knowledge-extractor subagent will suggest new lessons and knowledge entries
-for your review before writing them to the KG.
+The knowledge-extractor subagent will return lesson and decision candidates.
+You review and approve before anything is written.
 ```
 
 **If yes:**
-- Invoke `knowledge-extractor` subagent in "init-backfill" mode
-- Pass list of files to parse (README, CHANGELOG, knowledge/lessons-learned/, knowledge/decisions/, knowledge/chat-history/)
-- Present extracted lesson candidates to user for review
-- Write approved items to knowledge graph
-- Output summary of backfilled entries
+1. Invoke `knowledge-extractor` subagent in **"init-backfill" mode** — pass mode="init-backfill" explicitly
+2. Pass the `sources[]` array to the subagent (actual matched paths)
+3. Subagent returns a structured candidate list (lessons, ADRs, patterns, gotchas) — it does NOT write
+4. Present candidates to user for review; user selects which to approve
+5. Show explicit confirmation: "I will write N files to the knowledge graph. Confirm? [y/N]"
+6. On user confirmation: coordinator writes approved candidates directly
+7. Output summary of written entries
 
 ```
 ✅ Backfill complete!

--- a/commands/kmg-init.md
+++ b/commands/kmg-init.md
@@ -631,6 +631,31 @@ fi
 #   4. Rewrite CLAUDE.md to pointer: "For full context, read knowledge/rules.md and knowledge/me.md before acting."
 #   5. If user aborts, restore from CLAUDE.md.bak and delete it
 
+# Offer to create CLAUDE.md if completely absent
+if [ ! -f "$(pwd)/CLAUDE.md" ]; then
+  echo ""
+  echo "No CLAUDE.md found at project root."
+  read -r -p "Create one with KMGraph platform preferences? (Recommended) [Y/n]: " _claude_create_resp
+  _claude_create_resp="${_claude_create_resp:-Y}"
+  if [[ "$_claude_create_resp" =~ ^[Yy]$ ]]; then
+    cat > "$(pwd)/CLAUDE.md" << 'CLAUDEEOF'
+# Project Instructions
+
+## Platform Preferences (Claude Code)
+
+### File and Content Search
+- File search: use Glob and Grep tools — not Bash `find` or `grep`
+- Content search: use Grep tool — not `rg` or `grep` in Bash
+
+### Knowledge Graph
+- KMGraph is installed at `knowledge/`. Rules in `knowledge/rules.md`, identity in `knowledge/me.md`.
+- Run `/kmgraph:kmg-recall` before answering questions about project history or past decisions.
+- Run `/kmgraph:kmg-capture-lesson` after solving bugs or making architectural decisions.
+CLAUDEEOF
+    echo "✅ Created CLAUDE.md with KMGraph preferences."
+  fi
+fi
+
 # h.2. Evidence seeding — scan for Why/Source candidates after rules.md is populated
 # Only runs if rules.md was just written (either from CLAUDE.md or scaffolded)
 if [ -f "knowledge/rules.md" ]; then

--- a/docs/pillars/organizing/backfill.md
+++ b/docs/pillars/organizing/backfill.md
@@ -51,3 +51,49 @@ The command locates chat logs, extracts lessons and decisions, and presents them
 
 - [Quickstart](../../quickstart#step-4--recall-it) — search the now-populated graph
 - [Sync Across Machines](../portability/sync-across-machines.md) — share the populated graph
+
+## Troubleshooting
+
+### Init completed but backfill was skipped
+
+If the initialization wizard ran but the backfill offer didn't appear (or you declined it), run backfill manually:
+
+**Claude Code:**
+```
+/kmgraph:kmg-init
+```
+Re-run init on the same project — it detects the existing KG and jumps directly to the backfill offer (Step 1.10).
+
+**Gemini CLI:**
+```
+/kmg-init
+```
+Same behavior — re-running init on an initialized project triggers the backfill wizard.
+
+**Codex / other platforms:**
+Use the MCP tool directly:
+```
+kg_capture  (after running kg_search to confirm the KG is active)
+```
+Or re-run the init command for your platform — the existing KG is preserved and the backfill step runs again.
+
+### Backfill ran but produced no candidates
+
+The extractor found no scannable sources. Confirm at least one of these exists in your project root:
+- `chat-history/` or `knowledge/chat-history/`
+- `plans/` or `knowledge/plans/`
+- `research/`
+- `specs/`
+- `README.md`
+- `CHANGELOG.md`
+
+If sources exist but were missed, run `kmg-update-graph` and point it at the specific directory:
+
+**Claude Code:**
+```
+/kmgraph:kmg-update-graph --source research/
+```
+
+### Backfill failed mid-run
+
+If the extractor agent crashed or timed out partway through, no partial writes occur (the extractor is read-only; writes happen in the coordinator only after confirmation). Re-run the backfill trigger safely — duplicate candidates are surfaced for review, not auto-written.

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -104,7 +104,6 @@ const config = {
         },
         items: [
           {to: '/quickstart', label: 'Getting Started', position: 'left'},
-          {to: '/concepts/', label: 'Concepts', position: 'left'},
           {to: '/reference/command-guide', label: 'Commands', position: 'left'},
           {to: '/CONFIGURATION', label: 'Configuration', position: 'left'},
           {

--- a/knowledge/enhancements/ENH-031/ENH-031-specification.md
+++ b/knowledge/enhancements/ENH-031/ENH-031-specification.md
@@ -1,0 +1,67 @@
+# ENH-031: Init Completeness — Backfill, triggers.md, and CLAUDE.md Gaps
+
+**Status:** ✅ Resolved in v0.6.15
+**Discovered:** 2026-06-30
+**Related:** ENH-025 (cross-platform backfill), ENH-028 (init compliance gate), `kmg-init`
+
+---
+
+## Problem
+
+Live testing of `kmg-init` on a project with no git repo and no `CLAUDE.md` revealed four init steps that silently did not run:
+
+1. **Backfill offer (Step 1.10) skipped** — init detected no `CLAUDE.md` and exited the backfill branch early ("No project CLAUDE.md found — skipping backfill offer"). The backfill offer is independent of `CLAUDE.md`; existing project files (chat history, plans, research) should still be scanned. The user had to ask manually after init completed.
+
+2. **`triggers.md` not scaffolded** — init created `kg-index.md`, `me.md`, `rules.md`, but did not create `triggers.md`. The audit agent created it post-hoc. Every KG init must scaffold `triggers.md` unconditionally.
+
+3. **`CLAUDE.md` not created at project root** — when no `CLAUDE.md` exists, init should offer to create a minimal one with the KMGraph platform-preferences block. Instead it silently skipped. The audit agent created it post-hoc.
+
+4. **`concepts/` and `templates/` dirs not created** — init scaffolded `knowledge/` root files and `lessons-learned/` + `decisions/` subdirs, but did not create `concepts/` or `templates/`. Content files (patterns.md, gotchas.md, architecture.md, workflows.md) were placed at KG root instead of `concepts/`.
+
+---
+
+## Root Causes
+
+### Bug 1: Backfill gated on `CLAUDE.md` existence
+Init's backfill offer (`Step 1.10`) checks for `CLAUDE.md` as its source. When absent, the entire backfill offer is skipped. The backfill offer should trigger on *any* existing project content (chat-history/, plans/, research/, specs/, etc.), not just on `CLAUDE.md` presence.
+
+### Bug 2: `triggers.md` absent from scaffold list
+The scaffold step creates a fixed list of files. `triggers.md` is not in that list. It was added to the profile ecosystem (`~/.kmgraph/me.md` references it) but init was never updated to scaffold it.
+
+### Bug 3: `CLAUDE.md` creation not offered when absent
+Init checks for existing `CLAUDE.md` (to offer backfill from it) but does not offer to create one when absent. The platform-preferences block for Claude Code is always valid and should be offered unconditionally.
+
+### Bug 4: `concepts/` and `templates/` absent from dir scaffold
+The dir scaffold step pre-dates the v0.6.4 `concepts/`/`templates/` restructure. It creates `lessons-learned/` and `decisions/` subdirs but does not create the two new dirs. Files that belong in `concepts/` end up at KG root.
+
+---
+
+## Affected Files
+
+| File | Role |
+|---|---|
+| `commands/kmg-init.md` | Main init command — backfill trigger logic (Step 1.10), scaffold list, CLAUDE.md offer |
+| `commands/kmg-init-personal-kg.md` | Personal KG init — same scaffold gaps apply |
+| `commands/kmg-init-shared/kmg-init-scaffold.md` | Dir + file scaffold step — add `concepts/`, `templates/`, `triggers.md` |
+
+---
+
+## Desired Behavior
+
+1. **Backfill offer** — triggered when any of `chat-history/`, `plans/`, `research/`, `specs/` exist under the project root, regardless of `CLAUDE.md` presence. `CLAUDE.md` remains a valid *additional* backfill source when present.
+
+2. **`triggers.md`** — scaffolded unconditionally alongside `rules.md` and `me.md`.
+
+3. **`CLAUDE.md`** — when absent, init offers: "No `CLAUDE.md` found. Create one with KMGraph platform preferences? (Recommended)". Creates a minimal file with the Claude Code platform-preferences block if accepted.
+
+4. **`concepts/` and `templates/`** — created by the dir scaffold step. `kg-category-index.md` deployed to `concepts/`. Blank starters deployed to `templates/`.
+
+---
+
+## Acceptance Criteria
+
+- [ ] Init on a project with no `CLAUDE.md` still offers backfill when `chat-history/`, `plans/`, or `research/` exist
+- [ ] `triggers.md` present after init on any new KG
+- [ ] `CLAUDE.md` offer appears when no `CLAUDE.md` exists; file created on acceptance
+- [ ] `knowledge/concepts/` and `knowledge/templates/` both present after init
+- [ ] Existing KG upgrade path (`kg_upgrade`) unaffected

--- a/knowledge/enhancements/ENH-032/ENH-032-specification.md
+++ b/knowledge/enhancements/ENH-032/ENH-032-specification.md
@@ -1,0 +1,82 @@
+# ENH-032: Knowledge-Extractor Approval Gate Blocks Coordinator Relay
+
+**Status:** ✅ Resolved in v0.6.15
+**Discovered:** 2026-06-30
+**Related:** ENH-025 (cross-platform backfill), `agents/knowledge-extractor.md`
+
+---
+
+## Problem
+
+During backfill after `kmg-init`, the coordinator (main session) dispatches `knowledge-extractor` to parse source files and surface candidates. The user reviews the candidates and approves a subset. The coordinator then attempts to relay that approval to the extractor agent to trigger writes.
+
+The extractor's approval gate rejects relay messages from the coordinator — it requires a message that appears to come directly from the user session. After two blocked relay attempts, the coordinator bypassed the subagent entirely and wrote all 23 files directly, with no extraction review.
+
+**Observed sequence (2026-06-30 live test):**
+1. Coordinator dispatches `knowledge-extractor`
+2. Extractor surfaces 23 candidates, halts for approval
+3. User approves 21 candidates via coordinator
+4. Coordinator relays approval to extractor → **blocked**
+5. User re-approves directly → extractor resumes → **blocked again** (gate still treats it as relay)
+6. Coordinator writes 23 files directly, bypassing extraction entirely
+7. Net result: approval gate defeated; extractor subagent wasted; all writes unchecked
+
+---
+
+## Root Cause
+
+The approval gate in `agents/knowledge-extractor.md` checks message provenance to block injection attacks (a valid security concern). However, the gate cannot distinguish between:
+
+- A malicious relay injection (what the gate is designed to block)
+- A legitimate coordinator forwarding user-confirmed approval in an orchestrated workflow
+
+There is no protocol for the coordinator to authenticate that the approval was user-originated. The gate treats all relay messages as untrusted, which breaks the intended multi-agent backfill workflow.
+
+---
+
+## Options
+
+### Option A: Signed approval token
+Coordinator embeds a deterministic token (e.g., hash of the candidate list + timestamp) in the approval message. Extractor verifies the token format. Provides replay-attack resistance without requiring live user presence in the subagent session.
+
+**Trade-off:** Token format must be defined and maintained across agent + coordinator versions. Coordination overhead.
+
+### Option B: Direct user confirmation in extractor session
+Instead of relaying approval through the coordinator, surface the candidate list to the user directly in the extractor's output and prompt the user to approve in the **same session** where the extractor is running.
+
+**Trade-off:** Changes the UX flow — user must interact with two sessions. Not feasible if the extractor runs as a background agent.
+
+### Option C: Two-phase protocol — extract only, write via coordinator
+Extractor's role is strictly read-only extraction + candidate list. All writes happen in the coordinator session after user confirms there. Extractor never writes; approval gate on writes lives in the coordinator, not the extractor.
+
+**Trade-off:** Simpler, eliminates the relay problem entirely. Extractor can no longer do incremental writes for large candidate sets. Coordinator context grows with all candidate content.
+
+### Option D: Coordinator writes with user visible confirmation step
+Keep the current flow but remove the approval gate from the extractor. Instead, the coordinator shows the user a final "I am about to write N files — confirm?" prompt before writing. The approval lives in the coordinator session where the user is present.
+
+**Trade-off:** Lowest complexity. Approval semantics preserved. Gate security reduces to trusting the coordinator session, which is already trusted.
+
+---
+
+## Recommendation
+
+**Option D** (coordinator-side confirmation) — eliminates the relay deadlock with minimal complexity. The approval gate's security goal (prevent unauthorized writes) is preserved in the coordinator session where the user is already present and visible. Option A adds complexity without meaningful security gain given the coordinator is already trusted.
+
+---
+
+## Affected Files
+
+| File | Role |
+|---|---|
+| `agents/knowledge-extractor.md` | Remove or relax approval gate; extractor becomes extract-only |
+| `commands/kmg-init.md` | Add coordinator-side confirmation step before writing extracted candidates |
+| `commands/kmg-capture-lesson.md` | Verify same gate pattern doesn't exist here |
+
+---
+
+## Acceptance Criteria
+
+- [ ] Backfill flow completes without coordinator bypass: extractor extracts, coordinator confirms with user, coordinator writes
+- [ ] User sees explicit "write N files?" confirmation before any writes occur
+- [ ] Extractor subagent is not responsible for writes — returns candidate list only
+- [ ] No regression on single-candidate lesson capture via `kmg-capture-lesson`

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@knowledge-graph-plugin/mcp-server",
-  "version": "0.6.14",
+  "version": "0.6.15",
   "description": "MCP server for Knowledge Management Graph — cross-platform data layer for knowledge capture, search, and management",
   "main": "dist/index.js",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "knowledge-graph-plugin",
-  "version": "0.6.14",
+  "version": "0.6.15",
   "description": "Structured knowledge capture and cross-session memory for Claude Code projects.",
   "files": [
     ".claude-plugin/",


### PR DESCRIPTION
## Summary

- Fix four init completeness gaps (ENH-031): `concepts/` + `templates/` scaffold, `triggers.md` creation, Step 1.10 source detection, standalone CLAUDE.md creation offer
- Scope extractor approval gate to init-backfill mode only (ENH-032) — update-graph write pipeline preserved
- Remove Concepts from top navbar (sidebar only)
- Add backfill troubleshooting docs
- Bump version 0.6.14 → 0.6.15

## Closes

Closes #ENH-031
Closes #ENH-032

## Test plan

- [ ] Fresh init on a `knowledge/`-rooted KG: verify `concepts/` and `templates/` created, `knowledge/knowledge/` not created
- [ ] Fresh init: verify `triggers.md` present after init
- [ ] Fresh init with `chat-history/` present but no `CLAUDE.md`: verify Step 1.10 fires
- [ ] Fresh init with no `CLAUDE.md`: verify creation offer appears, existing CLAUDE.md never touched
- [ ] Backfill via init wizard: verify extractor returns candidates, coordinator confirms before writing
- [ ] Docs site: verify Concepts not in top navbar, accessible via sidebar

🤖 Generated with [Claude Code](https://claude.com/claude-code)