### PR TITLE
fix(deps): bump js-yaml to 3.15.0 in mcp-server (Dependabot #90)

### DIFF
--- a/mcp-server/package-lock.json
+++ b/mcp-server/package-lock.json
@@ -3793,9 +3793,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "3.14.2",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
-      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
+      "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
       "dev": true,
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
## Summary
- Resolves Dependabot alert #90: js-yaml quadratic-complexity DoS (GHSA-h67p-54hq-rp68) in `mcp-server/package-lock.json`.
- Transitive dependency only (pulled in via `@istanbuljs/load-nyc-config`), bumped 3.14.2 → 3.15.0 within the existing `^3.13.1` semver range via plain `npm audit fix`. No `package.json` changes needed.

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] `npx jest` — 124/124 tests passing (main's baseline count; differs from the 144 seen on `v0.6.18-misc-patches` only because that branch has an additional uncommitted test file not present on `main`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)