### PR TITLE
fix(skills): mechanical check for meta-issue Attempts paperwork drift

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ All notable changes to the Knowledge Plugin will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+
+- **Meta-issue "Attempts" paperwork drifted from actual attempts silently, confirmed 3x in one real instance** — the convention (README = terse index, `implementation-log.md` = chronological log, `attempts/NNN-*/` = full detail) was enforced only by prose, and the scaffold's own reminder to use `--add-attempt` had already failed twice before. Adds a new Step 5 to `kmg-paperwork-audit`: a mechanical folder↔log-header invariant check plus a README `## Attempts` entry size guardrail, both self-contained bash/awk since `scripts/pre-push-gate.sh` (where the skill previously said this kind of check belonged) isn't shipped to consumer repos. Confirmed against two live drift cases already present in this repo's own `knowledge/issues/` and a naming inconsistency in a third. Also tightens `core/default-templates/meta-issue/README.md` and `core/docs/META-ISSUE-GUIDE.md` to point at the atomic `--add-attempt`/`--log-attempt` commands instead of presenting folder-creation and log-update as independent steps. Closes #222, issue-45.
+
 ## [0.7.1.3] — 2026-08-12
 
 ### Changed

--- a/core/default-templates/meta-issue/README.md
+++ b/core/default-templates/meta-issue/README.md
@@ -34,6 +34,9 @@
 
 ## Attempts
 
+<!-- One line per attempt. Full detail belongs in attempts/NNN-*/attempt-results.md;
+     chronological narrative belongs in implementation-log.md. Do not expand entries here. -->
+
 [Auto-populated from implementation-log.md]
 
 1. **[001-baseline](attempts/001-baseline/)** — [Status] — [Brief outcome]
@@ -60,11 +63,13 @@
 
 ## How to Use This Meta-Issue
 
-1. **Add attempt:** Create new `attempts/NNN-name/` folder from attempt-template
+1. **Add attempt:** Create new `attempts/NNN-name/` folder **and** append its `## Attempt NNN`
+   entry to `implementation-log.md` together, as one step — `/kmgraph:kmg-meta-issue
+   --add-attempt` does both atomically for this reason. Doing only one half is the single most
+   common way this convention drifts out of sync (issue-45).
 2. **Update understanding:** Edit `analysis/root-cause-evolution.md` when beliefs shift
-3. **Log progress:** Update `implementation-log.md` with each attempt
-4. **Extract lessons:** Create lessons-learned when patterns emerge
-5. **Sync to KG:** Run `/kmgraph:kmg-update-graph` to extract insights
+3. **Extract lessons:** Create lessons-learned when patterns emerge
+4. **Sync to KG:** Run `/kmgraph:kmg-update-graph` to extract insights
 
 ---
 

--- a/core/docs/META-ISSUE-GUIDE.md
+++ b/core/docs/META-ISSUE-GUIDE.md
@@ -289,6 +289,12 @@ mkdir docs/meta-issues/[issue-name]/attempts/{001-caching,002-queries}
 
 ### 3. Before Each New Attempt
 
+> Prefer `/kmgraph:kmg-meta-issue --add-attempt NNN "<label>"` over the manual steps below — it
+> creates the attempt directory **and** appends the `implementation-log.md` entry in one atomic
+> operation. Doing them as two separate manual steps (as shown next) is the most common way this
+> convention drifts out of sync — a folder gets created without ever gaining a matching log entry,
+> or vice versa (issue-45). The manual steps are shown for reference, not as the preferred path.
+
 **Create attempt directory:**
 
 ```bash

--- a/knowledge/enhancements/ENH-052/ENH-052-specification.md
+++ b/knowledge/enhancements/ENH-052/ENH-052-specification.md
@@ -5,7 +5,7 @@ status: deferred
 github-issue: "#188"
 branch: none
 created: 2026-07-18
-related_issues: ["issue-13", "issue-26", "issue-28"]
+related_issues: ["issue-13", "issue-26", "issue-28", "issue-45"]
 related_enhs: ["ENH-042"]
 ---
 

--- a/knowledge/enhancements/ENH-052/solution-approach.md
+++ b/knowledge/enhancements/ENH-052/solution-approach.md
@@ -68,6 +68,14 @@ this flag** — see the companion skill spec below.
 Gate 6 depends on a skill that doesn't exist yet. This section specs it so
 Gate 6 isn't a permanent, unsatisfiable reminder.
 
+**Later extension (issue-45, 2026-08-13):** `kmg-paperwork-audit` gained a third
+check outside this original two-check scope — a mechanical, repo-wide meta-issue
+"Attempts" paperwork-drift check, landed as Step 5. It's mechanical (the kind of
+thing this ENH says belongs in a Gate, not this skill), but landed here anyway
+because `scripts/pre-push-gate.sh` isn't part of the distributed plugin surface
+and this skill is the only shipped mechanism on the right trigger set. See
+issue-45 for the full rationale.
+
 **Purpose:** handle the two checks Gate 5 explicitly cannot — they require
 reading and understanding content, not just counting files or grepping for a
 reference pattern.

--- a/knowledge/issues/issue-45/implementation-log.md
+++ b/knowledge/issues/issue-45/implementation-log.md
@@ -1,0 +1,49 @@
+# Implementation Log — Issue-45
+
+**Total Attempts:** 1
+**Last Updated:** 2026-08-13
+
+---
+
+## Attempts (Chronological)
+
+## Attempt 001: Mechanical checks in kmg-paperwork-audit (2026-08-13)
+
+**Status:** In Progress
+**Plan:** [v0.7.1.4-issue-45-meta-issue-attempts-paperwork-drift.md](../../plans/v0.7.1.4-issue-45-meta-issue-attempts-paperwork-drift.md) (local-only, gitignored)
+
+**Approach:**
+Plan drafted (folder↔header invariant + README size guardrail, both as a new Step 5 in
+`skills/kmg-paperwork-audit/SKILL.md`), reviewed by an independent Opus pass against live repo
+state, then a codex review (via peer session `codex-rescue`, run only after explicit approval) of
+the section-2 script specifically. Both review rounds' findings were verified against the actual
+repo rather than trusted at face value. During the executing-plans skill's mandatory pre-
+implementation critical review, section 1's script was run for the first time (previously only
+reasoned about) and two more real bugs were found and fixed: an invalid-bash-syntax crash
+(`${#nonconforming[@]:-0}`) that aborted the whole check under plain bash, and a missing branch
+that made the check silently produce zero output for the exact case (`kg-config-silent-overwrite`)
+the plan cites as motivating evidence.
+
+**Outcome (so far):**
+- `skills/kmg-paperwork-audit/SKILL.md` — new Step 5 (both checks) inserted after Step 4, old
+  Step 5 (Report) renumbered to Step 6, scope-boundary line amended, Edge Cases table updated.
+  Both embedded scripts executed exactly as pasted, under bash and zsh, against real repo data —
+  correct output confirmed, not just diffed against the tested source.
+- `core/default-templates/meta-issue/README.md` — HTML comment added under `## Attempts`; "How to
+  Use This Meta-Issue" steps 1/3 merged into one atomic step.
+- `core/docs/META-ISSUE-GUIDE.md` — added a callout pointing at `--add-attempt` ahead of the
+  manual two-step (create folder / update log) instructions that guide previously presented as the
+  primary path with no mention of the atomic alternative.
+- `docs/pillars/capturing/document-meta-issues.md` — read, already correctly leads with the atomic
+  `--log-attempt` command; no edit needed.
+
+**Key Learning:**
+Every review round this issue went through caught something the previous one missed, and none of
+them substituted for actually running the code: Opus caught real bash bugs in v1 by reasoning
+about it against real fixture data; codex caught real edge cases (CRLF, invalid input, re-entrant
+state) in the section-2 script; but section 1's script still shipped two fresh bugs — including one
+that silently defeated the check's own motivating use case — until it was actually executed for
+the first time. "Reviewed by a model" and "verified by execution" are not the same claim.
+
+**Next Steps:**
+Commit these changes (Mandatory Plan Step 4), then proceed to `finishing-a-development-branch`.

--- a/knowledge/issues/issue-45/issue-45-description.md
+++ b/knowledge/issues/issue-45/issue-45-description.md
@@ -1,0 +1,75 @@
+---
+id: issue-45
+type: Bug
+status: in-progress
+github-issue: "#222"
+branch: v0.7.1.4-issue-45-meta-issue-attempts-paperwork-drift
+created: 2026-08-13
+---
+
+# Issue-45: Meta-Issue "Attempts" Convention Drifts From Paperwork — Enforced Only By Prose, Failed 3x
+
+## Problem
+
+The meta-issue "Attempts" convention (`README.md` = terse index, `implementation-log.md` =
+chronological per-attempt log, `attempts/NNN-*/attempt-results.md` = full detail) is correctly
+designed but enforced only by prose — the scaffold's own "How to Use This Meta-Issue" section
+just asks people to remember to use `--add-attempt` next time. That has now failed three times
+in one real meta-issue instance
+(`knowledge/issues/style-guide-required-sections-saga/` in the `tidal-docs` repo, a downstream
+consumer of this plugin):
+
+1. **Attempts 002–007** — hand-logged directly into `implementation-log.md` instead of scaffolded
+   via `--add-attempt`; `attempts/NNN-*/` folders didn't exist for days, retroactively scaffolded
+   2026-07-28.
+2. **Attempts 009–012** — same pattern, retroactively fixed as part of Attempt 013 (2026-07-29).
+3. **Attempt 015** (2026-08-12/13) — the `attempts/015-voice-pronoun-canary-gate/` folder exists,
+   but has no corresponding `## Attempt 015` entry in `implementation-log.md` at all. With that
+   designated chronological-log tier empty, all ongoing detail piled into the meta-issue's
+   `README.md` instead — its Attempt-15 index-list entry ballooned to 13,194 characters (vs. a
+   ~350-char median across the other 14 entries) before being caught and manually trimmed.
+
+A deeper, independent read of the same `README.md` found the bloat isn't unique to Attempt 15:
+the file is 41.5KB total, and separately from the Attempt-15 entry it already carries four other
+full per-attempt writeups promoted to top-level `##` sections (a Corpus-Wide Trend Analysis, an
+Opus holistic audit, a Fable agenda review, a Codex review) plus a 12.7KB "Quick Summary" — i.e.
+"detail lands in README instead of its designated file" was already the house style before
+Attempt 15, a broken-windows precedent rather than something new.
+
+## Root Cause
+
+The convention is real and correctly designed (confirmed by reading
+`core/default-templates/meta-issue/README.md` and `implementation-log.md` in this repo — the
+`## Attempt NNN: [Approach Name] (YYYY-MM-DD)` header format and the folder-per-attempt structure
+are both explicit and internally consistent). But nothing mechanically checks that a
+`knowledge/issues/*/attempts/NNN-*/` folder has a matching `## Attempt NNN` header in that issue's
+`implementation-log.md`, and nothing checks README `## Attempts` index-entry size. The only
+enforcement is the scaffold's own prose reminder, which the same failure mode has now defeated
+three times.
+
+Separately, `core/default-templates/meta-issue/README.md`'s `## Attempts` section only implies
+brevity via a placeholder example (`— [Status] — [Brief outcome]`); it never states the
+one-line-per-attempt / pointer-elsewhere rule anywhere explicitly.
+
+`skills/kmg-paperwork-audit/SKILL.md` documents deferring index-count and backlink-symmetry
+checks to `scripts/pre-push-gate.sh` Gate 5 (confirmed: Gate 5 in this repo's
+`scripts/pre-push-gate.sh` covers KG index-count drift + backlink symmetry per ENH-052, unrelated
+to meta-issue attempts). That script lives under this repo's own `scripts/` directory, which is
+not part of the distributed plugin surface (`commands/`, `skills/`, `agents/`, `hooks/`,
+`mcp-server/`, `core/` per this repo's `CLAUDE.md`) — it does not exist in `tidal-docs` or any
+other consumer repo. Any new mechanical check for this convention cannot assume
+`pre-push-gate.sh` is present; it needs to be self-contained wherever it runs in a consumer repo.
+
+## Impact
+
+- Chronological history of a meta-issue becomes unreliable — the designated log tier
+  (`implementation-log.md`) can silently go empty for an entire attempt while work still happened.
+- README bloats from an index (should stay small and scannable) into a duplicate detail store,
+  defeating the three-tier design's purpose.
+- The failure is silent: nothing surfaces the drift until a human happens to notice (as in
+  Attempt 015), by which point cleanup is manual and retroactive.
+
+## Reported By
+
+Relayed from a peer session (Fable) investigating the `tidal-docs` meta-issue instance; confirmed
+by the user as an authentic report and requested for tracking in this repo (2026-08-13).

--- a/knowledge/issues/issue-45/solution-approach.md
+++ b/knowledge/issues/issue-45/solution-approach.md
@@ -1,0 +1,56 @@
+# Solution Approach — Issue-45
+
+## Principle
+
+Prose enforcement has failed 3x in one instance. The fix is a mechanical, grep-able check, not
+another reminder. (A one-line explicit rule in the scaffold template is worth adding too, but
+only as something for the mechanical check to *cite* — it is not the fix itself.)
+
+## Proposed Scope (from the original report, not yet re-validated against current skill internals)
+
+1. **Folder ↔ log-header invariant.** For every `knowledge/issues/*/attempts/NNN-*/` folder in
+   the changed/relevant scope, verify a matching `^## Attempt NNN` header exists in that issue's
+   `implementation-log.md`. Flag mismatches (folder with no header, or — worth checking during
+   planning — header with no folder, the inverse drift).
+2. **README size guardrail.** In the same check, flag any single numbered item in a meta-issue
+   README's `## Attempts` list whose entry exceeds roughly 1,500–2,000 characters. Calibration
+   points from the real instance: the manually-trimmed Attempt-15 entry landed at ~1,350 chars;
+   the prior largest *legitimate* entry was 1,708 chars.
+3. **Placement.** `scripts/pre-push-gate.sh` is dev-only tooling for this source repo — it is not
+   shipped to consumer repos, so it cannot be assumed present. The check must be self-contained
+   in whatever ships to consumers, most likely `skills/kmg-paperwork-audit/SKILL.md` (it already
+   owns the "checks Gate 5 doesn't do mechanically" scope boundary and already runs on the same
+   pre-ship trigger set) — needs confirmation this is the right home vs. a new dedicated skill,
+   during plan review.
+4. **Template rule.** Add a one-line explicit rule (not just an implied-by-example placeholder)
+   to `core/default-templates/meta-issue/README.md`'s `## Attempts` section — likely an HTML
+   comment stating the one-line-per-attempt / pointer-to-`attempt-results.md` /
+   pointer-to-`implementation-log.md` convention directly, so the mechanical check has something
+   explicit to cite when it flags a violation.
+
+## Open Questions for Plan Review
+
+- Does this check only apply to meta-issues (folders with `attempts/`), or to every
+  `knowledge/issues/*`? (Regular non-meta issues don't have an `attempts/` subfolder at all in
+  this repo's own convention — confirm scope is meta-issue-only.)
+- Should the check run repo-wide (every meta-issue) or scoped to the current branch's diff, matching
+  `kmg-paperwork-audit`'s existing Step 1 diff-scoping method?
+- Is a bash-only implementation (grep/find, no LLM judgment needed for the folder/header
+  invariant) feasible entirely within the skill doc's existing bash-snippet pattern, or does it
+  need agent-side file listing since skills describe behavior for the agent to execute rather than
+  ship their own interpreter?
+
+## Resolution (2026-08-13)
+
+All four open questions answered during plan review, see
+`knowledge/plans/v0.7.1.4-issue-45-meta-issue-attempts-paperwork-drift.md` for full detail and the
+tested scripts:
+
+- Scope: meta-issue only, detected as `attempts/` directory **or** `## Attempt N` headers present
+  (either alone was a blind spot against real fixtures in this repo).
+- Full repo-wide scan every run, not diff-scoped — drift can predate the current branch.
+- Bash-only (grep/find/awk), no agent-side judgment needed; confirmed feasible and landed as a new
+  Step 5 in `skills/kmg-paperwork-audit/SKILL.md`.
+- Threshold landed at a flat 2,000 chars rather than the original 1,500-2,000 range — the
+  tidal-docs calibration data isn't independently verifiable from this repo, and the real failure
+  (13,194 chars) is far enough past any threshold in that range that precision doesn't matter.

--- a/knowledge/issues/issue-45/test-cases.md
+++ b/knowledge/issues/issue-45/test-cases.md
@@ -1,0 +1,17 @@
+# Test Cases — Issue-45
+
+1. **Missing header, folder exists.** `attempts/015-foo/` exists, no `## Attempt 015` header in
+   `implementation-log.md` → check flags it (reproduces the real Attempt-15 case).
+2. **Missing folder, header exists.** `## Attempt 009` header exists, no `attempts/009-*/` folder
+   → check flags the inverse drift (reproduces the Attempts 002–007 / 009–012 retroactive-scaffold
+   pattern before it was fixed).
+3. **Matched pair.** Folder and header both exist, numbers agree → no flag.
+4. **Oversized README entry.** A `## Attempts` list item exceeds the calibrated threshold →
+   flagged with its char count.
+5. **Legitimate-size README entry.** An entry at or under ~1,708 chars (prior largest legitimate
+   entry) → not flagged.
+6. **Non-meta issue.** A plain `knowledge/issues/issue-N/` with no `attempts/` folder → check
+   skips it without error (this convention doesn't apply outside meta-issues).
+7. **Consumer repo without `pre-push-gate.sh`.** Check still runs and produces correct results in
+   a repo that only has the distributed plugin surface (no `scripts/` dir) — the original failure
+   mode this issue exists to close.

--- a/skills/kmg-paperwork-audit/SKILL.md
+++ b/skills/kmg-paperwork-audit/SKILL.md
@@ -16,7 +16,7 @@ Does **not** apply to:
 - Mid-session status updates for a single, already-known issue — just edit its frontmatter directly
 - Commits that touch no `knowledge/issues/` or `knowledge/enhancements/` files and don't need a session summary
 
-**Scope boundary (ENH-052):** this skill covers only the two checks `scripts/pre-push-gate.sh` Gate 5 cannot do mechanically — issue/enhancement `status:` accuracy and session-summary currency. It does **not** re-check index counts or backlink symmetry; Gate 5 already covers those cheaply in bash, and duplicating that work here would just be the same fact checked twice by two mechanisms.
+**Scope boundary (ENH-052):** this skill covers the two checks `scripts/pre-push-gate.sh` Gate 5 cannot do mechanically — issue/enhancement `status:` accuracy and session-summary currency — plus one exception (Step 5, issue-45): a mechanical check with nowhere else to live, because `scripts/` is dev-only tooling for this source repo and is never distributed to consumer repos, while this skill ships on the same trigger set every consumer repo gets. It does **not** re-check index counts or backlink symmetry; Gate 5 already covers those cheaply in bash, and duplicating that work here would just be the same fact checked twice by two mechanisms.
 
 ---
 
@@ -40,7 +40,7 @@ git diff --name-only "$MERGE_BASE" HEAD -- \
   'knowledge/enhancements/*/ENH-*-specification.md'
 ```
 
-If `DEFAULT_BRANCH` can't be determined (no `main`/`master` branch found), skip to Step 5 and report the scan as skipped with that reason — don't guess a fallback branch.
+If `DEFAULT_BRANCH` can't be determined (no `main`/`master` branch found), skip Steps 2-4 (they depend on this diff scope) and proceed to Step 5 — Step 5 scans every meta-issue in the repo directly and needs no diff scope — before reporting the Steps 2-4 portion as skipped with that reason at Step 6. Don't guess a fallback branch.
 
 ### Step 2 — Check `status: resolved` items for supporting evidence
 
@@ -66,7 +66,128 @@ If the summary's last-known commit is not the branch's actual latest commit, and
 
 If no session summary exists for this branch at all, do not flag this as an error — not every branch requires one. Note it only if the branch has been running long enough that its absence looks like an oversight (use judgment, don't hardcode a commit-count threshold).
 
-### Step 5 — Report and write completion flag
+### Step 5 — Meta-issue Attempts paperwork drift (issue-45)
+
+Unlike Steps 1-4, this step is **not diff-scoped** — it scans every meta-issue in
+`knowledge/issues/` on every run, because the drift it looks for can predate the current branch
+(confirmed: a real meta-issue in this repo had the drift for an unknown period before any audit
+caught it). "Meta-issue" here means a directory that has an `attempts/` subdirectory, has `##
+Attempt N` headers in its `implementation-log.md`, or both — either signal alone misses a real
+failure mode (see the two checks below).
+
+**5a — Folder ↔ log-header invariant.** The convention is: `attempts/NNN-slug/` folders and `##
+Attempt NNN` headers in `implementation-log.md` come in matched pairs (this is what
+`/kmgraph:kmg-meta-issue --add-attempt` creates atomically). Detect drift between them:
+
+```bash
+for issue_dir in knowledge/issues/*/; do
+  log="${issue_dir}implementation-log.md"
+  has_attempts_dir=false; has_headers=false
+  [ -d "${issue_dir}attempts" ] && has_attempts_dir=true
+  [ -f "$log" ] && grep -qE '^## Attempt [0-9]' "$log" && has_headers=true
+  $has_attempts_dir || $has_headers || continue   # not a meta-issue, skip
+
+  nonconforming=()   # always declared, regardless of which branch below runs
+
+  if $has_attempts_dir && [ ! -f "$log" ]; then
+    echo "⚠️ ${issue_dir}: has attempts/ but no implementation-log.md at all"
+  fi
+
+  if $has_headers && ! $has_attempts_dir; then
+    echo "⚠️ ${issue_dir}: has '## Attempt' headers in implementation-log.md but no attempts/ directory at all"
+  fi
+
+  if $has_attempts_dir; then
+    while IFS= read -r attempt_dir; do
+      name=$(basename "$attempt_dir")
+      num=$(echo "$name" | grep -oE '^[0-9]{1,3}')
+      if [ -z "$num" ]; then nonconforming+=("$name"); continue; fi
+      num_norm=$((10#$num))                       # strip leading zeros for numeric compare
+      [ -f "$log" ] && grep -qE "^## Attempt 0*${num_norm}(:| |\$)" "$log" || \
+        echo "⚠️ ${attempt_dir}/ has no matching '## Attempt ${num}' header in $log"
+    done < <(find "${issue_dir}attempts" -mindepth 1 -maxdepth 1 -type d 2>/dev/null | sort)
+    if [ "${#nonconforming[@]}" -gt 0 ]; then
+      echo "⚠️ ${issue_dir}: ${#nonconforming[@]} attempt folder(s) don't follow attempts/NNN-slug/ (${nonconforming[*]}) — folder↔header check skipped for these"
+    fi
+  fi
+
+  # inverse: header exists, folder missing (skip entirely if this issue had nonconforming folders,
+  # since we can't tell which header they'd map to)
+  if $has_attempts_dir && [ -f "$log" ] && [ "${#nonconforming[@]}" -eq 0 ]; then
+    grep -oE '^## Attempt [0-9]{1,3}' "$log" | grep -oE '[0-9]{1,3}' | while read -r num; do
+      num_norm=$((10#$num))
+      found=false
+      while IFS= read -r candidate; do
+        c_num=$(basename "$candidate" | grep -oE '^[0-9]{1,3}')
+        [ -n "$c_num" ] && [ "$((10#$c_num))" -eq "$num_norm" ] && found=true
+      done < <(find "${issue_dir}attempts" -mindepth 1 -maxdepth 1 -type d -name '*-*' 2>/dev/null)
+      $found || echo "⚠️ '## Attempt ${num}' header in $log has no matching attempts/${num}-*/ folder"
+    done
+  fi
+done
+```
+
+Non-`NNN-slug` attempt folder names (e.g. an enhancement ID used as the folder name instead of a
+zero-padded sequence number) are drift, not an alternate convention — `/kmgraph:kmg-meta-issue
+--add-attempt`'s own behavior is the source of truth for the canonical `attempts/[NNN]-[slug]/`
+form. Report them once per issue rather than pairing them positionally against headers — a
+positional match is not reliable once the sequence is out of order.
+
+**5b — README `## Attempts` entry size guardrail.** The index entries under a meta-issue's `##
+Attempts` heading should stay terse — one line pointing at `attempts/NNN-slug/` and
+`implementation-log.md` for detail, not the detail itself. Flag any single entry that's grown past
+a size that suggests detail leaked into the index:
+
+```bash
+THRESHOLD="${THRESHOLD:-2000}"
+case "$THRESHOLD" in
+  ''|*[!0-9]*) echo "error: THRESHOLD must be a non-negative integer, got '$THRESHOLD'" >&2; exit 1 ;;
+esac
+
+for issue_dir in knowledge/issues/*/; do
+  readme="${issue_dir}README.md"
+  [ -f "$readme" ] || continue
+
+  has_attempts_dir=false; has_headers=false
+  [ -d "${issue_dir}attempts" ] && has_attempts_dir=true
+  [ -f "${issue_dir}implementation-log.md" ] && grep -qE '^## Attempt [0-9]' "${issue_dir}implementation-log.md" && has_headers=true
+  $has_attempts_dir || $has_headers || continue   # meta-issues only, same detection as 5a
+
+  awk -v threshold="$THRESHOLD" -v readme="$readme" '
+    { sub(/\r$/, "") }
+    function flush_item() {
+      if (item_num != "") {
+        len = length(item_text)
+        if (len > threshold) {
+          printf "⚠️ %s: Attempts item %s is %d chars (over %d) — starts near line %d\n", readme, item_num, len, threshold, item_start_line
+        }
+      }
+      item_num = ""; item_text = ""
+    }
+    /^## Attempts[ \t]*$/ { flush_item(); in_attempts = 1; next }
+    in_attempts && /^## / { flush_item(); in_attempts = 0; next }
+    in_attempts && /^---[ \t]*$/ { flush_item(); in_attempts = 0; next }
+    in_attempts && /^[0-9]+\. / {
+      flush_item()
+      match($0, /^[0-9]+/)
+      item_num = substr($0, RSTART, RLENGTH)
+      item_start_line = NR
+      item_text = $0
+      next
+    }
+    in_attempts && item_num != "" { item_text = item_text "\n" $0; next }
+    END { if (in_attempts) flush_item() }
+  ' "$readme"
+done
+```
+
+`THRESHOLD` is env-overridable; 2,000 chars is a deliberately round default — real bloated entries
+run an order of magnitude past any threshold in dispute, so precision here isn't worth
+re-litigating case by case. This is advisory, same as every other check in this skill — surface
+it, don't auto-trim it; the fix belongs in the same `--add-attempt`/`implementation-log.md`
+workflow 5a checks, not in an automated edit to someone's README.
+
+### Step 6 — Report and write completion flag
 
 Present findings the same way `kmg-docs-impact-scan` does — advisory notes for the user to review, never auto-corrections:
 
@@ -104,8 +225,10 @@ Flag filename formula: `/tmp/kmgraph-paperwork-audit-<branch>-<sha>.flag`, detac
 
 | Situation | Behavior |
 |-----------|----------|
-| No `main`/`master` branch found | Skip Steps 1-4, report scan skipped with that reason, still write the completion flag (the audit "ran" — it just couldn't determine a diff scope) |
-| No issue/ENH docs changed on this branch | Skip Steps 2-3 silently, still run Step 4, still write the flag |
+| No `main`/`master` branch found | Skip Steps 2-4 (need the diff scope), still run Step 5 (no diff scope needed) and Step 6, report the Steps 2-4 portion as skipped with that reason, still write the completion flag (the audit "ran" — it just couldn't determine a diff scope for that portion) |
+| No issue/ENH docs changed on this branch | Skip Steps 2-3 silently, still run Steps 4-5, still write the flag |
 | `status:` field missing or unrecognized value entirely | Skip that doc for Steps 2-3, don't guess an intended status; note it as a separate, smaller finding ("`issue-N` has no recognized `status:` value") |
 | Multiple session summaries exist for the same branch | Use the most recently modified one; don't flag older ones as stale duplicates — that's a different concern, not this skill's job |
-| Diff is very large (many issue/ENH docs changed) | No cap — unlike `kmg-docs-impact-scan`'s 20-identifier cap, this scope is already narrow (only issue/ENH docs, only this branch) and unlikely to be large enough to need one; if it ever is, note the volume to the user rather than silently truncating |
+| Diff is very large (many issue/ENH docs changed, Steps 1-4) | No cap — unlike `kmg-docs-impact-scan`'s 20-identifier cap, this scope is already narrow (only issue/ENH docs, only this branch) and unlikely to be large enough to need one; if it ever is, note the volume to the user rather than silently truncating |
+| Many meta-issues exist repo-wide (Step 5) | No cap here either, but a different cost shape than the row above — Step 5 is a full repo-wide scan every run, not diff-scoped, because the drift it looks for can predate the current branch. Cheap at this repo's current meta-issue count; if that stops being true, note the volume rather than silently truncating, same policy as the diff-scoped steps |
+| Attempt folder name doesn't start with a zero-padded number (e.g. an enhancement-ID-named folder) | Not paired against a header positionally — reported once per issue as its own finding, folder↔header check skipped for just those folders (see Step 5a) |


### PR DESCRIPTION
## Summary

- Meta-issue "Attempts" paperwork drifted from actual attempts silently — confirmed 3x in one real instance (`tidal-docs`, relayed via a peer session and confirmed by the user), and confirmed independently in this repo too (`sessionstart-hook-path-saga`, `kg-config-silent-overwrite`).
- Adds a new Step 5 to `kmg-paperwork-audit`: a folder↔log-header invariant check plus a README `## Attempts` entry size guardrail, both self-contained bash/awk (`scripts/pre-push-gate.sh` isn't shipped to consumer repos, so nothing there could carry this).
- Tightens `core/default-templates/meta-issue/README.md` and `core/docs/META-ISSUE-GUIDE.md` to point at the atomic `--add-attempt`/`--log-attempt` command instead of presenting folder-creation and log-update as independent steps — the pattern that plausibly caused the drift in the first place.

## Review process

Plan drafted → independent Opus review against live repo state → codex review (peer session, user-approved) of the size-guardrail script → both scripts actually executed under bash and zsh against real and synthetic data during implementation, not just reasoned about. Two real bugs were found only by running section 1's script for the first time during the pre-implementation critical review (invalid bash array-length syntax that crashed the check entirely; a missing branch that silently produced zero output for the exact case this issue cites as motivating evidence) — full detail in `knowledge/issues/issue-45/implementation-log.md`.

## Test plan

- [x] Both scripts run under bash and zsh against real repo data (`sessionstart-hook-path-saga`, `kg-config-silent-overwrite`, `chat-extraction-reliability-saga`) — correct output confirmed
- [x] Embedded scripts in `SKILL.md` diffed and executed exactly as pasted, not just the tested source
- [x] Synthetic edge cases: empty `attempts/`, CRLF README, invalid `THRESHOLD`, duplicate `## Attempts` heading, clean matched pair alongside a genuine inverse-miss
- [x] `scripts/pre-push-gate.sh` passes clean
- [x] `tests/run-all-tests.sh --suite skills` — 7 pre-existing failures, confirmed unrelated (byte-identical test file to `main`, none reference files this branch touched)
- [x] docs-impact-scan and paperwork-audit both run; CHANGELOG entry added; missing ENH-052↔issue-45 backlink fixed

Closes #222

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BoYsTgQVofGx8BVrJhByhU