### PR TITLE
chore(release): bump version to 0.7.1.4

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
   "plugins": [
     {
       "name": "kmgraph",
-      "version": "0.7.1.3",
+      "version": "0.7.1.4",
       "description": "Structured knowledge capture, lesson-learned documentation, and cross-session memory for Claude Code projects. Includes KG entries, ADRs, meta-issue tracking, chat extraction, and profile-file behavioral memory.",
       "source": "./",
       "author": {

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "kmgraph",
-  "version": "0.7.1.3",
+  "version": "0.7.1.4",
   "description": "Structured knowledge capture, lesson-learned documentation, and cross-session memory for Claude Code projects. Includes KG entries, ADRs, meta-issue tracking, chat extraction, and profile-file rule capture.",
   "author": {
     "name": "technomensch",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "kmgraph",
-  "version": "0.7.1.3",
+  "version": "0.7.1.4",
   "description": "Structured knowledge capture, lesson-learned documentation, and cross-session memory for Claude Code projects. Includes KG entries, ADRs, meta-issue tracking, chat extraction, and profile-file rule capture.",
   "author": {
     "name": "technomensch",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ All notable changes to the Knowledge Plugin will be documented in this file.
 
 ## [Unreleased]
 
+## [0.7.1.4] — 2026-08-13
+
 ### Fixed
 
 - **Meta-issue "Attempts" paperwork drifted from actual attempts silently, confirmed 3x in one real instance** — the convention (README = terse index, `implementation-log.md` = chronological log, `attempts/NNN-*/` = full detail) was enforced only by prose, and the scaffold's own reminder to use `--add-attempt` had already failed twice before. Adds a new Step 5 to `kmg-paperwork-audit`: a mechanical folder↔log-header invariant check plus a README `## Attempts` entry size guardrail, both self-contained bash/awk since `scripts/pre-push-gate.sh` (where the skill previously said this kind of check belonged) isn't shipped to consumer repos. Confirmed against two live drift cases already present in this repo's own `knowledge/issues/` and a naming inconsistency in a third. Also tightens `core/default-templates/meta-issue/README.md` and `core/docs/META-ISSUE-GUIDE.md` to point at the atomic `--add-attempt`/`--log-attempt` commands instead of presenting folder-creation and log-update as independent steps. Closes #222, issue-45.

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -254,6 +254,7 @@ done
 | **v0.7.1.1** | No upgrade action required. Fixes `handoff-file-tracing-gate.sh` hard-blocking sessions run inside a git worktree (`CLAUDE_PROJECT_DIR` resolves to the main checkout; `REPO_ROOT` now resolved worktree-aware via `git rev-parse --show-toplevel` at the session cwd) — automatic after plugin reload. |
 | **v0.7.1.2** | No upgrade action required. Fixes `handoff-file-tracing-gate.sh` still hard-blocking worktree sessions when the handoff package itself (gitignored `handoff-packages/`) was generated in a different checkout — automatic after plugin reload. |
 | **v0.7.1.3** | No upgrade action required. `kmg-update-profile` now requires explicit approval before writing any profile file; `kmg-extract-chat` now requires `--project=<name>` or `--confirm-unscoped` (fails closed instead of silently merging every project's sessions) — automatic after plugin reload. |
+| **v0.7.1.4** | No upgrade action required. `kmg-paperwork-audit` gains a new Step 5 — a mechanical check for meta-issue "Attempts" paperwork drift (folder↔log-header invariant, README entry size guardrail) — automatic after plugin reload. |
 
 After the wizard completes, your existing lessons, ADRs, sessions, and chat history are untouched.
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Structured knowledge capture, lesson-learned documentation, and cross-session memory for Claude Code projects.
 
-**Version:** 0.7.1.3
+**Version:** 0.7.1.4
 **Status:** Actively developed and in daily use
 
 Documentation: https://kmgraph.stayinginsync.info
@@ -89,6 +89,10 @@ Pull the latest version and run `/kmgraph:kmg-init` in any project that uses it.
 ---
 
 ## v0.7.x Feature Highlights
+
+**v0.7.1.4 — 2026-08-13** *(meta-issue Attempts paperwork-drift check)*
+
+- **Meta-issue "Attempts" paperwork drifted from actual attempts silently, confirmed 3x in one real instance** — the README-index/implementation-log/attempts-folder convention was enforced only by prose. `kmg-paperwork-audit` gains a new Step 5: a mechanical folder↔log-header invariant check plus a README `## Attempts` entry size guardrail, both self-contained bash/awk (no dependency on `scripts/pre-push-gate.sh`, which isn't shipped to consumer repos). Closes #222, issue-45.
 
 **v0.7.1.3 — 2026-08-12** *(profile approval gate + extraction scoping hardening)*
 
@@ -219,7 +223,7 @@ knowledge-graph/
 
 ## Development Status
 
-**Current Release:** v0.7.1.3 (2026-08-12)
+**Current Release:** v0.7.1.4 (2026-08-13)
 
 Actively developed and in daily use. Behavior may evolve between minor versions.
 
@@ -321,6 +325,6 @@ MIT License - See [LICENSE](LICENSE)
 ---
 
 **Created:** 2026-02-12
-**Current Version:** v0.7.1.3 (2026-08-12)
+**Current Version:** v0.7.1.4 (2026-08-13)
 
 📚 **Full documentation:** https://kmgraph.stayinginsync.info

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "knowledge-graph-plugin",
-  "version": "0.7.1.3",
+  "version": "0.7.1.4",
   "description": "Structured knowledge capture and cross-session memory for Claude Code projects.",
   "files": [
     ".claude-plugin/",


### PR DESCRIPTION
## Summary

Version-sync follow-up to #223 (issue-45) — the merge landed without bumping any version manifest. Syncs all 8 files per `knowledge/rules.md`'s Version Files checklist:

- `package.json`, `.claude-plugin/plugin.json`, `.codex-plugin/plugin.json` → 0.7.1.4
- `.claude-plugin/marketplace.json` embedded `plugins[].version` → 0.7.1.4 (top-level marketplace-schema version untouched)
- `CHANGELOG.md` — `[Unreleased]` converted to dated `[0.7.1.4]`
- `README.md` — version badge, feature highlights, current release, footer
- `INSTALL.md` — upgrade-path table
- `mcp-server/package.json` — untouched, independently versioned per its own cadence

`.codex-plugin/plugin.json` was the one easy to miss — it's not in `CLAUDE.md`'s abbreviated Quick Commands grep, only in `knowledge/rules.md`'s full checklist (there's even a lesson-learned file on exactly this gap from 2026-06-21).

## Test plan

- [x] `grep -n "0.7.1.3"` across all 8 checklist files — only historical changelog/upgrade-table entries remain, no live "current version" references
- [x] `scripts/pre-push-gate.sh` passes clean
- [x] docs-impact-scan / paperwork-audit flags written (this branch's diff *is* the doc updates)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BoYsTgQVofGx8BVrJhByhU